### PR TITLE
Repair crack-telemetry and re-enable the clippy analysis workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,42 @@
 - [ ] Support discordbotlist.com (voting service).
 - [ ] Decide on whether to use ephemeral for admin messages.
 
+## v0.4.1 (2026/08/23)
+
+### Security
+
+- Cleared the four Dependabot alerts v0.4.0 left behind. protobuf 2.28 -> 3.7.2
+  (via prometheus 0.13 -> 0.14), idna down to 1.1 only (via whois-rust 1.6 -> 3.1),
+  and lru 0.12.5 -> 0.16.4 by dropping the `cycle-five/ipinfo-rs` fork for upstream
+  ipinfo 3.5 -- upstream had since removed the openssl dependency the fork existed
+  to avoid. The fourth, a libcrux panic, is unreachable: davey supports only the
+  AES-128-GCM ciphersuite, so ChaCha20Poly1305 is never selected.
+- Every workflow now declares an explicit `permissions:` block.
+
+### Dead features repaired
+
+Three optional features had rotted into a state where turning them on would not
+compile. `-A warnings` and a lint workflow that had been auto-disabled for
+inactivity meant nothing complained.
+
+- **`crack-metrics`** was `[]`, so it never enabled `dep:prometheus`;
+  `pub mod metrics;` was commented out of lib.rs, so `crate::metrics` did not exist
+  for `utils.rs` to import; and the module held a private, unreferenced
+  `metrics_handler` returning a `warp::Reply`, a crate crack-core does not depend on.
+- **`crack-telemetry`** was `[]` as well, while `init_telemetry` referenced
+  `JsonStorageLayer`, an undefined `formatting_layer`, and an OTLP
+  `set_text_map_propagator` -- all left dangling when the opentelemetry imports were
+  commented out. It now means structured JSON logs: `tracing-bunyan-formatter`
+  behind the feature, with `SERVICE_NAME` finally used as the bunyan service name.
+  The propagator call is gone rather than pulling in opentelemetry to feed a tracer
+  nothing reads.
+- **`crack-metrics` in crack-cli** was an empty feature that gated one dead const;
+  it now forwards to `crack-core/crack-metrics`.
+
+`cargo clippy --all-features` is clean for the first time in a long while, and
+`rust-clippy.yml` -- disabled by GitHub for inactivity since 2025-11-30 -- is
+enabled again now that it has something green to report.
+
 ## v0.4.0 (2026/08/22)
 
 ### Toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,14 +1079,14 @@ dependencies = [
 
 [[package]]
 name = "crack-bf"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "crack-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1128,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "crack-gpt"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-openai",
  "const_format",
@@ -1138,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "crack-osint"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "crack-types",
  "ipinfo",
@@ -1153,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "crack-testing"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1176,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "crack-types"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "humantime",
  "poise",
@@ -1193,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "crack-voting"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "dbl-rs",
@@ -1208,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "cracktunes"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "config-file",
  "crack-core",
@@ -1218,6 +1231,7 @@ dependencies = [
  "sqlx",
  "tokio",
  "tracing",
+ "tracing-bunyan-formatter",
  "tracing-subscriber",
  "vergen-gitcl",
 ]
@@ -2209,6 +2223,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,7 +2353,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -7117,6 +7141,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-bunyan-formatter"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d637245a0d8774bd48df6482e086c59a8b5348a910c3b0579354045a9d82411"
+dependencies = [
+ "ahash 0.8.12",
+ "gethostname",
+ "log",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.1.4",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-core"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7134,6 +7176,17 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -7162,7 +7215,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.2.0",
 ]
 
 [[package]]

--- a/crack-bf/Cargo.toml
+++ b/crack-bf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-bf"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-cli/Cargo.toml
+++ b/crack-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "cracktunes"
-version = "0.4.0"
+version = "0.4.1"
 description = "Cracktunes is a hassle-free, highly performant, host-it-yourself, cracking smoking, discord-music-bot."
 publish = true
 edition = "2021"
@@ -25,8 +25,12 @@ eula = false
 default = ["crack-tracing"]
 
 crack-tracing = ["tracing-subscriber"]
-crack-metrics = []
-crack-telemetry = []
+# Forwards to crack-core, which owns the prometheus registry. This was an empty
+# list, so turning it on here did nothing at all.
+crack-metrics = ["crack-core/crack-metrics"]
+# Structured JSON logs. Implies crack-tracing: `init_telemetry` is gated on it, so
+# crack-telemetry on its own would silently do nothing.
+crack-telemetry = ["crack-tracing", "tracing-bunyan-formatter"]
 
 [dependencies]
 crack-core = { path = "../crack-core/" }
@@ -37,6 +41,7 @@ dotenvy = "0.15"
 tracing-subscriber = { version = "0.3", features = [
   "env-filter",
 ], optional = true }
+tracing-bunyan-formatter = { version = "0.3", optional = true }
 
 # Core's dependencies
 poise = { workspace = true }

--- a/crack-cli/src/main.rs
+++ b/crack-cli/src/main.rs
@@ -6,7 +6,7 @@ use tokio::runtime::Handle;
 #[cfg(feature = "crack-tracing")]
 use crack_core::guild::settings::get_log_prefix;
 #[cfg(feature = "crack-telemetry")]
-use std::sync::Arc;
+use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 #[cfg(feature = "crack-tracing")]
 use tracing_subscriber::{filter, prelude::*, EnvFilter, Registry};
 // #[cfg(feature = "crack-metrics")]
@@ -21,8 +21,6 @@ use tracing_subscriber::{filter, prelude::*, EnvFilter, Registry};
 
 // #[cfg(feature = "crack-telemetry")]
 // const SERVICE_NAME: &str = "cracktunes";
-#[cfg(feature = "crack-metrics")]
-const WARP_PORT: u16 = 8833;
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 
@@ -280,35 +278,33 @@ pub async fn init_telemetry(_exporter_endpoint: &str) {
     //     .install_batch(opentelemetry_sdk::runtime::Tokio)
     //     .expect("Error: Failed to initialize the tracer.");
 
+    // The whole function is gated on `crack-tracing`, so the inner cfgs that used to
+    // repeat that gate are gone. A `set_text_map_propagator(TraceContextPropagator)`
+    // call also used to sit here, gated on `crack-metrics` of all things: it is OTLP
+    // context propagation with no exporter behind it and no opentelemetry dependency
+    // in the tree, left over from the commented-out block above. Removed rather than
+    // pulling in opentelemetry to feed a tracer nothing reads.
+
     // Define a subscriber.
-    #[cfg(feature = "crack-tracing")]
     let subscriber = Registry::default();
     // Level filter layer to filter traces based on level (trace, debug, info, warn, error).
-    #[cfg(feature = "crack-tracing")]
     let level_filter_layer = EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new("INFO"));
-    // Layer for adding our configured tracer.
-    // let tracing_layer = tracing_opentelemetry::layer().with_tracer(tracer);
-    // Layer for printing spans to a file.
-    #[cfg(feature = "crack-telemetry")]
-    let stdout_formatting_layer = get_current_log_layer();
-
     // Layer for printing to stdout.
-    #[cfg(feature = "crack-tracing")]
     let stdout_formatting_layer = get_current_log_layer();
 
-    // global::set_text_map_propagator(TraceContextPropagator::new());
-    #[cfg(feature = "crack-metrics")]
-    set_text_map_propagator(TraceContextPropagator::new());
-
-    #[cfg(feature = "crack-tracing")]
     let x = subscriber
         .with(stdout_formatting_layer)
         .with(level_filter_layer);
-    // .with(tracing_layer)
-    #[cfg(feature = "crack-telemetry")]
-    let x = x.with(JsonStorageLayer).with(formatting_layer);
 
-    #[cfg(any(feature = "crack-tracing", feature = "crack-telemetry"))]
+    // Structured JSON on top: JsonStorageLayer carries span fields through to
+    // BunyanFormattingLayer, which is what `formatting_layer` referred to before it
+    // was left dangling.
+    #[cfg(feature = "crack-telemetry")]
+    let x = x.with(JsonStorageLayer).with(BunyanFormattingLayer::new(
+        SERVICE_NAME.to_string(),
+        std::io::stdout,
+    ));
+
     x.init()
 }
 

--- a/crack-core/Cargo.toml
+++ b/crack-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-core"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 edition = "2021"
 description = "Core module for the cracking smoking, discord-music-bot Cracktunes."

--- a/crack-gpt/Cargo.toml
+++ b/crack-gpt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-gpt"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-osint/Cargo.toml
+++ b/crack-osint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-osint"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-testing/Cargo.toml
+++ b/crack-testing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "crack-testing"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/crack-types/Cargo.toml
+++ b/crack-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-types"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-voting/Cargo.toml
+++ b/crack-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-voting"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true


### PR DESCRIPTION
`rust-clippy.yml` has been `disabled_inactivity` since 2025-11-30 — GitHub turns off
scheduled workflows in repos idle 60+ days. That is why its stale SARIF sat in code
scanning for nine months while the code underneath changed. Re-enabling it is one
command, but it runs `cargo clippy --all-features`, and that did not compile.

## What was broken

Four unresolved names in `crack-cli/src/main.rs`, all under `crack-telemetry`:
`JsonStorageLayer`, `formatting_layer`, `TraceContextPropagator`,
`set_text_map_propagator`.

The cause is visible a few lines above them — an entire `use { opentelemetry::…,
prometheus::…, warp::Filter }` block sits commented out. The imports were removed
and the call sites were not. `crack-telemetry = []` enabled no dependencies either,
so the feature could never have compiled no matter what.

This is the same shape as the `crack-metrics` breakage fixed in #400, and the third
dead optional feature in this repo after that and `whois`.

## What it does now

The feature means the one thing its leftovers pointed at and that can actually be
verified: **structured JSON logging**. `tracing-bunyan-formatter` sits behind the
feature, `JsonStorageLayer` carries span fields through to a `BunyanFormattingLayer`,
and `SERVICE_NAME` — a const dead since the day it was written — is what names the
service. Running the binary with the feature on:

```json
{"v":0,"name":"crack-tunes","msg":"DISCORD_TOKEN not found in environment.",
 "level":40,"target":"cracktunes","line":129,"file":"crack-cli/src/main.rs"}
```

`set_text_map_propagator(TraceContextPropagator::new())` is **removed, not repaired**.
It is OTLP context propagation with no exporter behind it and no opentelemetry crate
in the tree, and it was gated on `crack-metrics` rather than on anything to do with
telemetry. Real OTLP export is a feature rather than a fix — it needs an endpoint, a
collector to test against, and a decision about which exporter — so it is not
smuggled in here.

## Smaller things in the same area

- `crack-telemetry` now implies `crack-tracing`. `init_telemetry` is gated on
  crack-tracing, so asking for telemetry alone silently did nothing at all.
- crack-cli's `crack-metrics` was `[]`, gating a single const that appears only
  inside a comment. It forwards to `crack-core/crack-metrics` now, so
  `--all-features` genuinely exercises the metrics code rather than skipping it.
- Removed `WARP_PORT`, an unused `Arc` import, and the inner `#[cfg(crack-tracing)]`
  attributes inside a function already gated on crack-tracing — one of which shadowed
  a duplicate binding.

## Verification

| command | result |
|---|---|
| `cargo clippy --all-features` (what the workflow runs) | **clean** |
| `cargo clippy --all-features --all-targets` | clean |
| `cargo clippy --all -- -D clippy::all -D warnings` (lint workflow) | clean |
| `cargo fmt --all -- --check` | clean |
| `cargo test --workspace` | 180 passed, 0 failed, 3 ignored |
| `cargo test -p cracktunes --features crack-telemetry` | passes, incl. `test_init_telemetry` |
| binary run with the feature | emits bunyan JSON, shown above |

The default build is unchanged — none of these features ship by default.

Once this is in, `rust-clippy.yml` gets switched back on so the analysis has
something green to report instead of nine-month-old errors.