### PR TITLE
Clear the remaining security alerts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ name: Main Workflow
 on:
   workflow_call:
 
+# Least privilege: these jobs only check out and build.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -13,12 +13,16 @@ jobs:
   build:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.ref == 'refs/heads/master')
     name: Build
+    permissions:
+      contents: read
     uses: ./.github/workflows/build.yml
     secrets: inherit
 
   lint:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.ref == 'refs/heads/master')
     name: Lint
+    permissions:
+      contents: read
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
@@ -26,6 +30,11 @@ jobs:
     name: Docker
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: [build, lint]
+    # docker.yml pushes an image, so this caller must grant packages: write --
+    # a called workflow only ever gets what the calling job holds.
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/docker.yml
     secrets: inherit
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,10 @@
 name: coverage
 
 on: [push]
+
+# Least privilege: these jobs only check out and build.
+permissions:
+  contents: read
 jobs:
   test:
     name: coverage

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,10 @@ name: Lint
 on:
   workflow_call:
 
+# Least privilege: these jobs only check out and build.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Fmt and clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,6 +788,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chardetng"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13de944a44b5064ee5d3a5ceccc49a41bfec50f2580e66f82e87703acdb88b53"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,7 +999,7 @@ checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
 dependencies = [
  "cookie",
  "document-features",
- "idna 1.1.0",
+ "idna",
  "log",
  "publicsuffix",
  "serde",
@@ -1755,14 +1766,14 @@ dependencies = [
 
 [[package]]
 name = "educe"
-version = "0.5.11"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4bd92664bf78c4d3dba9b7cdafce6fa15b13ed3ed16175218196942e99168a8"
+checksum = "e451fac8dd8dece16234604bf1efce6e90fddd8ab6ad4d66eec0eca5160959dd"
 dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1808,24 +1819,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -3016,26 +3009,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
@@ -3098,13 +3071,14 @@ dependencies = [
 
 [[package]]
 name = "ipinfo"
-version = "3.0.1"
-source = "git+https://github.com/cycle-five/ipinfo-rs#4eed1b15144ca070dc628e84a1255343cd3b77ff"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad2b98165c2c9d03284b23b65ccbab010ca7dd9f7776f2e8c666b19507768a5"
 dependencies = [
  "ipnetwork",
  "lazy_static",
  "lru",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tokio",
@@ -3118,12 +3092,9 @@ checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "ipnetwork"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
+checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3579,11 +3550,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3807,15 +3778,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "no-std-net"
@@ -4544,22 +4506,21 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
  "bitflags 2.13.1",
  "hex",
- "lazy_static",
  "procfs-core",
  "rustix 0.38.44",
 ]
 
 [[package]]
 name = "procfs-core"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
  "bitflags 2.13.1",
  "hex",
@@ -4567,9 +4528,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -4579,14 +4540,28 @@ dependencies = [
  "parking_lot 0.12.5",
  "procfs",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "psl-types"
@@ -4620,7 +4595,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
 dependencies = [
- "idna 1.1.0",
+ "idna",
  "psl-types",
 ]
 
@@ -4718,16 +4693,6 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
 
 [[package]]
 name = "rand"
@@ -5006,6 +4971,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2 0.4.18",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
@@ -7222,50 +7188,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b40688ea6389c8171614b25491f71d4a27946e0c7ce2da1c6de27e25abf1a0ae"
 
 [[package]]
-name = "trust-dns-client"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14135e72c7e6d4c9b6902d4437881a8598f0145dbb2e3f86f92dbad845b61e63"
-dependencies = [
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-util",
- "once_cell",
- "radix_trie",
- "rand 0.8.7",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "trust-dns-proto",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.4.0",
- "ipnet",
- "once_cell",
- "rand 0.8.7",
- "smallvec",
- "thiserror 1.0.69",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7527,7 +7449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
- "idna 1.1.0",
+ "idna",
  "percent-encoding",
  "serde",
  "serde_derive",
@@ -7582,13 +7504,13 @@ dependencies = [
 
 [[package]]
 name = "validators"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e4dd623e1c294e7d7850097c41863cda2703166c5f58c225c5ca969299fb7a"
+checksum = "d697fa150a42271c2be78aa0cd5038cd273266a04590b8078f8a683344462fdd"
 dependencies = [
  "byte-unit",
  "data-encoding",
- "idna 0.5.0",
+ "idna",
  "semver",
  "serde",
  "serde_json",
@@ -7597,15 +7519,15 @@ dependencies = [
 
 [[package]]
 name = "validators-derive"
-version = "0.25.2"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72377736834d42b3e4029d46058f7ee2dbd44340bed0e82aaffd5c395bb0e6b3"
+checksum = "ef40b6d24b27f2ac534259ae4d4916cef769c5fb073f3956b7bac9e1d194179b"
 dependencies = [
  "educe",
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7888,14 +7810,14 @@ dependencies = [
 
 [[package]]
 name = "whois-rust"
-version = "1.6.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e98fa932e195e0253ae71fc1b6e206e53ae7031c40b24ff6b68eaabbf5e87f"
+checksum = "fad6f4738ff5c67a77c99cb62f67aa14dbc97ededacda8a2a4d73336dc80675c"
 dependencies = [
- "once_cell",
+ "chardetng",
+ "encoding_rs",
  "regex",
  "serde_json",
- "trust-dns-client",
  "validators",
 ]
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,234 @@
+# CrackTunes modernization — handoff
+
+Work done in a Cowork cloud sandbox; the container is gone. Everything needed to
+resume is in this file plus `cracktunes-modernize.bundle`.
+
+Repo: `github.com/cycle-five/cracktunes`. Base: `master` @ `7758352`.
+
+## Getting the branch
+
+```sh
+git clone https://github.com/cycle-five/cracktunes.git
+cd cracktunes
+git fetch /path/to/cracktunes-modernize.bundle modernize-2026:modernize-2026
+git checkout modernize-2026
+```
+
+`cracktunes-modernize.patch` is the same three commits for `git am`, if you prefer.
+
+## State
+
+Three commits on `modernize-2026`, 61 files, +4142/-1989. Each commit builds.
+Nothing is pushed — see **GitHub access** below.
+
+| | |
+|---|---|
+| `42eaa54` | Build on stable Rust 1.98 with upstream serenity/songbird/poise |
+| `2614ffd` | Resolve playlists concurrently instead of one track at a time |
+| `557b687` | Read YouTube playlists directly; playlists had stopped resolving |
+
+Verified: `cargo build --release -p cracktunes` succeeds (68M binary, runs, exits
+cleanly on missing `DISCORD_TOKEN`). `cargo clippy --workspace --all-targets` has
+no errors. Tests below.
+
+## The three commits
+
+### 1. Toolchain + dependencies
+
+`rust-toolchain.toml` was pinned to `nightly`. The only nightly feature in the tree
+was `fmt_internals` / `formatting_options`, used in exactly one test that
+Debug-formatted an embed. Replaced with `format!("{embed:?}")`; now on stable.
+Container was on 1.95, `rustup update stable` → **1.98.0**.
+
+**The three `CycleFive/*` forks were all dead weight and are gone:**
+
+- `CycleFive/serenity` `next` — zero custom commits, 29 behind upstream
+- `CycleFive/songbird` `serenity-next` — identical commit to upstream
+- `CycleFive/poise` `serenity-next` — one commit of delta, a stale `rev` pin
+
+Worse than redundant: songbird 0.6 and poise both resolve serenity from
+`serenity-rs/serenity`, so keeping the mirror forced two incompatible copies of
+serenity into the graph. All three now point at upstream.
+
+`[patch.crates-io.serenity-voice-model]` removed — that subcrate no longer lives in
+the serenity repo and the patch broke resolution outright (`cargo update` refused
+to run). `serenity-voice-model` now comes from crates.io at 0.3.
+
+Other bumps: songbird 0.4.5 → 0.6, tokio 1.42 → 1.53, sqlx 0.8.2 → 0.8.6,
+extract_map 0.1 → 0.3, vergen-gitcl 1.0 → 10.0 (API changed: `Build::all_build()`
+and `Gitcl::all_git()` are infallible now), async-openai 0.26 → 0.41 from crates.io,
+dropping the `cycle-five/async-openai` fork and the `backoff` patch with it.
+async-openai 0.41 is feature-gated — needs `features = ["chat-completion"]` — and
+its types moved to `types::chat::*`.
+
+Also: `.cargo/config.toml` no longer sets `-A warnings`. That flag was hiding every
+lint in the workspace, which is a large part of how this much drift went unnoticed.
+`--cfg proc_macro_c_str_literals` dropped too; nothing reads it. Dockerfile builder
+`rust:1.81.0-alpine3.20` → `rust:1.98.0-alpine3.22` (1.81 cannot build
+serenity-next, which requires 1.95), and the exact alpine 3.20 apk pins unpinned
+since they don't resolve on 3.22.
+
+**API migration map** (~96 errors, all in `crack-core`):
+
+- `ChannelId` split into `ChannelId` (guild channels) and `GenericChannelId`
+  (anything you can send a message to). `ctx.channel_id()` and `Message.channel_id`
+  are `GenericChannelId`; `VoiceState.channel_id` and `GuildChannel.id` stay
+  `ChannelId`. Convert with `.widen()` / `.expect_channel()`.
+- `EventHandler`'s per-event methods collapsed into one `dispatch(&self, ctx,
+  &FullEvent)`. `SerenityHandler`'s handlers kept their shapes as inherent methods
+  with a `dispatch` that routes to them.
+- poise dropped `FrameworkOptions::event_handler` and `FrameworkError::EventHandler`,
+  so `handle_event` is now driven from the serenity handler's `dispatch`.
+- Components v2: top-level components are `CreateComponent`, action rows are one
+  variant. `create_nav_btns` returns `Vec<CreateComponent>`.
+- Collectors take `&Context`, not a `ShardMessenger`; `Context::shard` is private.
+- `MessageUpdateEvent` is now `{ message: Message }`. `GuildChannel` gained a
+  flattened `base` (`guild_id`, `name`, `kind`).
+- `FullEvent::snake_case_name()` gone; the enum derives `strum::IntoStaticStr` with
+  SCREAMING_SNAKE_CASE. Helper is `event_log::full_event_name`.
+- `CreateEmbed::thumbnail` takes an alt-text second arg. `CreateAttachment::path` is
+  no longer async. `GuildId::ban` takes `u32` days.
+- poise no longer accepts `usize` command arguments — `remove`, `movesong`, `skip`
+  take `u32` and convert at the boundary.
+- songbird 0.6: `AudioStream` lost its `hint` field; `DecodeMode::Decode` now carries
+  a `DecodeConfig`.
+- `Client::builder` takes erased handles: `.voice_manager(Arc<dyn ...>)`,
+  `.event_handler(Arc::new(h))`, `.framework(Box::new(f))`. `client.shard_manager` is
+  a plain `ShardManager`, not an `Arc` — use `get_shutdown_trigger()` for the
+  Ctrl-C path.
+
+### 2. Playlist resolution was serial
+
+The play path threw away the metadata the playlist fetch had already returned and
+re-resolved every entry from scratch, one at a time, spawning a `yt-dlp` subprocess
+per track (`queue_vec_query_type` → `ready_query` →
+`get_track_source_and_metadata`). Load time scaled linearly with playlist length and
+a single `?` on a bad entry aborted the whole load.
+
+Now: entries carry metadata straight from the listing. Anything that genuinely needs
+resolving (keyword lists, Spotify tracks) goes through `resolve_track_many`, which
+keeps `RESOLVE_CONCURRENCY` (8) lookups in flight via `buffered` — `buffered` not
+`buffer_unordered`, because playlist order is user-visible. Keyword resolution no
+longer follows its search hit with a redundant `get_info` round trip; that was
+doubling the cost of every Spotify playlist track for metadata the search already
+returned. The first track is queued alone so playback starts immediately, progress
+edits are throttled to 3 s (Discord rate-limits edits per channel), unresolvable
+entries are skipped and logged, and batch enqueues take the call lock once.
+
+### 3. Playlists had stopped resolving entirely
+
+**This is the finding that matters most.** `rusty_ytdl` 0.7.4 locates playlist
+entries by looking for `playlistVideoRenderer` in `ytInitialData`. YouTube migrated
+playlist listings to their view-model shape, so that lookup finds nothing and every
+playlist fails with `PlaylistBodyCannotParsed`. Not slow — broken.
+
+Reproduce:
+
+```sh
+curl -sS -A 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36' \
+  'https://www.youtube.com/playlist?list=PLc1HPXyC5ookjUsyLkdfek0WUIGuGXRcP' -o pl.html
+grep -c playlistVideoRenderer pl.html   # 0
+grep -c lockupViewModel        pl.html  # >0
+```
+
+Continuations moved too: `continuationItemRenderer` → `continuationItemViewModel`,
+with the token one `innertubeCommand` deeper.
+
+`crack-testing/src/yt_playlist.rs` reads the playlist page directly and handles both
+shapes, following continuations via `/youtubei/v1/browse` for playlists longer than
+one page. `rusty_ytdl` stays as the fallback so we pick its richer results back up if
+it's ever fixed upstream. There is no newer release to upgrade to — 0.7.4 is current
+on crates.io.
+
+Measured live: 8 entries 520 ms, 100 entries 730 ms (1 request), 300 entries 1.8 s
+(3 requests). `rusty_ytdl` failed all three. `cargo run -p crack-testing --example
+playlist_bench -- <url> <limit>` reproduces this.
+
+## Verification
+
+```sh
+cargo build --release -p cracktunes
+cargo clippy --workspace --all-targets
+cargo test --workspace
+```
+
+Tests need Postgres. Without it, ~20 crack-core tests fail with `PoolTimedOut`.
+With it, **120/120 crack-core pass**:
+
+```sh
+# any Postgres will do; docker-compose-postgres.yml also works
+createdb cracktunes
+export DATABASE_URL="postgres://postgres@127.0.0.1:5432/cracktunes"
+cargo install sqlx-cli --no-default-features --features rustls,postgres
+sqlx migrate run
+cargo test --workspace
+```
+
+**Two tests fail on any bot-checked IP and this is not a code problem:**
+`crack_testing::tests::test_resolve_track` and `test_enqueue_query`. Both hit the
+innertube `player` endpoint, which from a datacenter IP returns:
+
+```
+playabilityStatus.status = LOGIN_REQUIRED
+reason = "Sign in to confirm you're not a bot"
+adaptiveFormats = 0
+```
+
+Confirmed against `WEB` (current and older client versions), `ANDROID` and `IOS`
+contexts — all refused, so no client-string bump fixes it. They may well pass from a
+residential IP. `test_cli2` (playlist resolution) **now passes** where it previously
+failed; that one was the real bug.
+
+Note the enqueue path no longer touches the player endpoint at all — only actual
+playback does. So queueing a playlist works and displays correctly even under
+bot-check conditions.
+
+Remaining clippy noise is `mismatched_lifetime_syntaxes` (a newer rustc lint,
+`ResolvedTrack` → `ResolvedTrack<'_>` in return position). Purely stylistic, left
+alone deliberately to keep the diff attributable.
+
+## GitHub access
+
+Nothing is pushed. The sandbox had a working GitHub credential authenticated as
+`cycle-five` — `GET /user` returned 200 — but a git proxy scoped it per-repo:
+
+```
+GET /repos/cycle-five/cracktunes  → 403
+git push origin modernize-2026    → 403
+remote: access denied by the git proxy: cycle-five/cracktunes is not in this
+session's authorized repository set, so the proxy will not inject a credential
+for it. To fix, add the repository to the session's sources.
+```
+
+Not a connector problem — there is no GitHub MCP connector installed, and GitHub
+isn't in the connector registry. In Claude Code on your own machine with your own
+credentials this is a non-issue.
+
+## Pending issues to file
+
+Two drafts, deliberately **not** in this branch — the PR stays scoped to the library
+upgrade:
+
+- `issue-playlist-limit.md` — make `PLAYLIST_PLAY_LIMIT` (currently 100) a guild
+  setting and raise the default. Now ~600 ms per 100 tracks, so the limit is close
+  to free. Lists what to sort out first: queue memory at scale, queue-embed
+  pagination beyond four nav buttons, `MAX_CONTINUATIONS`, and the fact that Spotify
+  playlists take a different (per-track) path and need separate measurement.
+- `issue-lavalink-resolver.md` — add Lavalink as an alternative resolver, switchable
+  at runtime, not a replacement. Key point: there are two seams. Metadata resolution
+  is easy (`CrackTrackClient` is already the single chokepoint — a `TrackResolver`
+  trait over its four methods is mechanical). Stream production is hard, because
+  Lavalink replaces songbird's driver and terminates the voice connection itself, so
+  "switch at runtime" realistically means per-guild at connect time. There's a
+  tempting metadata-only split that probably doesn't work — the stream URL still has
+  to be fetched from the bot-checked IP — worth confirming before designing around it.
+
+## Deliberately out of scope
+
+- Raising the playlist limit (issue above)
+- Lavalink (issue above)
+- `mismatched_lifetime_syntaxes` cleanup
+- CI workflows still list a `nightly` matrix entry. Harmless —
+  `rust-toolchain.toml` overrides it — but it's now pointless.
+- The workspace-root `build.rs` is dead code (the workspace root is not a package)
+  and still uses the vergen 8 `EmitBuilder` API. Left untouched.

--- a/crack-core/Cargo.toml
+++ b/crack-core/Cargo.toml
@@ -28,7 +28,7 @@ cache = ["serenity/cache", "poise/cache"]
 crack-activity = []
 crack-bf = ["dep:crack-bf"]
 crack-gpt = ["dep:crack-gpt"]
-crack-metrics = []
+crack-metrics = ["dep:prometheus"]
 crack-telemetry = []
 crack-music = []
 crack-osint = ["dep:crack-osint"]
@@ -58,7 +58,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 url = "2.5"
 sys-info = "0.9"
-prometheus = { version = "0.13", features = ["process"], optional = true }
+prometheus = { version = "0.14", features = ["process"], optional = true }
 typemap_rev = "0.3"
 either = "1.13"
 once_cell = "1.20"

--- a/crack-core/src/lib.rs
+++ b/crack-core/src/lib.rs
@@ -9,7 +9,7 @@ pub mod http_utils;
 #[macro_use]
 pub mod macros;
 pub mod messaging;
-// pub mod metrics;
+pub mod metrics;
 #[cfg(feature = "crack-music")]
 pub mod music;
 pub mod poise_ext;

--- a/crack-core/src/metrics.rs
+++ b/crack-core/src/metrics.rs
@@ -41,23 +41,12 @@ mod metrics_internal {
             .expect("collector can be registered");
     }
 
-    /// Prometheus handler
-    #[cfg(feature = "crack-metrics")]
-    #[cfg(not(tarpaulin_include))]
-    async fn metrics_handler() -> Result<impl warp::Reply, warp::Rejection> {
-        let encoder = TextEncoder::new();
-        let mut metric_families = prometheus::gather();
-        metric_families.extend(REGISTRY.gather());
-        // tracing::info!("Metrics: {:?}", metric_families);
-        let mut buffer = vec![];
-        encoder.encode(&metric_families, &mut buffer).unwrap();
-
-        Ok(warp::reply::with_header(
-            buffer,
-            "content-type",
-            encoder.format_type(),
-        ))
-    }
+    // A `metrics_handler` returning a warp reply used to live here. It was private
+    // and unreferenced -- its only callers are commented out in crack-cli/src/main.rs
+    // -- and it referenced `warp`, which crack-core does not depend on, plus an
+    // unimported `TextEncoder`. So the whole feature failed to compile. Serving these
+    // metrics over HTTP belongs in whatever actually runs an HTTP server (crack-voting
+    // already has warp), not in crack-core; `REGISTRY.gather()` is what it would call.
 
     #[cfg(test)]
     mod test {

--- a/crack-osint/Cargo.toml
+++ b/crack-osint/Cargo.toml
@@ -15,9 +15,9 @@ repository = "https://github.com/cycle-five/cracktunes"
 workspace = "../"
 
 [dependencies]
-whois-rust = "1.6"
+whois-rust = "3.1"
 sha1 = "0.10"
-ipinfo = { git = "https://github.com/cycle-five/ipinfo-rs", version = "3.0.1" }
+ipinfo = "3.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 crack-types = { path = "../crack-types" }


### PR DESCRIPTION
Follow-up to the v0.4.0 modernization, which auto-closed 20 of the 22 Dependabot
alerts. This deals with what was left across all three security surfaces.

## Dependabot: the three with an upgrade path

All three lived in dependencies that are **not in the default build**, so none was
exploitable as shipped — but the vulnerable versions were still in `Cargo.lock`.

| alert | package | fix |
|---|---|---|
| #40 medium | protobuf 2.28.0 → **3.7.2** | prometheus 0.13 → 0.14, which requires `protobuf ^3.7.2` |
| #36 medium | idna 0.4/0.5 → **1.1 only** | whois-rust 1.6 → 3.1; the old one pulled `trust-dns-proto` + `validators 0.25`, 3.1 needs only `validators 0.26`, which is on `idna ^1` |
| #48 low | lru 0.12.5 → **0.16.4** | dropped the `cycle-five/ipinfo-rs` fork for upstream ipinfo 3.5 |

The ipinfo fork was a *real* fork, unlike the serenity/songbird/poise mirrors v0.4.0
removed: four commits taking out the openssl dependency. Upstream has since solved
that itself — ipinfo 3.5 depends on reqwest with `default-features = false` — so the
fork had become 32 commits of drift for no remaining benefit. crack-osint compiles
against upstream with no code changes, and reqwest 0.13 was already in the lock, so
this introduces no new duplicate.

## Dependabot #65 (libcrux, high) — dismissed, not fixed

Dismissed as not-used, with the reasoning recorded on the alert. It is the only one
that reaches the shipped binary, via songbird → davey → openmls_rust_crypto →
hpke-rs → libcrux-aead, but it is unreachable by construction: davey supports
exactly one MLS ciphersuite, `MLS_128_DHKEMP256_AES128GCM_SHA256_P256`
(`session.rs:38` — any other protocol version returns `UnsupportedProtocolVersion`),
and encrypts media with AES-128-GCM directly. ChaCha20Poly1305 is never selected.
The advisory also needs a caller-supplied ciphertext buffer longer than
`ptxt.len() + TAG_LEN`, which davey does not do.

There is no fix to apply in any case: we are already on the newest published davey
(0.1.4), and the upgrade is blocked behind `openmls_rust_crypto` 0.6.0, still a
release candidate. Worth revisiting when that chain releases.

## Code scanning #32 — `crack-metrics` never compiled

The alert (`E0432`, unresolved import `crate::metrics`) was reporting something
real. Three separate things were broken:

1. `crack-metrics = []` never enabled `dep:prometheus`, so turning the feature on
   did not bring in the crate it needs.
2. `pub mod metrics;` was commented out of `lib.rs`, so `crate::metrics` did not
   exist for `utils.rs:4` to import in any configuration.
3. The module carried a private, unreferenced `metrics_handler` returning a
   `warp::Reply` — referencing a crate crack-core does not depend on, plus an
   unimported `TextEncoder`.

The handler is removed rather than dragging an HTTP framework into crack-core for
dead code; its only callers are commented out in `crack-cli/src/main.rs`. Serving
these metrics over HTTP belongs wherever an HTTP server actually runs — crack-voting
already has warp — and `REGISTRY.gather()` is what it would call.

`cargo check -p crack-core --features crack-metrics` now succeeds, and the module's
test runs and passes for the first time.

## Code scanning #1–#6 — workflow permissions

A workflow with no `permissions:` block gets the repository default, which is
usually far more than checkout-build-test needs. build.yml, lint.yml and
coverage.yml get `contents: read` at the workflow level (coverage uploads with an
explicit `CODECOV_TOKEN` rather than OIDC, so it needs no `id-token: write`).

ci_workflow.yml gets per-job blocks instead, because a reusable workflow only ever
receives what the calling job holds: its docker job calls docker.yml, which pushes
an image, so that caller has to pass `packages: write` through or the push loses its
credential. docker.yml, dockerhub.yml and rust-clippy.yml already declared job-level
permissions and were not flagged.

## Verification

Run on stable 1.98 against Postgres in Docker:

| command | result |
|---|---|
| `cargo check -p cracktunes` (default build) | unchanged, clean |
| `cargo clippy --all -- -D clippy::all -D warnings` | clean |
| `cargo clippy -p crack-core --features crack-metrics --all-targets` | clean |
| `cargo fmt --all -- --check` | clean |
| `cargo test --workspace` | 180 passed, 0 failed, 3 ignored |
| `cargo test -p crack-core --features crack-metrics metrics` | 1 passed (previously uncompilable) |

Resulting lockfile: `protobuf 3.7.2`, `lru 0.16.4`, `idna 1.1.0` only,
`prometheus 0.14.0`, `whois-rust 3.1.0`, `ipinfo 3.5.0`.

## Noted, not changed

`whois-rust` is currently an unused dependency. `crack-osint/src/whois.rs` is
commented out of the module tree and cannot be re-enabled as written — it imports
`crack_core`, which cannot be a dependency of crack-osint because crack-core depends
on crack-osint. Upgrading it fixes the alert and keeps the intent; dropping the
dependency outright would also work, but that is a call about whether whois is coming
back, so it is left alone.