### PR TITLE
ci: stop dockerhub.yml from building every pull request

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -16,8 +16,8 @@ on:
       - 'master'
     tags: ['v*.*.*']
   pull_request:
-    #branches:
-    #  - 'master'
+    branches:
+      - 'master'
   workflow_call:
 
 env:
@@ -26,9 +26,14 @@ env:
 
 jobs:
   push:
-    #if: github.event_name == 'push' || (github.event_name == 'workflow_call' && github.event.inputs.trigger == 'build') 
-    #if: github.event_name == 'push' || (github.event_name == 'workflow_call' && github.event.inputs.trigger == 'build') 
+    name: Build & Push to Docker Hub
     runs-on: ubuntu-latest
+    # Never on a pull request. Dependabot PRs carry no secrets, so the
+    # Docker Hub login below fails outright -- but the real hazard is the
+    # branch where it would succeed: a PR build pushed under `push: true`
+    # publishes unreviewed code to cyclefive/cracktunes. docker.yml (GHCR)
+    # has carried this same guard all along; only this file lost it.
+    if: github.event_name == 'push' || (github.event_name == 'workflow_call' && github.event.inputs.trigger == 'build')
     permissions:
       contents: read
       packages: write
@@ -59,6 +64,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## The bug

`dockerhub.yml` is `docker.yml` with the safety removed — same job, same shape, but three guards were disabled:

| | `docker.yml` (GHCR) | `dockerhub.yml` (Docker Hub) |
|---|---|---|
| `pull_request` scope | `branches: ['master']` | **commented out** |
| event guard | `if: github.event_name == 'push' \|\| …` | **commented out, twice** |
| `push:` | `${{ github.event_name != 'pull_request' }}` | **`true`** |

## Two consequences

**The visible one:** five red dependabot PRs (#405–#409). Dependabot PRs are not granted repository secrets, so `docker/login-action` receives empty strings and the job dies in 28 seconds:

```
##[error]Username and password required
```

**The one that matters:** that is the *harmless* branch. Any pull request that did carry credentials would run `docker/build-push-action` with `push: true` and publish unreviewed code to `cyclefive/cracktunes` on Docker Hub. Nothing in the file prevented it.

## The fix

Restore what `docker.yml` has carried all along — scope the trigger, reinstate the guard (one copy), and make `push:` conditional so the job stays safe even if the guard is loosened again.

Also names the job, which reported as a bare `push` in the checks list. The name is deliberately *not* `docker.yml`'s — two checks both reading "Build & Push Docker Image" would be indistinguishable at a glance. No required status checks reference the old name; verified against the branch protection API before renaming.

## Effect on the open PRs

#405 and #406 fail on nothing but this job. Once this lands and they rebase, both should go green.