### PR TITLE
docs: record why symphonia cannot leave 0.5, and stop reproposing it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,29 @@ updates:
       interval: "daily"
     allow:
       - dependency-type: "all"
+    ignore:
+      # symphonia's version is not ours to choose. songbird pins `^0.5.2` on
+      # EVERY branch -- current, next, serenity-next (the one we track) and
+      # v0.4.x -- with no open issue or PR proposing 0.6. Our direct dependency
+      # exists to unify with songbird's and to switch on the codec features
+      # songbird itself declares `default-features = false` for; it is not an
+      # independent choice we can bump.
+      #
+      # A 0.5 -> 0.6 bump therefore cannot compile: two `symphonia-core` crates
+      # land in one graph, and `impl MediaSource` in crack-core is then written
+      # against a different trait than the one songbird's `Compose` expects.
+      # That is E0053, and it is trait *identity*, not a trait change -- the
+      # `MediaSource` trait is byte-identical between 0.5.5 and 0.6.1.
+      #
+      # Patch updates inside 0.5.x are still wanted, so only minor and major are
+      # ignored. Revisit when songbird ships symphonia 0.6; see
+      # docs/symphonia-and-songbird.md for what that port involves.
+      - dependency-name: "symphonia"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      # Must track symphonia exactly, so it hits the same wall.
+      - dependency-name: "symphonia-metadata"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,13 @@ features = [
   "builtin-queue",
 ]
 
+# 🪤 This version is NOT an independent choice -- songbird pins `^0.5.2` on every
+# branch, and bumping only our side puts two `symphonia-core` crates in one graph
+# (E0053 on `Compose::create`). The features are load-bearing too: songbird
+# declares symphonia with `default-features = false`, so THIS line is what
+# enables MP3/AAC/FLAC/Vorbis/MKV/ISO-MP4 decoding, and dropping the dependency
+# in favour of songbird's re-export would silently lose them.
+# See docs/symphonia-and-songbird.md.
 [workspace.dependencies.symphonia]
 version = "0.5.4"
 features = ["all-formats", "all-codecs", "opt-simd"]

--- a/docs/symphonia-and-songbird.md
+++ b/docs/symphonia-and-songbird.md
@@ -1,0 +1,136 @@
+# symphonia is pinned by songbird
+
+Why dependabot's symphonia 0.6 pull requests cannot be merged, what would have
+to happen first, and the trap in our own `Cargo.toml` that is easy to trip while
+tidying up.
+
+Verified 2026-08-27 against upstream, the lockfile, and both crates' docs.
+
+## The short version
+
+`symphonia`'s version is not ours to choose. `songbird` pins `^0.5.2`, our
+direct dependency exists to unify with it, and the two must move together or
+nothing compiles.
+
+## Why the bump fails
+
+Dependabot's symphonia 0.6.1 PR fails to build with:
+
+```
+error[E0053]: method `create` has an incompatible type for trait
+  --> crack-core/src/sources/rusty_ytdl.rs:186:5
+  --> symphonia-core-0.5.5/src/io/mod.rs:42:1
+error[E0053]: method `create_async` has an incompatible type for trait
+```
+
+Read which version the *trait* comes from: `symphonia-core-**0.5.5**`, while the
+PR moves our direct dependency to 0.6.1.
+
+This is trait **identity**, not a trait change. `MediaSource` is byte-identical
+in both versions:
+
+```rust
+pub trait MediaSource: Read + Seek + Send + Sync {
+    fn is_seekable(&self) -> bool;
+    fn byte_len(&self) -> Option<u64>;
+}
+```
+
+`crack-core/src/sources/rusty_ytdl.rs` implements that trait and hands the result
+to songbird's `Compose`, whose signature is
+`Result<AudioStream<Box<dyn MediaSource>>, AudioStreamError>`. Bump only our
+side and two `symphonia-core` crates land in one graph — our impl satisfies
+0.6's trait, songbird wants 0.5's, and to rustc those are two different traits
+that merely look alike.
+
+**Our own porting cost for symphonia 0.6 is zero.** The workspace's entire
+symphonia surface is one line:
+
+```
+crack-core/src/sources/rusty_ytdl.rs:21:  use symphonia::core::io::MediaSource;
+```
+
+## Who else is involved — nobody
+
+Only two crates in the whole lock graph depend on symphonia: `crack-core` and
+`songbird`. Not serenity, not poise, not lavalink-rs, not rusty_ytdl. There is no
+wide multi-crate bump to coordinate. The cascade is narrow and deep, not broad.
+
+## songbird pins 0.5.2 on every branch
+
+Checked against `serenity-rs/songbird` directly:
+
+| branch | symphonia |
+|---|---|
+| `current` | `0.5.2` |
+| `next` | `0.5.2` |
+| `serenity-next` — the branch we track | `0.5.2` |
+| `v0.4.x` | `0.5.2` |
+
+No open issue or PR proposes 0.6; the only symphonia issues are closed ones from
+the original 0.5 migration. Our own fork (`CycleFive/songbird`, branch
+`bot-template-experiment`) sits on top of `serenity-next` and is likewise on
+0.5.2. There is no branch to switch to.
+
+## What the songbird port would involve
+
+symphonia 0.6 restructured precisely the surfaces songbird is built on. Its
+exposure, across 34 files:
+
+| symphonia API | songbird refs | what 0.6 did |
+|---|---:|---|
+| `AudioBuffer` | 63 | `Signal` split into `Audio`, `AudioMut`, `AudioBytes`, `AudioBufferBytes` |
+| `AudioBufferRef` | 42 | replaced by `GenericAudioBufferRef`, no longer copy-on-write |
+| `Layout` | 16 | **removed**; replaced by a `layouts` submodule of `Channels` constants |
+| `CodecRegistry` | 15 | `register()` **removed**; `make()` → `make_audio_decoder()` |
+| `Probe` / `get_probe` | 15 / 14 | moved to `formats::probe`; `format()` → `probe()`; tiered registration |
+| `SignalSpec` | 13 | renamed `AudioSpec`; `Channels` no longer a bitmask |
+| `MediaSourceStream` | 11 | gained an explicit lifetime |
+| `next_packet` | 6 | returns `Ok(None)` at EOF instead of an error |
+| `SampleBuffer` | 5 | **removed** — use the new trait copy functions |
+| `QueryDescriptor` | 4 | **removed** — implement `ProbeableFormat` instead |
+
+Two items make this more than a mechanical port:
+
+1. **It breaks songbird's public API.** `Config` exposes
+   `codec_registry: &'static CodecRegistry` and `format_registry: &'static Probe`.
+   Both types moved and changed shape, so a bump is semver-breaking for every
+   songbird consumer.
+2. **songbird registers its own codecs.** It ships `FormatReader` impls for dca
+   and raw plus an `OpusDecoder`, registered through `CodecRegistry::register()`
+   — the exact call 0.6 removed.
+
+symphonia 0.6 also raises MSRV to 1.85. That part is free for us: no
+`rust-version` pin anywhere, and `rust-toolchain` is `stable`.
+
+## 🪤 The trap — do not "clean up" our direct dependency
+
+songbird re-exports symphonia at `songbird::input::core`
+(`pub use symphonia_core as core;`), which makes an obvious-looking tidy-up
+suggest itself: drop our direct symphonia dependency and import `MediaSource`
+from songbird instead, so only one symphonia can ever be in the graph.
+
+**That would silently break audio playback.** Compare the declarations:
+
+```toml
+# ours -- Cargo.toml
+symphonia = { version = "0.5.4", features = ["all-formats", "all-codecs", "opt-simd"] }
+
+# songbird's
+symphonia = { default-features = false, optional = true, version = "0.5.2" }
+```
+
+songbird enables **no format or codec features at all**. Our declaration is what
+actually switches on MP3, AAC, FLAC, Vorbis, MKV and ISO-MP4 decoding, via cargo
+feature unification. Remove it and the bot keeps compiling while losing the
+ability to decode nearly everything.
+
+If that consolidation is ever wanted, the codec features have to move onto
+songbird's side first.
+
+## Loose end
+
+`[workspace.dependencies.symphonia-metadata]` in the root `Cargo.toml` is
+referenced by no crate and no source file. It is dead and can be deleted on its
+own; it is left in place here only because removing it is unrelated to this
+document.


### PR DESCRIPTION
Closes #407.

## The error lies about the cause

Dependabot's symphonia 0.6.1 PR fails with:

```
error[E0053]: method `create` has an incompatible type for trait
  --> crack-core/src/sources/rusty_ytdl.rs:186:5
  --> symphonia-core-0.5.5/src/io/mod.rs:42:1
```

That reads like an API change we need to absorb. It isn't. Note the trait comes from **0.5.5** while the PR moves us to **0.6.1** — and `MediaSource` is byte-identical between the two versions:

```rust
pub trait MediaSource: Read + Seek + Send + Sync {
    fn is_seekable(&self) -> bool;
    fn byte_len(&self) -> Option<u64>;
}
```

This is trait **identity**, not shape. songbird pins `^0.5.2`, so bumping only our side puts two `symphonia-core` crates in one graph; `crack-core`'s impl then satisfies 0.6's trait while songbird's `Compose` wants 0.5's, and to rustc those are different traits that merely look alike.

**Our own porting cost for symphonia 0.6 is zero** — the workspace's entire symphonia surface is one `use` line in one file.

## There is no branch to switch to

Checked `serenity-rs/songbird` directly:

| branch | symphonia |
|---|---|
| `current` | `0.5.2` |
| `next` | `0.5.2` |
| **`serenity-next`** — the one we track | **`0.5.2`** |
| `v0.4.x` | `0.5.2` |

No open issue or PR proposes 0.6; the only symphonia issues are closed ones from the original 0.5 migration. Our fork sits on top of `serenity-next` and is likewise 0.5.2.

## Changes

**`docs/symphonia-and-songbird.md`** — the full record: why it fails, the branch sweep, and what a songbird port would involve. 0.6 restructured `AudioBuffer` (63 refs), `AudioBufferRef` (42), `Layout` (16, *removed*), `CodecRegistry` (15, `register()` *removed*), `Probe`/`get_probe` (15/14, moved), `SignalSpec` (13, renamed `AudioSpec`) — exactly songbird's surface, across 34 files. It also breaks songbird's public API, since `Config` exposes `&'static CodecRegistry` and `&'static Probe`.

**`.github/dependabot.yml`** — ignore symphonia minor/major so the unmergeable PR stops returning. Patch updates inside 0.5.x are still wanted, so only minor and major are ignored (0.5→0.6 is a *minor* bump in strict semver). `symphonia-metadata` must track symphonia exactly and gets the same treatment.

**`Cargo.toml`** — annotate the declaration, because the obvious tidy-up is a trap. songbird re-exports symphonia at `songbird::input::core`, which makes "drop our direct dep and import from songbird" look attractive. But songbird declares symphonia with `default-features = false`, so **our** `all-formats`/`all-codecs` line is what actually enables MP3/AAC/FLAC/Vorbis/MKV/ISO-MP4 decoding. Removing it would keep compiling and silently lose them.

## Risk

Comments and documentation only. `Cargo.lock` is untouched and dependency resolution is unchanged — verified with `cargo metadata`.