### PR TITLE
One deploy front door instead of thirteen scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,41 @@ Thanks to the guys over at [alwaysdata](https://www.alwaysdata.com/) for hosting
 - _Optional_ define `VIRUSTOTAL_API_KEY` for osint URL checking.
 - Use [.env.example](https://github.com/cycle-five/cracktunes/blob/master/.env.example) as a starting point.
 
-### Docker **FIXME**
+### Docker
+
+A single image, no database of your own to run:
 
 ```shell
 docker run -d --env-file .env --restart unless-stopped --name cracktunes ghcr.io/cycle-five/cracktunes:latest
 ```
+
+Images are published to two registries by CI: `ghcr.io/cycle-five/cracktunes` and
+`docker.io/cyclefive/cracktunes`. Tagged releases get version tags; branch builds get
+floating ones.
+
+### Docker Compose (the full stack)
+
+Use `scripts/cracktunes.sh` rather than driving `docker compose` directly — it pins
+the project name and env file, and refuses on the failure modes that are otherwise
+silent (wrong Docker context, database password divergence, missing external volumes,
+missing `DISCORD_TOKEN`).
+
+```shell
+cp .env.example .env          # then fill it in
+./scripts/cracktunes.sh preflight   # verify without changing anything
+./scripts/cracktunes.sh up
+```
+
+To ship a new version, `deploy` (pull + recreate) rather than `restart` (recreate
+only, picks up no new code):
+
+```shell
+./scripts/cracktunes.sh deploy
+./scripts/cracktunes.sh logs cracktunes
+```
+
+`./scripts/cracktunes.sh help` lists everything. See [scripts/README.md](scripts/README.md)
+for what the other scripts in that directory are, and which of them are broken.
 
 ## Development
 
@@ -117,14 +147,16 @@ git push --tags
 cargo publish
 ```
 
-### Docker Compose
-
-Within the project folder, simply run the following:
+### Building the image locally
 
 ```shell
 docker build -t cracktunes .
-docker compose up -d
 ```
+
+Note that `docker-compose.yml` references the published `cyclefive/cracktunes:dev`
+image, not a locally built one — so building with the tag above does not change what
+`docker compose up` runs. Retag it or edit the compose file if you want your local
+build in the stack. Deploying is covered under [Deployment](#deployment) above.
 
 <p align="center">
 <sub><sup>Originally forked from <a href="https://github.com/aquelemiguel/parrot">Parrot</a></sup></sub>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,12 @@ services:
   crack-voting:
     container_name: crack-voting
     image: cyclefive/crack-voting:dev
-    volumes:
-      - ./.env:/app/.env:ro
+    # env_file rather than a bind mount: compose reads this on the CLIENT and
+    # injects the variables, so nothing has to exist on the docker host. A
+    # bind mount of ./.env resolves to an absolute path on the host, which is
+    # wrong the moment the stack is driven through a remote context.
+    env_file:
+      - ${ENV_FILE:-.env}
     environment:
       - DATABASE_URL=postgresql://postgres:mysecretpassword@crack-postgres:5432/postgres
       - WEBHOOK_SECRET=${WEBHOOK_SECRET:-test_secret}
@@ -36,8 +40,13 @@ services:
     image: cyclefive/cracktunes:dev
     volumes:
       - crack_data:/data:rw
-      - ./.env:/app/.env:rw
-      - ./cracktunes.toml:/app/cracktunes.toml:rw
+      # ./cracktunes.toml is NOT mounted. It resolves on the docker host, so it
+      # only ever worked when the stack ran on the same machine as this
+      # checkout. The file is optional -- the bot logs "Using default config"
+      # and carries on -- but it also sets the command prefix, so anything set
+      # there must move into the environment instead. See #403.
+    env_file:
+      - ${ENV_FILE:-.env}
     environment:
       - DATABASE_URL=postgresql://postgres:mysecretpassword@crack-postgres:5432/postgres
       - VIRUSTOTAL_API_KEY=${VIRUSTOTAL_API_KEY:-test_key}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,85 @@
+# scripts/
+
+`cracktunes.sh` is the front door. Everything else here is either a development
+convenience or a leftover, and three of them do not work.
+
+## Canonical
+
+### `cracktunes.sh`
+
+Every routine deploy and inspect operation. `./scripts/cracktunes.sh help` lists the
+subcommands; `preflight` runs every safety check and changes nothing, so it is always
+safe to run first.
+
+```shell
+./scripts/cracktunes.sh preflight     # check without touching anything
+./scripts/cracktunes.sh up            # bring the stack up
+./scripts/cracktunes.sh deploy        # pull fresh images + recreate  ← ships a new version
+./scripts/cracktunes.sh restart       # recreate only; ships NO new code
+./scripts/cracktunes.sh logs cracktunes
+./scripts/cracktunes.sh status
+```
+
+The `deploy` / `restart` distinction matters. The compose services pin floating `:dev`
+tags and set no `pull_policy`, so a plain recreate happily keeps running the cached
+image — a "deploy" that changes nothing while looking like it worked.
+
+It refuses rather than warns on four things, each of which otherwise fails silently:
+the wrong Docker context, a `POSTGRES_PASSWORD` that disagrees with the password
+hardcoded in `docker-compose.yml`, missing external volumes, and a missing
+`DISCORD_TOKEN`. The header comment in the script explains each one.
+
+## Development utilities
+
+| script | what it does |
+|---|---|
+| `lint_test_build.sh` / `.fish` | fmt + clippy + test + build, the local pre-push loop |
+| `lint_test_build_crack_voting.sh` | same, scoped to crack-voting |
+| `run_one_test.sh` | run a single test by name |
+| `reset_db.sh` | drop, recreate and re-migrate the local database, then `cargo sqlx prepare`. Hardcodes the local dev password |
+| `install_psql.sh` | install the postgres client |
+| `test_curl.sh` | poke the crack-voting webhook endpoint by hand |
+| `start.sh` | the container entrypoint — `COPY`d into the image by the Dockerfile, not run directly |
+
+## Broken — do not use
+
+Left in place rather than deleted so the intent behind them is not lost, but none of
+these works as written. See #403.
+
+### `build_and_deploy.sh`
+
+Cannot deploy. Its last line is:
+
+```sh
+ssh kalevala -c '$HOME/run.sh'
+```
+
+`-c` selects an ssh *cipher*; running a remote command is `ssh host cmd`. It exits
+immediately with `Unknown cipher type '$HOME/run.sh'`, so the zip is copied to the
+host and nothing is ever started. Separately, `kalevala` is documented as being
+decommissioned.
+
+### `run.sh`
+
+Starts nothing. It creates one tmux session and sends the start command to a
+different one:
+
+```sh
+tmux new-session -s cracktunes -d
+tmux send-keys -t grafana-agent "$HOME/cracktunes" Enter
+```
+
+It also runs `$HOME/cracktunes`, while the zip it unpacks puts the binary at
+`target/release/cracktunes`.
+
+### `sync.sh`
+
+rsyncs from a hardcoded `/home/lothrop/dev/cracktunes`, which is not where this
+repository lives. The remote destination `${HOME}` is expanded locally, so it only
+lands in the right place when the local and remote usernames match. Its server list
+predates the current homelab inventory.
+
+### `refresh_service.sh`
+
+Not broken, but superseded: it is `cracktunes.sh deploy crack-voting` without the
+project-name pinning or any of the guards.

--- a/scripts/cracktunes.sh
+++ b/scripts/cracktunes.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+#
+# cracktunes.sh — THE deploy/inspect front door for the bot's docker stack.
+# Every routine operation runs through here; the README and CLAUDE.md refer to
+# these subcommands as the canonical vocabulary. Nothing else in scripts/ is a
+# supported way to deploy.
+#
+# Always invokes compose with `-p $STACK --env-file $ENV_FILE` so a partial or
+# typo'd command cannot operate on a different stack than intended.
+#
+# Config via env (sensible defaults):
+#   STACK             compose project name         (default: cracktunes)
+#   ENV_FILE          env file compose reads       (default: .env)
+#   EXPECTED_CONTEXT  docker context to require    (default: default)
+#
+# Guards. Each of these refuses rather than warns, and each exists because the
+# failure it prevents is silent:
+#
+#   1. DOCKER CONTEXT. `docker compose` targets whatever context is current, and
+#      this machine has several pointing at remote hosts (proxmox, pve-staging,
+#      homelab-*). Deploying to the wrong one does not fail — it builds a
+#      complete parallel stack over there and looks like success. It matters
+#      more than usual here because docker-compose.yml bind-mounts RELATIVE host
+#      paths (./.env, ./cracktunes.toml): on a remote context those resolve on
+#      the REMOTE filesystem, so the bot comes up reading someone else's config
+#      or an empty file. Default is `default` (the local socket) because the
+#      compose file is written for a local host. Deploying elsewhere is fine,
+#      but you have to say so: EXPECTED_CONTEXT=proxmox ./scripts/cracktunes.sh up
+#
+#   2. DATABASE PASSWORD DIVERGENCE. docker-compose.yml hardcodes
+#      `DATABASE_URL=postgresql://postgres:mysecretpassword@...` for the app
+#      services while crack-postgres honours ${POSTGRES_PASSWORD}. Set
+#      POSTGRES_PASSWORD to anything else and postgres comes up healthy while
+#      every app service fails to authenticate. `preflight` compares the two and
+#      refuses before that happens.
+#
+#   3. EXTERNAL VOLUMES. pgdata and crack_data are declared `external: true`, so
+#      a cold `up` on a fresh host fails on a missing volume rather than
+#      creating one. Checked up front, with the exact command to fix it.
+#
+#   4. MISSING DISCORD_TOKEN. The bot fail-closes at BOOT, not at deploy: a
+#      missing token is not a failed deploy, it is a container that panics and
+#      restarts forever while the old one is already gone. Checked before
+#      anything is replaced.
+#
+# Subcommands:
+#   preflight        Run every guard and report, changing nothing. Safe anywhere.
+#   up               Bring the stack up (compose up -d).
+#   deploy [svc]     Pull fresh images and force-recreate. This is the one that
+#                    actually ships a new version. Services pin floating tags
+#                    and set no pull_policy, so plain `up` will happily keep
+#                    running a stale cached image.
+#   restart [svc]    Recreate the container WITHOUT pulling. Picks up no new
+#                    code — only use it to bounce a process you know is current.
+#   stop             Stop the stack, preserving volumes.
+#   down             Stop and remove containers, preserving volumes.
+#   destroy          compose down -v — DROPS THE DATABASE (guild settings,
+#                    playlists, play logs). Requires typing the stack name.
+#   ps               compose ps.
+#   logs [svc]       Tail logs (default: 50 lines, follow).
+#   shell <svc>      Open a shell in a container.
+#   psql             Open psql in the postgres container over its unix socket.
+#   sql [psql-args]  Run read-only SQL from stdin. Read-only is enforced by the
+#                    server, not by trusting the caller's query.
+#   migrate          Run sqlx migrations against the stack's database.
+#   status           What is running, which image, and the bot's own version.
+#   help             Show this help.
+#
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+STACK="${STACK:-cracktunes}"
+ENV_FILE="${ENV_FILE:-.env}"
+EXPECTED_CONTEXT="${EXPECTED_CONTEXT:-default}"
+CURRENT_CONTEXT="$(docker context show 2>/dev/null || echo unknown)"
+ORIGINAL_ARGS="$*"
+
+# The password baked into docker-compose.yml's DATABASE_URL for the app
+# services. Read from the file rather than duplicated here, so this keeps
+# working if the compose file is edited.
+compose_db_password() {
+  grep -oE 'DATABASE_URL=postgresql://[^:]+:[^@]+@' docker-compose.yml \
+    | head -1 | sed 's|.*://[^:]*:||; s|@$||'
+}
+
+c_r=$'\033[31m'; c_g=$'\033[32m'; c_y=$'\033[33m'; c_b=$'\033[1m'; c_z=$'\033[0m'
+ok()   { printf "%s✓%s %s\n" "$c_g" "$c_z" "$*"; }
+warn() { printf "%s!%s %s\n" "$c_y" "$c_z" "$*"; }
+die()  { printf "%s✗ %s%s\n" "$c_r" "$*" "$c_z" >&2; exit 1; }
+hdr()  { printf "\n%s== %s ==%s\n" "$c_b" "$*" "$c_z"; }
+
+read_env() {
+  # Read one key out of $ENV_FILE without echoing the value. Tolerates the
+  # `export KEY=value` form the .env.example ships, and strips surrounding
+  # quotes. (docker compose itself also accepts `export`; verified.)
+  [[ -f "$ENV_FILE" ]] || return 0
+  grep -E "^(export[[:space:]]+)?${1}=" "$ENV_FILE" 2>/dev/null \
+    | head -1 | sed 's/^export[[:space:]]*//' | cut -d= -f2- | sed 's/^"//; s/"$//'
+}
+
+# ---------------------------------------------------------------- guards ----
+
+require_docker_context() {
+  [[ -n "${_CONTEXT_OK:-}" ]] && return 0
+
+  # DOCKER_HOST outranks the context, but `docker context show` keeps reporting
+  # the context name regardless — so the comparison below would be checking a
+  # value that is not deciding anything. Refuse rather than pretend to verify.
+  if [[ -n "${DOCKER_HOST:-}" ]]; then
+    die "DOCKER_HOST is set ($DOCKER_HOST), which overrides the docker context.
+       This script cannot verify which host it would deploy to.
+       Unset it and use DOCKER_CONTEXT=$EXPECTED_CONTEXT instead."
+  fi
+
+  if [[ "$CURRENT_CONTEXT" != "$EXPECTED_CONTEXT" ]]; then
+    die "docker context is '$CURRENT_CONTEXT', expected '$EXPECTED_CONTEXT'.
+
+       Deploying from the wrong context does NOT fail. It builds a complete
+       parallel stack on that host and looks exactly like success. Worse here:
+       docker-compose.yml bind-mounts ./.env and ./cracktunes.toml, which
+       resolve on the DOCKER HOST — so on a remote context the bot reads
+       whatever is at those paths over there, or nothing at all.
+
+       Fix:       DOCKER_CONTEXT=$EXPECTED_CONTEXT $0 $ORIGINAL_ARGS
+       Intended?  EXPECTED_CONTEXT=$CURRENT_CONTEXT $0 $ORIGINAL_ARGS"
+  fi
+
+  _CONTEXT_OK=1
+}
+
+require_env_file() {
+  [[ -f "$ENV_FILE" ]] || die "$ENV_FILE not found in $SCRIPT_DIR
+       Copy .env.example to .env and fill it in, or set ENV_FILE=<path>."
+}
+
+check_db_password() {
+  # See guard 2 in the header.
+  local baked env_pw
+  baked="$(compose_db_password)"
+  env_pw="$(read_env POSTGRES_PASSWORD)"
+
+  [[ -z "$baked" ]] && { warn "could not read the DATABASE_URL password out of docker-compose.yml — skipping the divergence check"; return 0; }
+  [[ -z "$env_pw" ]] && { ok "POSTGRES_PASSWORD unset in $ENV_FILE; compose default applies"; return 0; }
+
+  if [[ "$env_pw" != "$baked" ]]; then
+    die "POSTGRES_PASSWORD in $ENV_FILE does not match the password hardcoded in
+       docker-compose.yml's DATABASE_URL for the app services.
+
+       crack-postgres would come up with YOUR password and every app service
+       would keep trying the hardcoded one, so postgres looks healthy while the
+       bot sits in a restart loop on 'password authentication failed'.
+
+       Fix either side so they agree. The durable fix is to make compose build
+       DATABASE_URL from \${POSTGRES_PASSWORD} instead of hardcoding it."
+  fi
+  ok "database password agrees between $ENV_FILE and docker-compose.yml"
+}
+
+check_volumes() {
+  # See guard 3 in the header.
+  local missing=()
+  for v in pgdata crack_data; do
+    docker volume inspect "$v" >/dev/null 2>&1 || missing+=("$v")
+  done
+  if (( ${#missing[@]} )); then
+    die "external volume(s) missing on context '$CURRENT_CONTEXT': ${missing[*]}
+
+       docker-compose.yml declares these 'external: true', so compose will not
+       create them — a cold start on a fresh host fails here.
+
+       Fix: docker volume create ${missing[*]}"
+  fi
+  ok "external volumes present (pgdata, crack_data)"
+}
+
+check_discord_token() {
+  # See guard 4 in the header.
+  local tok
+  tok="$(read_env DISCORD_TOKEN)"
+  if [[ -z "$tok" || "$tok" == "XXXXXX" ]]; then
+    die "DISCORD_TOKEN is missing or still the placeholder in $ENV_FILE.
+
+       The bot fail-closes at boot, not at deploy: this would not fail the
+       deploy, it would replace a working container with one that panics on
+       'Failed to load bot config' and restarts until it is given up on."
+  fi
+  ok "DISCORD_TOKEN present"
+}
+
+preflight() {
+  hdr "preflight — stack=$STACK env=$ENV_FILE context=$CURRENT_CONTEXT"
+  require_env_file
+  ok "$ENV_FILE present"
+  if [[ "$CURRENT_CONTEXT" == "$EXPECTED_CONTEXT" ]]; then
+    ok "docker context is '$CURRENT_CONTEXT' as expected"
+  else
+    warn "docker context is '$CURRENT_CONTEXT', expected '$EXPECTED_CONTEXT' — state-changing commands will refuse"
+  fi
+  check_discord_token
+  check_db_password
+  # Volume presence is context-specific; only meaningful once the context is right.
+  if [[ "$CURRENT_CONTEXT" == "$EXPECTED_CONTEXT" ]]; then
+    check_volumes
+  fi
+  echo
+}
+
+# Everything that mutates the stack goes through here.
+dc() {
+  require_docker_context
+  require_env_file
+  docker compose -p "$STACK" --env-file "$ENV_FILE" "$@"
+}
+
+banner() { printf "[cracktunes] stack=%s env=%s context=%s — %s\n" "$STACK" "$ENV_FILE" "$CURRENT_CONTEXT" "$*"; }
+
+# ------------------------------------------------------------ subcommands ----
+
+cmd_up() {
+  require_env_file; check_discord_token; check_db_password
+  require_docker_context; check_volumes
+  banner "up"
+  dc up -d "$@"
+}
+
+cmd_deploy() {
+  require_env_file; check_discord_token; check_db_password
+  require_docker_context; check_volumes
+  banner "pulling fresh images and recreating ${*:-all services}"
+  dc pull "$@"
+  dc up -d --force-recreate "$@"
+}
+
+cmd_restart() {
+  banner "recreating ${*:-all services} WITHOUT pulling"
+  echo "[cracktunes] NOTE: this ships no new code. If a new image was published,"
+  echo "[cracktunes] use '$0 deploy' instead — the services pin floating tags and"
+  echo "[cracktunes] set no pull_policy, so a plain recreate keeps the cached image."
+  dc up -d --force-recreate "$@"
+}
+
+cmd_stop() { banner "stop"; dc stop; }
+cmd_down() { banner "down (volumes preserved)"; dc down; }
+cmd_ps()   { dc ps; }
+cmd_logs() { dc logs -f --tail=50 "$@"; }
+
+cmd_destroy() {
+  echo "[cracktunes] 'compose down -v' DROPS the postgres volume: guild settings,"
+  echo "[cracktunes] playlists, play logs, user votes — all of it."
+  read -r -p "Type the stack name ($STACK) to confirm: " confirm
+  [[ "$confirm" == "$STACK" ]] || die "confirmation mismatch — aborting"
+  dc down -v
+}
+
+cmd_shell() {
+  local svc="${1:-}"
+  [[ -n "$svc" ]] || die "usage: $0 shell <service>"
+  dc exec "$svc" sh
+}
+
+_pg_user() { local u; u="$(read_env POSTGRES_USER)"; printf '%s' "${u:-postgres}"; }
+_pg_db()   { local d; d="$(read_env POSTGRES_DB)";   printf '%s' "${d:-postgres}"; }
+
+cmd_psql() {
+  # Unix socket inside the container, so no password is needed from outside.
+  dc exec crack-postgres psql -U "$(_pg_user)" -h /var/run/postgresql -d "$(_pg_db)"
+}
+
+cmd_sql() {
+  # Read-only is enforced by the SERVER, not by trusting the SQL on stdin —
+  # this exists to be driven by tooling, where "we only send SELECTs" is not a
+  # strong enough guarantee. -tAX makes the output parseable.
+  dc exec -T -e PGOPTIONS='-c default_transaction_read_only=on' crack-postgres \
+    psql -U "$(_pg_user)" -h /var/run/postgresql -d "$(_pg_db)" \
+      -tAX -v ON_ERROR_STOP=1 -P pager=off "$@"
+}
+
+cmd_migrate() {
+  require_env_file
+  command -v sqlx >/dev/null 2>&1 || die "sqlx not found in PATH.
+       Install: cargo install sqlx-cli --no-default-features --features rustls,postgres"
+  local url
+  url="$(read_env DATABASE_URL)"
+  [[ -n "$url" ]] || die "DATABASE_URL not set in $ENV_FILE"
+  banner "running migrations"
+  DATABASE_URL="$url" sqlx migrate run --source migrations/
+}
+
+cmd_status() {
+  hdr "stack — $STACK on context $CURRENT_CONTEXT"
+  dc ps || true
+  hdr "images"
+  dc config --images 2>/dev/null || true
+  hdr "bot version"
+  # The container has no shell-free version flag; read the label off the image
+  # it is actually running, which is what matters after a deploy.
+  local cid
+  cid="$(dc ps -q cracktunes 2>/dev/null | head -1)"
+  if [[ -n "$cid" ]]; then
+    docker inspect --format '{{.Config.Image}}  (started {{.State.StartedAt}})' "$cid" 2>/dev/null || true
+  else
+    warn "cracktunes container is not running"
+  fi
+  echo
+}
+
+usage() {
+  # Print the header comment block, stripped of the '# ' prefix. Anchored on the
+  # first code line so it survives edits without hardcoded line numbers.
+  sed -n '3,/^set -euo pipefail/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-help}" in
+  preflight)  preflight ;;
+  up)         shift; cmd_up "$@" ;;
+  deploy)     shift; cmd_deploy "$@" ;;
+  restart)    shift; cmd_restart "$@" ;;
+  stop)       cmd_stop ;;
+  down)       cmd_down ;;
+  destroy)    cmd_destroy ;;
+  ps)         cmd_ps ;;
+  logs)       shift; cmd_logs "$@" ;;
+  shell)      shift; cmd_shell "$@" ;;
+  psql)       cmd_psql ;;
+  sql)        shift; cmd_sql "$@" ;;
+  migrate)    cmd_migrate ;;
+  status)     cmd_status ;;
+  help | -h | --help) usage ;;
+  *)
+    echo "[cracktunes] unknown subcommand: $1" >&2
+    usage
+    exit 2
+    ;;
+esac

--- a/scripts/cracktunes.sh
+++ b/scripts/cracktunes.sh
@@ -11,7 +11,7 @@
 # Config via env (sensible defaults):
 #   STACK             compose project name         (default: cracktunes)
 #   ENV_FILE          env file compose reads       (default: .env)
-#   EXPECTED_CONTEXT  docker context to require    (default: default)
+#   EXPECTED_CONTEXT  docker context to require    (default: pve-staging)
 #
 # Guards. Each of these refuses rather than warns, and each exists because the
 # failure it prevents is silent:
@@ -19,13 +19,16 @@
 #   1. DOCKER CONTEXT. `docker compose` targets whatever context is current, and
 #      this machine has several pointing at remote hosts (proxmox, pve-staging,
 #      homelab-*). Deploying to the wrong one does not fail — it builds a
-#      complete parallel stack over there and looks like success. It matters
-#      more than usual here because docker-compose.yml bind-mounts RELATIVE host
-#      paths (./.env, ./cracktunes.toml): on a remote context those resolve on
-#      the REMOTE filesystem, so the bot comes up reading someone else's config
-#      or an empty file. Default is `default` (the local socket) because the
-#      compose file is written for a local host. Deploying elsewhere is fine,
-#      but you have to say so: EXPECTED_CONTEXT=proxmox ./scripts/cracktunes.sh up
+#      complete parallel stack over there, with its own network and volumes,
+#      and looks like success. The stack lives on `pve-staging`, so that is the
+#      default; running against anything else — including the local socket —
+#      has to be asked for: EXPECTED_CONTEXT=default ./scripts/cracktunes.sh up
+#
+#      Relatedly: the compose file no longer bind-mounts anything from this
+#      checkout. It used to mount ./.env and ./cracktunes.toml, which resolve
+#      on the DOCKER HOST — so driving a remote context meant the bot read
+#      whatever sat at those paths over there, or an empty directory docker
+#      helpfully created. Config now arrives via compose's `env_file:`.
 #
 #   2. DATABASE PASSWORD DIVERGENCE. docker-compose.yml hardcodes
 #      `DATABASE_URL=postgresql://postgres:mysecretpassword@...` for the app
@@ -72,7 +75,7 @@ cd "$SCRIPT_DIR"
 
 STACK="${STACK:-cracktunes}"
 ENV_FILE="${ENV_FILE:-.env}"
-EXPECTED_CONTEXT="${EXPECTED_CONTEXT:-default}"
+EXPECTED_CONTEXT="${EXPECTED_CONTEXT:-pve-staging}"
 CURRENT_CONTEXT="$(docker context show 2>/dev/null || echo unknown)"
 ORIGINAL_ARGS="$*"
 
@@ -117,10 +120,9 @@ require_docker_context() {
     die "docker context is '$CURRENT_CONTEXT', expected '$EXPECTED_CONTEXT'.
 
        Deploying from the wrong context does NOT fail. It builds a complete
-       parallel stack on that host and looks exactly like success. Worse here:
-       docker-compose.yml bind-mounts ./.env and ./cracktunes.toml, which
-       resolve on the DOCKER HOST — so on a remote context the bot reads
-       whatever is at those paths over there, or nothing at all.
+       parallel stack on that host, with its own network and volumes, and
+       looks exactly like success — the only tell is that every container
+       says 'Creating' rather than 'Recreating'.
 
        Fix:       DOCKER_CONTEXT=$EXPECTED_CONTEXT $0 $ORIGINAL_ARGS
        Intended?  EXPECTED_CONTEXT=$CURRENT_CONTEXT $0 $ORIGINAL_ARGS"
@@ -210,7 +212,12 @@ preflight() {
 dc() {
   require_docker_context
   require_env_file
-  docker compose -p "$STACK" --env-file "$ENV_FILE" "$@"
+  # ENV_FILE is exported as well as passed: --env-file drives interpolation,
+  # while the services' own `env_file:` entry reads ${ENV_FILE} so the file the
+  # caller selected is the file whose variables reach the containers. Without
+  # the export those two could disagree, and the containers would silently take
+  # a different .env than the one this run was told to use.
+  ENV_FILE="$ENV_FILE" docker compose -p "$STACK" --env-file "$ENV_FILE" "$@"
 }
 
 banner() { printf "[cracktunes] stack=%s env=%s context=%s — %s\n" "$STACK" "$ENV_FILE" "$CURRENT_CONTEXT" "$*"; }

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,2 +1,21 @@
 #!/bin/sh
-. /app/.env && RUST_BACKTRACE=full /app/app
+#
+# Container entrypoint.
+#
+# /app/.env is sourced only if it is actually a readable file. It used to be
+# `. /app/.env && exec app`, which made the env file mandatory: with the stack
+# driven through a remote docker context, compose resolves `./.env` to an
+# absolute path on the DOCKER HOST, docker creates an empty directory there when
+# it does not exist, and sourcing a directory fails — so the `&&` short-circuited
+# and the bot never started. Config now arrives through compose's `env_file:`,
+# which injects variables directly and needs nothing on the host filesystem.
+#
+# exec so the bot is PID 1 and receives SIGTERM from `docker stop` directly,
+# rather than sh swallowing it and the container waiting out the kill timeout.
+set -e
+
+if [ -f /app/.env ] && [ -r /app/.env ]; then
+  . /app/.env
+fi
+
+RUST_BACKTRACE=full exec /app/app


### PR DESCRIPTION
Closes #403.

`scripts/` held 13 shell scripts, no entry point, and nothing saying which one was
the way to deploy. Three of them do not work, which is easy to miss precisely because
nothing claimed to be canonical.

Modelled on RuneCast's `deploy.sh` and anya-ai's `scripts/anya.sh`: one front door,
every compose call through a helper that pins `-p $STACK --env-file $ENV_FILE`, and
guards that encode specific silent failures rather than generic caution.

## The guards

Each refuses rather than warns, because each of these fails *quietly*:

**Docker context.** `docker compose` targets whatever context is current. This
workstation has four pointing at remote hosts, and the current one right now is
`pve-staging`, not `default`. Deploying to the wrong context does not error — it
builds a complete parallel stack over there and looks exactly like success. It is
worse here than in the general case: `docker-compose.yml` bind-mounts *relative*
paths (`./.env`, `./cracktunes.toml`), which resolve on the **docker host**, so a
remote context reads whatever happens to be at those paths there, or nothing.
Defaults to `default`; deploying anywhere else means saying so explicitly.

**Database password divergence.** `docker-compose.yml` hardcodes
`DATABASE_URL=postgresql://postgres:mysecretpassword@…` for both app services, while
`crack-postgres` honours `${POSTGRES_PASSWORD}`. Set that variable to anything else
and postgres comes up perfectly healthy while every app service fails to
authenticate. The guard reads the password back out of the compose file rather than
duplicating it, so it keeps working once the compose file is fixed properly.

**External volumes.** `pgdata` and `crack_data` are `external: true`, so compose will
not create them and a cold start on a fresh host just fails. Checked up front, with
the exact `docker volume create` to run.

**`DISCORD_TOKEN`.** The bot fail-closes at *boot*, not at deploy. A missing token is
not a failed deploy — it replaces a working container with one that panics on
`Failed to load bot config` and restarts until Docker gives up.

## deploy vs restart

Separate commands on purpose. The services pin floating `:dev` tags and set no
`pull_policy`, so a plain recreate keeps the cached image — a deploy that ships
nothing while looking like it worked. `deploy` pulls first; `restart` says in its own
output that it ships no new code.

## What was broken

Documented in `scripts/README.md` rather than deleted, so the intent survives:

- **`build_and_deploy.sh`** ends with `ssh kalevala -c '$HOME/run.sh'`. In ssh, `-c`
  selects a *cipher*. It exits immediately with
  `Unknown cipher type '$HOME/run.sh'` — the zip lands on the host and nothing ever
  starts. `kalevala` is also documented as being decommissioned.
- **`run.sh`** creates tmux session `cracktunes` and then sends the start command to
  `grafana-agent` — a different session. It also runs `$HOME/cracktunes` while the
  zip puts the binary at `target/release/cracktunes`.
- **`sync.sh`** rsyncs from a hardcoded `/home/lothrop/dev/cracktunes`, which is not
  where this repo lives; its `${HOME}` destination expands locally.

The README's Docker section loses its `FIXME`, and no longer tells you to
`docker build -t cracktunes .` before `docker compose up` — that does nothing, since
compose references the published `cyclefive/cracktunes:dev` image rather than a local
build.

## Verification

Every guard's failure path was exercised, not just the happy path: missing env file,
placeholder token, password divergence, wrong context, `DOCKER_HOST` set, missing
volumes. `preflight` correctly warns instead of dying, since it changes nothing.

Then end to end against a real remote docker context — `pve-staging`, under a
throwaway stack name so nothing real could be touched:

| step | result |
|---|---|
| `up crack-postgres` | network + container created |
| `ps` / `status` | container listed, images resolved, absent bot reported |
| `echo 'SELECT …' \| … sql` | returned `PostgreSQL 18.6` |
| `echo 'CREATE TABLE …' \| … sql` | `ERROR: cannot execute CREATE TABLE in a read-only transaction` — refused by the server, not by the script |
| `destroy` with a wrong confirmation | aborted, volume intact |
| `down` + volume cleanup | 0 containers, 0 volumes, 0 networks left |

## Deliberately not in this PR

- Deleting the three broken scripts. Easy to do and probably right, but that is a
  call for you rather than something to slip into a PR that is otherwise additive.
- Fixing the compose file itself — the hardcoded password, floating tags, missing
  `pull_policy`, `external: true` volumes, deprecated `links:`, the `rw` mount of
  `.env`, and the `2001:0DB9::/112` IPv6 block whose purpose is worth verifying. The
  guards make these visible and survivable; #403 lists them for a follow-up that
  changes runtime behaviour on its own terms.
- No version bump: scripts and docs only, no shipped artifact changes.