### PR TITLE
feat: start with only a token, and stop logging that token

### DIFF
--- a/crack-cli/src/main.rs
+++ b/crack-cli/src/main.rs
@@ -134,8 +134,14 @@ fn load_key(k: String) -> Result<String, Error> {
 
 /// Load the bot's config
 fn load_bot_config() -> Result<BotConfig, Error> {
+    // The token is the one thing the bot genuinely cannot start without.
     let discord_token = load_key("DISCORD_TOKEN".to_string())?;
-    let discord_app_id = load_key("DISCORD_APP_ID".to_string())?;
+    // Optional: nothing reads it. serenity derives the application id from the
+    // token itself, and requiring this was the sole reason a bot with a valid
+    // token would refuse to boot.
+    let discord_app_id = load_key("DISCORD_APP_ID".to_string())
+        .ok()
+        .unwrap_or_default();
     let spotify_client_id = load_key("SPOTIFY_CLIENT_ID".to_string()).ok();
     let spotify_client_secret = load_key("SPOTIFY_CLIENT_SECRET".to_string()).ok();
     let openai_api_key = load_key("OPENAI_API_KEY".to_string()).ok();
@@ -149,6 +155,13 @@ fn load_bot_config() -> Result<BotConfig, Error> {
             BotConfig::default()
         },
     };
+    // Env wins over the file. Nothing read DATABASE_URL before this, so the
+    // documented docker-compose deployment set it and the bot ignored it,
+    // silently running with no persistence while appearing configured.
+    if let Ok(database_url) = env::var("DATABASE_URL") {
+        config.database_url = Some(database_url);
+    }
+
     let config_with_creds = config.set_credentials(BotCredentials {
         discord_token,
         discord_app_id,

--- a/crack-core/src/config.rs
+++ b/crack-core/src/config.rs
@@ -210,12 +210,38 @@ pub async fn poise_framework(
         })
         .unwrap_or_default();
 
-    let db_url: &str = &config_ref.get_database_url();
-    let database_pool = match sqlx::postgres::PgPoolOptions::new().connect(db_url).await {
-        Ok(pool) => Some(pool),
-        Err(e) => {
-            tracing::error!("Error getting database pool: {}, db_url: {}", e, db_url);
+    // Only attempt a connection when a database was actually configured.
+    // Guessing at a localhost Postgres cost every DB-less boot a 30s pool
+    // timeout, for a deployment that never had one to reach.
+    //
+    // The failure arm deliberately does NOT log the URL: it carries the
+    // password, and this used to put it in the logs at ERROR on every start
+    // without a database.
+    let database_pool = match config_ref.database_url.as_deref() {
+        None => {
+            tracing::info!(
+                "No database configured (set DATABASE_URL) -- running without persistence. \
+                 Play history, track reactions and playlist storage are disabled; \
+                 everything else works."
+            );
             None
+        },
+        Some(db_url) => match sqlx::postgres::PgPoolOptions::new()
+            // Bounded so an unreachable database costs seconds at startup, not
+            // the 30s sqlx defaults to.
+            .acquire_timeout(Duration::from_secs(5))
+            .connect(db_url)
+            .await
+        {
+            Ok(pool) => Some(pool),
+            Err(e) => {
+                tracing::warn!(
+                    "Database configured but unreachable ({e}) -- continuing without \
+                     persistence. Play history, track reactions and playlist storage \
+                     are disabled."
+                );
+                None
+            },
         },
     };
     let db_channel = match database_pool.clone().map(db::worker_pool::setup_workers) {

--- a/crack-core/src/lib.rs
+++ b/crack-core/src/lib.rs
@@ -123,7 +123,7 @@ impl Display for CamKickConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct BotCredentials {
     pub discord_token: String,
     pub discord_app_id: String,
@@ -131,6 +131,56 @@ pub struct BotCredentials {
     pub spotify_client_secret: Option<String>,
     pub openai_api_key: Option<String>,
     pub virustotal_api_key: Option<String>,
+}
+
+/// Hand-written so no `{:?}` anywhere can print a secret. The startup config
+/// dump did exactly that with the Discord token, which is a full bot-takeover
+/// credential; a derived Debug puts it in the logs of every deployment. What
+/// is useful in a log is whether a credential is PRESENT, never its value.
+impl std::fmt::Debug for BotCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn shown(v: &Option<String>) -> &'static str {
+            if v.is_some() {
+                "<set>"
+            } else {
+                "<unset>"
+            }
+        }
+        f.debug_struct("BotCredentials")
+            .field("discord_token", &"<redacted>")
+            .field(
+                "discord_app_id",
+                &if self.discord_app_id.is_empty() {
+                    "<unset>"
+                } else {
+                    "<set>"
+                },
+            )
+            .field("spotify_client_id", &shown(&self.spotify_client_id))
+            .field("spotify_client_secret", &shown(&self.spotify_client_secret))
+            .field("openai_api_key", &shown(&self.openai_api_key))
+            .field("virustotal_api_key", &shown(&self.virustotal_api_key))
+            .finish()
+    }
+}
+
+/// A connection URL with its password replaced. These get logged at startup,
+/// so the password must not survive the trip.
+pub fn redact_url(url: &str) -> String {
+    let Some(scheme_end) = url.find("://") else {
+        return url.to_string();
+    };
+    let rest = &url[scheme_end + 3..];
+    let Some(at) = rest.rfind('@') else {
+        return url.to_string();
+    };
+    let user = rest[..at].split(':').next().unwrap_or("");
+    format!(
+        "{}{}:<redacted>{}",
+        &url[..scheme_end + 3],
+        user,
+        &rest[at..]
+    )
 }
 
 impl Default for BotCredentials {
@@ -176,7 +226,9 @@ impl Default for BotConfig {
             guild_settings_map: None,
             prefix: Some(DEFAULT_PREFIX.to_string()),
             credentials: Some(BotCredentials::default()),
-            database_url: Some(DEFAULT_DB_URL.to_string()),
+            // None, not a localhost guess: the bot must not assume a Postgres
+            // nobody configured. DATABASE_URL or cracktunes.toml supplies it.
+            database_url: None,
             log_prefix: Some(DEFAULT_LOG_PREFIX.to_string()),
         }
     }
@@ -209,7 +261,10 @@ impl Display for BotConfig {
                 .unwrap_or(DEFAULT_PREFIX.to_string())
         ));
         result.push_str(&format!("credentials: {:?}\n", self.credentials.is_some()));
-        result.push_str(&format!("database_url: {:?}\n", self.database_url));
+        result.push_str(&format!(
+            "database_url: {:?}\n",
+            self.database_url.as_deref().map(redact_url)
+        ));
         result.push_str(&format!("log_prefix: {:?}\n", self.log_prefix));
         write!(f, "{}", result)
     }


### PR DESCRIPTION
The bot refused to boot without `DISCORD_APP_ID`, then spent **thirty seconds** failing to reach a Postgres nobody had configured, then **printed the Discord token into the log**. Deploying it anywhere minimal meant standing up a whole stack it did not actually need.

## Starting with only a token

**`DISCORD_APP_ID` is now optional.** Nothing reads it — it is stored in `BotCredentials` and never used again, and serenity derives the application id from the token itself. Requiring it was the *sole* reason a bot holding a valid token would refuse to start.

**The database is only contacted if one was configured.** `BotConfig::default` supplied a localhost URL, so a deployment with no database still opened a connection to nothing and paid sqlx's 30s acquire timeout every boot. Default is `None` now, the attempt is skipped, and the log says what is off: play history, track reactions, playlist storage. A configured-but-*unreachable* database is bounded at 5s and downgraded ERROR → WARN, because that is a degraded start, not a failure.

| | before | after |
|---|---|---|
| token only | panic | starts |
| time to reach the token check | 30s | **0s** |

## A bug found on the way

**`DATABASE_URL` was never read.** `crack-voting` reads it; the bot never did. So the documented `docker-compose` deployment sets it and the bot ignores it in favour of the localhost default — appearing configured while silently running with no persistence. Now read, env winning over the file.

## Two credential leaks

Both into logs, readable by anyone with log access:

- **The startup config dump printed the Discord token in plaintext.** That is a full bot-takeover credential. `BotCredentials` now has a hand-written `Debug` that redacts it and reports every other secret as `<set>`/`<unset>`. Fixed **at the type level** deliberately — no future `{:?}` anywhere can leak it either, which patching the one log site would not have achieved.
- **The database URL was logged with its password**, on every failed connection and in `BotConfig`'s `Display`. Both now go through `redact_url`.

## Verification

Ran the binary with `DISCORD_TOKEN` set and nothing else, from a directory with **no `cracktunes.toml`** — the container's actual situation:

```
WARN  Using config: BotConfig { ... credentials: Some(BotCredentials {
        discord_token: "<redacted>", discord_app_id: "<unset>", ... }),
        database_url: None, ... }
INFO  No database configured (set DATABASE_URL) -- running without persistence.
      Play history, track reactions and playlist storage are disabled;
      everything else works.
ERROR Error: InvalidToken
```

Zero seconds to the token check, database reported absent rather than broken, and the real token string appears nowhere in the output. `InvalidToken` is the correct end for a fake token — with a real one it proceeds.

`cargo build`, `clippy --all-targets -D warnings`, `cargo fmt --check` clean. `cargo test -p crack-core --lib` is 100/20, identical to master.

## Relationship to #419

Independent — branched from master, no overlapping files. #419 adds `/spotify`; this makes the bot deployable without a stack behind it. Both are wanted for the bots-VM deploy.