### PR TITLE
Let the clippy analysis workflow be triggered by hand

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -17,6 +17,12 @@ on:
     branches: [ "master" ]
   schedule:
     - cron: '0 0 * * *'
+  # Lets this be re-run by hand. GitHub disables workflows with a `schedule:`
+  # trigger after 60 days of repository inactivity, which is what happened here --
+  # it went dormant on 2025-11-30 and its stale results sat in code scanning for
+  # nine months. Re-enabling it does not itself schedule a run, and without this
+  # there was no way to start one short of pushing to master or waiting for the cron.
+  workflow_dispatch:
 
 jobs:
   rust-clippy-analyze:


### PR DESCRIPTION
Follow-up to #401, which fixed `cargo clippy --all-features` so this workflow has
something green to report.

`rust-clippy.yml` carries a `schedule:` trigger, and GitHub disables scheduled
workflows after 60 days of repository inactivity. It went dormant on 2025-11-30, and
the SARIF it had uploaded sat in code scanning untouched for nine months — still
reporting `E0554` and `E0432` against code that had since been fixed. Three of the
alerts I closed in this pass were that stale data rather than live problems.

It is enabled again now, but enabling a workflow does not run one, and this one had
no way to be started short of pushing to master or waiting for the nightly cron —
so there was no way to confirm it actually passes. `workflow_dispatch:` fixes that
and makes the analysis re-runnable on demand.

This PR also verifies itself: the workflow triggers on `pull_request` against
master, so its run on this PR is the first in nine months.

**Worth knowing:** the 60-day inactivity disable will happen again if the repo goes
quiet, and it is silent when it does. If that matters, dropping the `schedule:`
trigger and relying on push/PR would make it immune, at the cost of the nightly
sweep.