### PR TITLE
fix: restore the bot to a working state (0.5.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,41 +1,49 @@
+# Copy to .env and fill in. scripts/cracktunes.sh reads this file, and compose
+# injects it into the containers via `env_file:` -- so it is read on THIS
+# machine, not on the docker host, and works unchanged through a remote context.
 #
-# [REQUIRED] To authenticate with Discord, you must create a Discord app.
-# See more: https://discord.com/developers/applications
-export DISCORD_TOKEN=XXXXXX
-export DISCORD_APP_ID=XXXXXX
+# Only DISCORD_TOKEN is required. Everything else switches on a feature: leave
+# it unset and the bot logs which one it disabled and carries on.
 
-#
-# [REQUIRED] Postgres database URL for the bot to use.
-#
-export DATABASE_URL=postgresql://postgres:mysecretpassword@localhost:5432/postgres
-export PG_USER=postgres
-export PG_PASSWORD=mysecretpassword
+# ---------------------------------------------------------------- required --
+# The bot fail-closes at boot without this.
+DISCORD_TOKEN=XXXXXX
 
-#
-# [Optional] To support Spotify links, you must create a Spotify app.
-# See more: https://developer.spotify.com/dashboard/applications
-export SPOTIFY_CLIENT_ID=XXXXXX
-export SPOTIFY_CLIENT_SECRET=XXXXXX
+# ---------------------------------------------------------------- optional --
+# Application id. Only needed if you register commands against a different
+# application than the token belongs to.
+DISCORD_APP_ID=
 
-#
-# [Optional] OpenAI API key for the chatgpt feature.
-#
-export OPENAI_API_KEY=XXXXXX
+# Persistence: play history, track reactions, playlists, guild settings.
+# Unset -> the bot runs without persistence and says so at startup.
+# For the compose stack this must match the URL baked into docker-compose.yml.
+DATABASE_URL=postgresql://postgres:mysecretpassword@localhost:5432/postgres
 
-#
-# [Optional] pgadmin support
-#
-export PGADMIN_MAIL=XXXXXX
-export PGADMIN_PW=XXXXXX
+# Postgres container. POSTGRES_PASSWORD must agree with the password in
+# docker-compose.yml's DATABASE_URL or the app services cannot authenticate --
+# `cracktunes.sh preflight` checks this.
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=mysecretpassword
+POSTGRES_DB=postgres
+PUB_PORT=5432
 
-#
-# [Optional] VirusTotal API key for the url scanning.
-#
-export VIRUSTOTAL_API_KEY=XXXXXX
+# Spotify link resolution, via a sleevenote instance.
+# Unset -> defaults to http://127.0.0.1:3000.
+SLEEVENOTE_BASE_URL=
 
-#
-# [Optional] top.gg and discordbotlist.com integration.
-#
-export TOPGG_TOKEN=XXXXXX
-export DBL_TOKEN=XXXXXX
-export WEBHOOK_SECRET=XXXXXX
+# Spotify's own API. Long dead for new apps; sleevenote replaces it.
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+
+# top.gg vote tracking (crack-voting).
+TOPGG_TOKEN=
+WEBHOOK_SECRET=test_secret
+
+# Feature-gated integrations.
+OPENAI_API_KEY=
+VIRUSTOTAL_API_KEY=
+NUMVERIFY_API_KEY=
+
+# pgadmin container.
+PGADMIN_MAIL=a@b.com
+PGADMIN_PW=password

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,9 @@ jobs:
           DATABASE_URL: ${{ steps.postgres.outputs.connection-uri }}
           PG_USER: postgres
           PG_PASSWORD: mysecretpassword
-        run: cargo test --workspace
+        # CI provisions postgres above, so the database-backed tests run here.
+        # They are ignored by default so the suite is green without one.
+        run: cargo test --workspace --features crack-core/db-tests,cracktunes/db-tests,crack-voting/db-tests
 
       - name: Run Release Unit Tests
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -79,7 +81,7 @@ jobs:
           DATABASE_URL: ${{ steps.postgres.outputs.connection-uri }}
           PG_USER: postgres
           PG_PASSWORD: mysecretpassword
-        run: cargo test --release --locked
+        run: cargo test --release --locked --workspace --features crack-core/db-tests,cracktunes/db-tests,crack-voting/db-tests
 
       # - name: Build Binary
       #   if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -74,7 +74,8 @@ jobs:
           VIRUSTOTAL_API_KEY: ${{secrets.VIRUSTOTAL_API_KEY}}
           WEBHOOK_SECRET: ${{secrets.WEBHOOK_SECRET}}
         run: |
-          cargo tarpaulin --ignore-tests --verbose --all --timeout 120 --out xml
+          cargo tarpaulin --ignore-tests --verbose --all --timeout 120 --out xml \
+            --features crack-core/db-tests,cracktunes/db-tests,crack-voting/db-tests
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,14 +1094,14 @@ dependencies = [
 
 [[package]]
 name = "crack-bf"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "crack-core"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "crack-gpt"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "async-openai",
  "const_format",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "crack-osint"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "crack-types",
  "ipinfo",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "crack-sleevenote"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "crack-testing"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "crack-types"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "humantime",
  "poise",
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "crack-voting"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "dbl-rs",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "cracktunes"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "config-file",
  "crack-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,14 +1094,14 @@ dependencies = [
 
 [[package]]
 name = "crack-bf"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "crack-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "crack-gpt"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-openai",
  "const_format",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "crack-osint"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "crack-types",
  "ipinfo",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "crack-sleevenote"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "crack-testing"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "crack-types"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "humantime",
  "poise",
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "crack-voting"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "dbl-rs",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "cracktunes"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "config-file",
  "crack-core",

--- a/crack-bf/Cargo.toml
+++ b/crack-bf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-bf"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-bf/Cargo.toml
+++ b/crack-bf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-bf"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-cli/Cargo.toml
+++ b/crack-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "cracktunes"
-version = "0.4.2"
+version = "0.5.0"
 description = "Cracktunes is a hassle-free, highly performant, host-it-yourself, cracking smoking, discord-music-bot."
 publish = true
 edition = "2021"
@@ -31,6 +31,13 @@ crack-metrics = ["crack-core/crack-metrics"]
 # Structured JSON logs. Implies crack-tracing: `init_telemetry` is gated on it, so
 # crack-telemetry on its own would silently do nothing.
 crack-telemetry = ["crack-tracing", "tracing-bunyan-formatter"]
+
+# Tests that need a live postgres at DATABASE_URL. Off by default: the bot runs
+# without a database, so its test suite has to as well -- otherwise every
+# checkout without postgres reports 20+ red tests that say nothing about the
+# change under review. The gated tests are still COMPILED, so they cannot rot;
+# CI turns this on. See docs/testing.md.
+db-tests = []
 
 [dependencies]
 crack-core = { path = "../crack-core/" }

--- a/crack-cli/Cargo.toml
+++ b/crack-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "cracktunes"
-version = "0.4.1"
+version = "0.4.2"
 description = "Cracktunes is a hassle-free, highly performant, host-it-yourself, cracking smoking, discord-music-bot."
 publish = true
 edition = "2021"

--- a/crack-cli/src/test/playlist.rs
+++ b/crack-cli/src/test/playlist.rs
@@ -16,6 +16,10 @@ mod test {
 
     //#[tokio::test]
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_delete_playlist_by_id(pool: PgPool) {
         // Setup
         let user_id = 1; // or fetch a user id for the test

--- a/crack-core/Cargo.toml
+++ b/crack-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-core"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 edition = "2021"
 description = "Core module for the cracking smoking, discord-music-bot Cracktunes."

--- a/crack-core/Cargo.toml
+++ b/crack-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-core"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 edition = "2021"
 description = "Core module for the cracking smoking, discord-music-bot Cracktunes."
@@ -38,6 +38,13 @@ crack-voting = ["dep:crack-voting"]
 crack-testing = ["dep:crack-testing"]
 crack-types = ["dep:crack-types"]
 ignore-presence-log = []
+
+# Tests that need a live postgres at DATABASE_URL. Off by default: the bot runs
+# without a database, so its test suite has to as well -- otherwise every
+# checkout without postgres reports 20+ red tests that say nothing about the
+# change under review. The gated tests are still COMPILED, so they cannot rot;
+# CI turns this on. See docs/testing.md.
+db-tests = []
 
 [dependencies]
 cfg-if = "1"

--- a/crack-core/src/commands/mod.rs
+++ b/crack-core/src/commands/mod.rs
@@ -71,26 +71,14 @@ pub fn all_commands() -> Vec<crate::Command> {
     .collect()
 }
 
-/// Return all the commands that are available in the bot.
+/// The commands registered with Discord as application (slash) commands.
+///
+/// Delegates to [`all_commands`] on purpose: this list and the framework's
+/// dispatch list must be the same set. A slash command registered but absent
+/// from the framework silently does nothing when invoked, and one in the
+/// framework but unregistered can never be invoked at all.
 pub fn commands_to_register() -> Vec<crate::Command> {
-    vec![
-        register(),
-        #[cfg(feature = "crack-bf")]
-        bf(),
-        #[cfg(feature = "crack-osint")]
-        osint(),
-        #[cfg(feature = "crack-gpt")]
-        chat(),
-    ]
-    .into_iter()
-    //.chain(help::help_commands())
-    .chain(music::music_commands())
-    // .chain(music::game_commands())
-    .chain(utility::utility_commands())
-    //.chain(settings::commands())
-    //.chain(admin::commands())
-    //.chain(playlist::commands())
-    .collect()
+    all_commands()
 }
 
 pub fn all_command_names() -> Vec<Cow<'static, str>> {

--- a/crack-core/src/commands/mod.rs
+++ b/crack-core/src/commands/mod.rs
@@ -150,3 +150,33 @@ pub async fn register(ctx: Context<'_>) -> Result<(), Error> {
     register_application_commands_buttons_cracked(ctx).await?;
     Ok(())
 }
+
+#[cfg(test)]
+mod test {
+    use super::commands_to_register;
+
+    /// Every command we register must be invocable as a slash or context-menu
+    /// command.
+    ///
+    /// The bot runs without the MESSAGE_CONTENT intent, so a prefix-only
+    /// command is unreachable in practice: message content is empty unless the
+    /// message mentions the bot. This is the check that turns "nobody can call
+    /// it and nobody notices" into a failing test.
+    #[test]
+    fn every_registered_command_is_reachable() {
+        let unreachable: Vec<String> = commands_to_register()
+            .iter()
+            .filter(|c| {
+                c.create_as_slash_command().is_none()
+                    && c.create_as_context_menu_command().is_none()
+            })
+            .map(|c| c.name.to_string())
+            .collect();
+
+        assert!(
+            unreachable.is_empty(),
+            "prefix-only commands cannot be invoked without the MESSAGE_CONTENT \
+             intent; add `slash_command` to: {unreachable:?}"
+        );
+    }
+}

--- a/crack-core/src/commands/music/vote.rs
+++ b/crack-core/src/commands/music/vote.rs
@@ -132,6 +132,10 @@ mod test {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_check_and_record_vote(pool: sqlx::PgPool) {
         let user_id = 285219649921220608;
         let username = "test".to_string();

--- a/crack-core/src/config.rs
+++ b/crack-core/src/config.rs
@@ -13,7 +13,7 @@ use crate::{
     http_utils::SendMessageParams,
     messaging::message::CrackedMessage,
     utils::{check_reply, count_command},
-    BotConfig, Context, Data, DataInner, Error, EventLogAsync, PhoneCodeData,
+    BotConfig, Data, DataInner, Error, EventLogAsync, PhoneCodeData,
 };
 use ::serenity::secrets::Token;
 use colored::Colorize;
@@ -120,6 +120,16 @@ pub async fn poise_framework(
                             return Ok(Some(msg.content.split_at(7)));
                         }
                     }
+                    // The bot is Discord-verified WITHOUT the MESSAGE_CONTENT
+                    // intent, so `content` is empty on every guild message
+                    // except the ones that mention us -- Discord exempts those.
+                    // Returning early hands the message straight to poise's
+                    // `mention_as_prefix` fallback, and skips a settings lookup
+                    // (plus a WARN) per message across every guild the bot is
+                    // in, none of which could ever have matched a prefix.
+                    if msg.content.is_empty() {
+                        return Ok(None);
+                    }
                     let guild_id = match msg.guild_id {
                         Some(id) => id,
                         None => {
@@ -158,7 +168,7 @@ pub async fn poise_framework(
                             Ok(None)
                         }
                     } else {
-                        tracing::warn!("Guild not found in guild settings map");
+                        tracing::trace!("Guild not found in guild settings map");
                         Ok(None)
                     }
                 })
@@ -265,6 +275,12 @@ pub async fn poise_framework(
         ..Default::default()
     }));
 
+    // No MESSAGE_CONTENT. The bot is Discord-verified without it, and it is not
+    // coming back for an application in 100+ guilds without a review. Message
+    // content therefore arrives EMPTY unless the message mentions the bot, so
+    // prefix commands work only as `@CrackTunes <command>`. Everything a user
+    // is meant to reach has to be a slash command --
+    // `commands::test::every_registered_command_is_reachable` enforces that.
     let intents = GatewayIntents::non_privileged()
         | GatewayIntents::GUILD_MEMBERS
         | GatewayIntents::GUILD_VOICE_STATES
@@ -401,13 +417,4 @@ fn check_prefixes(prefixes: &[String], content: &str) -> Option<usize> {
         }
     }
     None
-}
-
-#[poise::command(prefix_command, owners_only)]
-async fn register_commands_new(ctx: Context<'_>) -> Result<(), Error> {
-    let commands = &ctx.framework().options().commands;
-    poise::builtins::register_globally(ctx.http(), commands).await?;
-
-    ctx.say("Successfully registered slash commands!").await?;
-    Ok(())
 }

--- a/crack-core/src/db/guild.rs
+++ b/crack-core/src/db/guild.rs
@@ -476,6 +476,10 @@ mod test {
     pub static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./test_migrations");
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_get_or_create(pool: PgPool) {
         let (guild, settings) = crate::db::guild::GuildEntity::get_or_create(
             &pool,
@@ -493,6 +497,10 @@ mod test {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_update_prefix(pool: PgPool) {
         let (mut guild, _) = crate::db::guild::GuildEntity::get_or_create(
             &pool,
@@ -517,6 +525,10 @@ mod test {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_get_write_settings(pool: PgPool) {
         let (guild, settings) = crate::db::guild::GuildEntity::get_or_create(
             &pool,
@@ -559,6 +571,10 @@ mod test {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_write_banned_comains(pool: PgPool) {
         let (guild, _) = crate::db::guild::GuildEntity::get_or_create(
             &pool,
@@ -585,6 +601,10 @@ mod test {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_write_allowed_domains(pool: PgPool) {
         let (guild, _) = crate::db::guild::GuildEntity::get_or_create(
             &pool,
@@ -611,6 +631,10 @@ mod test {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_write_log_settings(pool: PgPool) {
         let (guild, _) = crate::db::guild::GuildEntity::get_or_create(
             &pool,

--- a/crack-core/src/db/play_log.rs
+++ b/crack-core/src/db/play_log.rs
@@ -278,6 +278,10 @@ mod tests {
     pub static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./test_migrations");
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_playlog(pool: PgPool) -> Result<(), Error> {
         let user_id = 1;
         let guild_id = 1;
@@ -290,6 +294,10 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_playlog_get_last_played(pool: PgPool) -> Result<(), Error> {
         let user_id = 2;
         let guild_id = 1;
@@ -301,6 +309,10 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_playlog_get_last_played_by_user(pool: PgPool) -> Result<(), Error> {
         let user_id = 3;
         let guild_id = 1;

--- a/crack-core/src/db/user.rs
+++ b/crack-core/src/db/user.rs
@@ -191,6 +191,10 @@ mod test {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_insert_user(pool: PgPool) {
         let _ = User::insert_test_user(&pool, Some(1), Some(TEST.to_string())).await;
         let user = User::get_user(&pool, 1).await.unwrap();
@@ -198,6 +202,10 @@ mod test {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_insert_user_failed(pool: PgPool) {
         // Inserting the same user twice must not clobber the row; the
         // duplicate insert is expected to be rejected.
@@ -208,6 +216,10 @@ mod test {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_insert_or_update_user(pool: PgPool) {
         User::insert_or_update_user(&pool, 1, TEST.to_string())
             .await
@@ -217,6 +229,10 @@ mod test {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_insert_user_vote(pool: PgPool) {
         let insert_res = UserVote::insert_user_vote(&pool, 1, TEST.to_string()).await;
         assert!(insert_res.is_ok());
@@ -230,6 +246,10 @@ mod test {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_has_voted_recently(pool: PgPool) {
         UserVote::insert_user_vote(&pool, 1, TEST.to_string())
             .await
@@ -249,6 +269,10 @@ mod test {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_has_voted_recently_topgg(pool: PgPool) {
         UserVote::insert_user_vote(&pool, 1, "top.gg".to_string())
             .await

--- a/crack-core/src/db/worker_pool.rs
+++ b/crack-core/src/db/worker_pool.rs
@@ -127,6 +127,10 @@ mod test {
     pub static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./test_migrations");
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_workers(pool: PgPool) {
         let url = "https://www.youtube.com/watch?v=6n3pFFPSlW4".to_string();
         let sender = setup_workers(pool.clone()).await;
@@ -151,6 +155,10 @@ mod test {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_get_failed_metadata(pool: PgPool) {
         let url = "https://www.youtube.com/watch?v=6n3pFFPSlW4".to_string();
         let metadata = crate::db::metadata::Metadata::get_by_url(&pool, &url)

--- a/crack-core/src/guild/permissions.rs
+++ b/crack-core/src/guild/permissions.rs
@@ -703,6 +703,10 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_insert_permission_settings(pool: PgPool) {
         let mut settings = GenericPermissionSettings::default();
         // settings.add_allowed_command("test".to_string());
@@ -727,6 +731,10 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_insert_command_channel(pool: PgPool) {
         let mut settings = GenericPermissionSettings::default();
         // settings.add_allowed_command("test".to_string());

--- a/crack-core/src/handlers/event_log.rs
+++ b/crack-core/src/handlers/event_log.rs
@@ -12,9 +12,6 @@ use poise::serenity_prelude::{FullEvent, GenericChannelId, GuildId};
 use serde::{ser::SerializeStruct, Serialize};
 use serenity::User;
 
-pub(crate) const DEFAULT_GLOBAL_LOG_CHANNEL: Option<GenericChannelId> =
-    Some(GenericChannelId::new(1191633527763116039));
-
 /// serenity's `FullEvent` dropped `snake_case_name()`; the enum now derives
 /// `strum::IntoStaticStr`, which yields SCREAMING_SNAKE_CASE variant names.
 #[must_use]
@@ -51,8 +48,7 @@ pub async fn get_log_channel(
     let guild_settings_map = data.guild_settings_map.read().await;
     guild_settings_map
         .get(&guild_id)
-        .map(|x| x.get_log_channel(channel_name))
-        .unwrap()
+        .and_then(|x| x.get_log_channel(channel_name))
 }
 
 // .unwrap_or_else(|| {
@@ -88,7 +84,12 @@ pub async fn get_channel_id(
                 guild_id,
             )),
         },
-        None => DEFAULT_GLOBAL_LOG_CHANNEL.ok_or(CrackedError::LogChannelWarning(
+        // A guild we hold no settings for has not opted into event logging.
+        // This used to fall back to a single hardcoded channel ID living in one
+        // specific server, so every event in every other guild tried to post
+        // there and came back 403 Missing Access. Without a database the
+        // settings map is empty, so that was every guild.
+        None => Err(CrackedError::LogChannelWarning(
             full_event_name(event),
             guild_id,
         )),

--- a/crack-core/src/handlers/serenity.rs
+++ b/crack-core/src/handlers/serenity.rs
@@ -61,7 +61,15 @@ impl EventHandler for SerenityHandler {
         // poise removed `FrameworkOptions::event_handler`, so the event log /
         // router that used to hang off it is driven from here instead.
         if let Err(e) = crate::handlers::handle_event(ctx, event, ctx.data::<Data>()).await {
-            tracing::error!("Error handling event: {e}");
+            // A guild that has not configured a log channel is the ordinary
+            // case, not a failure -- logging it at ERROR put one line on every
+            // event in every such guild.
+            match e.downcast_ref::<CrackedError>() {
+                Some(CrackedError::LogChannelWarning(..)) => {
+                    tracing::trace!("Event not logged: {e}")
+                },
+                _ => tracing::error!("Error handling event: {e}"),
+            }
         }
     }
 }
@@ -75,6 +83,32 @@ impl SerenityHandler {
         );
 
         ctx.set_activity(Some(ActivityData::listening(DEFAULT_ACTIVITY)));
+
+        // Sync THIS build's command list to Discord.
+        //
+        // Nothing did this before. The setup closure that called
+        // `register_globally_cracked` was commented out when poise dropped the
+        // old `Framework` builder, and the only remaining path was an admin
+        // manually running `register`. So the application kept whatever the
+        // last bot to run under it had registered -- a stale list that never
+        // contained `/spotify`.
+        //
+        // `Ready` fires once per shard and again after a full reconnect, so
+        // this is gated to once per process.
+        static COMMANDS_REGISTERED: std::sync::atomic::AtomicBool =
+            std::sync::atomic::AtomicBool::new(false);
+        if !COMMANDS_REGISTERED.swap(true, Ordering::SeqCst) {
+            let commands = crate::commands::commands_to_register();
+            match crate::commands::register_globally_cracked(&ctx.http, &commands).await {
+                Ok(()) => tracing::info!("Registered {} global commands", commands.len()),
+                Err(e) => {
+                    tracing::error!("Failed to register global commands: {e}");
+                    // Clear the gate so a later `Ready` retries; otherwise one
+                    // transient failure leaves the process with no commands.
+                    COMMANDS_REGISTERED.store(false, Ordering::SeqCst);
+                },
+            }
+        }
 
         // Attempt to authenticate to Spotify, and SAY SO EITHER WAY.
         //

--- a/crack-gpt/Cargo.toml
+++ b/crack-gpt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-gpt"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-gpt/Cargo.toml
+++ b/crack-gpt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-gpt"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-osint/Cargo.toml
+++ b/crack-osint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-osint"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-osint/Cargo.toml
+++ b/crack-osint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-osint"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-sleevenote/Cargo.toml
+++ b/crack-sleevenote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-sleevenote"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-sleevenote/Cargo.toml
+++ b/crack-sleevenote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-sleevenote"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-testing/Cargo.toml
+++ b/crack-testing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "crack-testing"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/crack-testing/Cargo.toml
+++ b/crack-testing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "crack-testing"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/crack-types/Cargo.toml
+++ b/crack-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-types"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-types/Cargo.toml
+++ b/crack-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-types"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-voting/Cargo.toml
+++ b/crack-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-voting"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true
@@ -27,6 +27,14 @@ eula = false
 
 # [package.metadata.dist]
 # dist = false
+
+[features]
+# Tests that need a live postgres at DATABASE_URL. Off by default: the bot runs
+# without a database, so its test suite has to as well -- otherwise every
+# checkout without postgres reports 20+ red tests that say nothing about the
+# change under review. The gated tests are still COMPILED, so they cannot rot;
+# CI turns this on. See docs/testing.md.
+db-tests = []
 
 [dependencies]
 lazy_static = "1.5"

--- a/crack-voting/Cargo.toml
+++ b/crack-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-voting"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-voting/src/lib.rs
+++ b/crack-voting/src/lib.rs
@@ -319,6 +319,10 @@ mod test {
     // }
 
     #[sqlx::test]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
     async fn test_log_headers() {
         let app = warp::post().and(log_headers()).map(warp::reply);
         let secret = "asdf";

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,59 @@
+# Testing
+
+```bash
+cargo test --workspace          # everything that needs no database
+```
+
+That is the default, and it passes on a clean checkout with nothing running.
+
+## Tests that need postgres
+
+Roughly twenty tests exercise the database layer through `#[sqlx::test]`, which
+creates a scratch database per test and runs the migrations into it. They are
+marked `#[ignore]` unless the `db-tests` feature is on:
+
+```rust
+#[sqlx::test(migrator = "MIGRATOR")]
+#[cfg_attr(
+    not(feature = "db-tests"),
+    ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+)]
+async fn test_insert_user(pool: PgPool) { ... }
+```
+
+To run them, start a postgres and turn the feature on. The feature lives in
+each package that has such tests, so a workspace run names all three:
+
+```bash
+docker run -d --name crack-pg -p 5432:5432 \
+  -e POSTGRES_PASSWORD=mysecretpassword postgres:latest
+
+cargo test --workspace \
+  --features crack-core/db-tests,cracktunes/db-tests,crack-voting/db-tests
+```
+
+`DATABASE_URL` defaults to `postgresql://postgres:mysecretpassword@localhost:5432/postgres`,
+set by a `#[ctor]` in the test modules; export your own to point elsewhere.
+
+CI provisions postgres and passes those features, so the database tests do run
+on every push — the gate is about the default local experience, not coverage.
+
+## Why they are off by default
+
+The bot runs without a database. `crack-core/src/config.rs` skips the pool
+entirely when `DATABASE_URL` is unset, logs which features that disables, and
+carries on; the deployed instance is running that way right now. A test suite
+that hard-fails without postgres contradicts the thing it is testing, and in
+practice it meant twenty red tests on every checkout that said nothing about
+the change under review — noise that trains you to ignore a red suite.
+
+`#[cfg_attr(..., ignore)]` rather than `#[cfg(...)]` on purpose: the tests are
+still **compiled** either way, so they cannot rot against a changed query or
+schema without someone noticing at build time.
+
+## Tests that reach the network
+
+Some tests in `crack-testing` and `crack-osint` make live calls (YouTube,
+various OSINT endpoints). Those are marked `#[ignore]` on their own and are not
+covered by `db-tests`. They fail for reasons unrelated to whatever you changed;
+run them deliberately, by name.

--- a/scripts/cracktunes.sh
+++ b/scripts/cracktunes.sh
@@ -13,16 +13,28 @@
 #   ENV_FILE          env file compose reads       (default: .env)
 #   EXPECTED_CONTEXT  docker context to require    (default: pve-staging)
 #
-# Guards. Each of these refuses rather than warns, and each exists because the
-# failure it prevents is silent:
+# Guards. Each exists because the failure it prevents is silent. How they
+# behave depends on what you asked for:
+#
+#   * State-changing subcommands (up, deploy, restart, down, destroy, migrate)
+#     refuse at the FIRST failed guard. These replace a working container, so
+#     stopping early is the point.
+#   * Read-only subcommands (preflight, ps, logs, status) never refuse. They
+#     degrade: preflight runs every guard and reports all of them before
+#     exiting nonzero, so you fix the set rather than rediscovering one per
+#     run; ps/logs/status warn and carry on, because reading the wrong host or
+#     reading without a .env is recoverable by looking at the banner.
 #
 #   1. DOCKER CONTEXT. `docker compose` targets whatever context is current, and
-#      this machine has several pointing at remote hosts (proxmox, pve-staging,
-#      homelab-*). Deploying to the wrong one does not fail — it builds a
-#      complete parallel stack over there, with its own network and volumes,
-#      and looks like success. The stack lives on `pve-staging`, so that is the
-#      default; running against anything else — including the local socket —
-#      has to be asked for: EXPECTED_CONTEXT=default ./scripts/cracktunes.sh up
+#      a machine may have several pointing at remote hosts. Deploying to the
+#      wrong one does not fail — it builds a complete parallel stack over
+#      there, with its own network and volumes, and looks like success.
+#
+#      The default is `default`, the local docker socket: this compose file is
+#      the self-host stack (postgres, pgadmin, the bot), and a clone of this
+#      repo has no idea what remote contexts you keep. Deploying anywhere else
+#      has to be asked for, which is the guard doing its job:
+#          EXPECTED_CONTEXT=my-host DOCKER_CONTEXT=my-host ./scripts/cracktunes.sh up
 #
 #      Relatedly: the compose file no longer bind-mounts anything from this
 #      checkout. It used to mount ./.env and ./cracktunes.toml, which resolve
@@ -47,7 +59,8 @@
 #      anything is replaced.
 #
 # Subcommands:
-#   preflight        Run every guard and report, changing nothing. Safe anywhere.
+#   preflight        Run every guard and report ALL failures, changing nothing.
+#                    Exits nonzero if any failed. Safe anywhere.
 #   up               Bring the stack up (compose up -d).
 #   deploy [svc]     Pull fresh images and force-recreate. This is the one that
 #                    actually ships a new version. Services pin floating tags
@@ -75,7 +88,7 @@ cd "$SCRIPT_DIR"
 
 STACK="${STACK:-cracktunes}"
 ENV_FILE="${ENV_FILE:-.env}"
-EXPECTED_CONTEXT="${EXPECTED_CONTEXT:-pve-staging}"
+EXPECTED_CONTEXT="${EXPECTED_CONTEXT:-default}"
 CURRENT_CONTEXT="$(docker context show 2>/dev/null || echo unknown)"
 ORIGINAL_ARGS="$*"
 
@@ -92,6 +105,19 @@ ok()   { printf "%s✓%s %s\n" "$c_g" "$c_z" "$*"; }
 warn() { printf "%s!%s %s\n" "$c_y" "$c_z" "$*"; }
 die()  { printf "%s✗ %s%s\n" "$c_r" "$*" "$c_z" >&2; exit 1; }
 hdr()  { printf "\n%s== %s ==%s\n" "$c_b" "$*" "$c_z"; }
+
+# STRICT=1 (the default) is for anything that changes the stack: the first
+# failed guard exits. preflight clears it so a single run can report every
+# problem instead of handing them back one per invocation.
+STRICT=1
+PROBLEMS=0
+fail() {
+  if (( STRICT )); then
+    die "$@"
+  fi
+  printf "%s✗%s %s\n" "$c_r" "$c_z" "$*" >&2
+  PROBLEMS=$((PROBLEMS + 1))
+}
 
 read_env() {
   # Read one key out of $ENV_FILE without echoing the value. Tolerates the
@@ -146,7 +172,7 @@ check_db_password() {
   [[ -z "$env_pw" ]] && { ok "POSTGRES_PASSWORD unset in $ENV_FILE; compose default applies"; return 0; }
 
   if [[ "$env_pw" != "$baked" ]]; then
-    die "POSTGRES_PASSWORD in $ENV_FILE does not match the password hardcoded in
+    fail "POSTGRES_PASSWORD in $ENV_FILE does not match the password hardcoded in
        docker-compose.yml's DATABASE_URL for the app services.
 
        crack-postgres would come up with YOUR password and every app service
@@ -155,6 +181,7 @@ check_db_password() {
 
        Fix either side so they agree. The durable fix is to make compose build
        DATABASE_URL from \${POSTGRES_PASSWORD} instead of hardcoding it."
+    return 0
   fi
   ok "database password agrees between $ENV_FILE and docker-compose.yml"
 }
@@ -166,12 +193,13 @@ check_volumes() {
     docker volume inspect "$v" >/dev/null 2>&1 || missing+=("$v")
   done
   if (( ${#missing[@]} )); then
-    die "external volume(s) missing on context '$CURRENT_CONTEXT': ${missing[*]}
+    fail "external volume(s) missing on context '$CURRENT_CONTEXT': ${missing[*]}
 
        docker-compose.yml declares these 'external: true', so compose will not
        create them — a cold start on a fresh host fails here.
 
        Fix: docker volume create ${missing[*]}"
+    return 0
   fi
   ok "external volumes present (pgdata, crack_data)"
 }
@@ -181,30 +209,51 @@ check_discord_token() {
   local tok
   tok="$(read_env DISCORD_TOKEN)"
   if [[ -z "$tok" || "$tok" == "XXXXXX" ]]; then
-    die "DISCORD_TOKEN is missing or still the placeholder in $ENV_FILE.
+    fail "DISCORD_TOKEN is missing or still the placeholder in $ENV_FILE.
 
        The bot fail-closes at boot, not at deploy: this would not fail the
        deploy, it would replace a working container with one that panics on
        'Failed to load bot config' and restarts until it is given up on."
+    return 0
   fi
   ok "DISCORD_TOKEN present"
 }
 
 preflight() {
+  # Report everything, refuse nothing. Dying on the first failed guard turns
+  # "your deploy is not ready" into one problem per invocation; this is the
+  # subcommand whose entire job is to hand back the whole list at once.
+  STRICT=0
   hdr "preflight — stack=$STACK env=$ENV_FILE context=$CURRENT_CONTEXT"
-  require_env_file
-  ok "$ENV_FILE present"
+
+  if [[ -f "$ENV_FILE" ]]; then
+    ok "$ENV_FILE present"
+    check_discord_token
+    check_db_password
+  else
+    fail "$ENV_FILE not found in $SCRIPT_DIR
+       Copy .env.example to .env and fill it in, or set ENV_FILE=<path>."
+    warn "skipping the DISCORD_TOKEN and database-password checks — both read $ENV_FILE"
+  fi
+
+  # Volume presence is context-specific, so it only means anything once the
+  # context is the one a deploy would actually use.
   if [[ "$CURRENT_CONTEXT" == "$EXPECTED_CONTEXT" ]]; then
     ok "docker context is '$CURRENT_CONTEXT' as expected"
-  else
-    warn "docker context is '$CURRENT_CONTEXT', expected '$EXPECTED_CONTEXT' — state-changing commands will refuse"
-  fi
-  check_discord_token
-  check_db_password
-  # Volume presence is context-specific; only meaningful once the context is right.
-  if [[ "$CURRENT_CONTEXT" == "$EXPECTED_CONTEXT" ]]; then
     check_volumes
+  else
+    fail "docker context is '$CURRENT_CONTEXT', expected '$EXPECTED_CONTEXT'
+       State-changing subcommands will refuse until these agree.
+       Fix:       DOCKER_CONTEXT=$EXPECTED_CONTEXT $0 $ORIGINAL_ARGS
+       Intended?  EXPECTED_CONTEXT=$CURRENT_CONTEXT $0 $ORIGINAL_ARGS"
+    warn "skipping the external-volume check — it is specific to the target context"
   fi
+
+  echo
+  if (( PROBLEMS )); then
+    die "$PROBLEMS problem(s) above. Nothing was changed."
+  fi
+  ok "all guards passed"
   echo
 }
 
@@ -218,6 +267,24 @@ dc() {
   # the export those two could disagree, and the containers would silently take
   # a different .env than the one this run was told to use.
   ENV_FILE="$ENV_FILE" docker compose -p "$STACK" --env-file "$ENV_FILE" "$@"
+}
+
+# Read-only compose invocation. Deliberately does NOT require the context or
+# the env file: `ps` against the wrong host shows nothing and `logs` without a
+# .env still tails fine, and refusing to SHOW you the state of things is a poor
+# trade for a mistake you cannot make by looking. Both facts are warned about
+# and both appear in the banner.
+dc_ro() {
+  local envargs=()
+  if [[ -f "$ENV_FILE" ]]; then
+    envargs=(--env-file "$ENV_FILE")
+  else
+    warn "$ENV_FILE not found — reading without it; docker-compose.yml's \${VAR:-default} values apply" >&2
+  fi
+  if [[ "$CURRENT_CONTEXT" != "$EXPECTED_CONTEXT" ]]; then
+    warn "docker context is '$CURRENT_CONTEXT', not '$EXPECTED_CONTEXT' — this reads THAT host" >&2
+  fi
+  ENV_FILE="$ENV_FILE" docker compose -p "$STACK" ${envargs[@]+"${envargs[@]}"} "$@"
 }
 
 banner() { printf "[cracktunes] stack=%s env=%s context=%s — %s\n" "$STACK" "$ENV_FILE" "$CURRENT_CONTEXT" "$*"; }
@@ -249,8 +316,8 @@ cmd_restart() {
 
 cmd_stop() { banner "stop"; dc stop; }
 cmd_down() { banner "down (volumes preserved)"; dc down; }
-cmd_ps()   { dc ps; }
-cmd_logs() { dc logs -f --tail=50 "$@"; }
+cmd_ps()   { dc_ro ps; }
+cmd_logs() { dc_ro logs -f --tail=50 "$@"; }
 
 cmd_destroy() {
   echo "[cracktunes] 'compose down -v' DROPS the postgres volume: guild settings,"
@@ -296,14 +363,14 @@ cmd_migrate() {
 
 cmd_status() {
   hdr "stack — $STACK on context $CURRENT_CONTEXT"
-  dc ps || true
+  dc_ro ps || true
   hdr "images"
-  dc config --images 2>/dev/null || true
+  dc_ro config --images 2>/dev/null || true
   hdr "bot version"
   # The container has no shell-free version flag; read the label off the image
   # it is actually running, which is what matters after a deploy.
   local cid
-  cid="$(dc ps -q cracktunes 2>/dev/null | head -1)"
+  cid="$(dc_ro ps -q cracktunes 2>/dev/null | head -1)"
   if [[ -n "$cid" ]]; then
     docker inspect --format '{{.Config.Image}}  (started {{.State.StartedAt}})' "$cid" 2>/dev/null || true
   else


### PR DESCRIPTION
Four fixes, all in the same direction: the bot as deployed could not be reached by its own commands, and the repo's front door pointed at an empty host. Version **0.5.0**, not 0.4.2 — 0.4.1 shipped with commands that were never registered.

## 1. Commands were never registered

Discord held 18 global commands for this application:

```
ping leave pause play queue resume skip stop status join
playlist lavalink tts record stt radio
"Play attachments" "Transcribe attachment"
```

`lavalink`, `tts`, `stt` and `record` are **bot-template-rs** commands — the *previous* bot's registration, still standing. cracktunes had never pushed its own list, so `spotify` and most of `music_commands()` were never registered.

**Root cause.** The setup closure calling `register_globally_cracked` was commented out (`crack-core/src/config.rs`) when poise dropped the old `Framework` builder, and nothing replaced it. What remained: `register`, needing a human to invoke it, and `register_commands_new`, which was in no command list at all.

**Fix.** `on_ready` syncs the command list, gated to once per process (`Ready` fires per shard and on reconnect). A failed registration clears the gate so a later `Ready` retries instead of leaving the process command-less for its lifetime. `commands_to_register` now delegates to `all_commands` — they were byte-identical and must stay the same set.

## 2. The `Missing Access` flood

`crack-core/src/handlers/event_log.rs` hardcoded a fallback log channel:

```rust
pub(crate) const DEFAULT_GLOBAL_LOG_CHANNEL: Option<GenericChannelId> =
    Some(GenericChannelId::new(1191633527763116039));
```

`get_channel_id` returned it for **any guild absent from the guild settings map**. Without a database that map is empty, so every message, typing, presence and voice event in all **135 guilds** tried to post an embed to one channel in one specific server. Probed with the deployed bot's own token:

```
GET /channels/1191633527763116039 → HTTP 403 {"message": "Missing Access", "code": 50001}
```

113 occurrences per 400 log lines. A guild with no configured log channel now yields `LogChannelWarning`, logged at `TRACE` — the ordinary case, not a failure. Without that demotion the flood would have survived the fix with a different message.

Also drops a latent panic in `get_log_channel`, which `unwrap()`ped an `Option` that is `None` for exactly the guilds that path serves.

## 3. No MESSAGE_CONTENT, permanently

The bot is Discord-verified without the intent and is in 100+ guilds, so it is not coming back without a review. Content arrives empty except on messages that mention the bot. The code half-knew this — there is a comment saying so — but nothing acted on it.

- The dynamic prefix callback ran a settings lookup **and logged a WARN** per message per guild, comparing prefixes against content that is always empty. It now returns immediately on empty content, straight to poise's `mention_as_prefix` fallback. The residual warn is demoted to `trace`.
- `commands::test::every_registered_command_is_reachable` asserts everything in `commands_to_register()` builds as a slash or context-menu command. A prefix-only command is now a failing test rather than one nobody can call and nobody notices. (Verified non-vacuous: adding a prefix-only command makes it fail.)
- `register_commands_new` deleted — prefix-only, unlisted, and redundant now.

## 4. Deploy script and test suite

**`scripts/cracktunes.sh`** defaulted `EXPECTED_CONTEXT` to `pve-staging`, which now runs nothing — the front door refused every command while pointing at an empty host. Defaults to `default` (local socket); this compose file is the self-host stack, and a clone has no idea what remote contexts you keep.

Guards now split by intent: state-changing subcommands still refuse at the first failure, `preflight` runs every guard and reports all of them before exiting nonzero (its docstring already promised this), and `ps`/`logs`/`status` warn and carry on rather than refusing to show you the state of things. Adds the `.env.example` the header has been telling people to copy since it was written.

**Database tests** now carry `#[cfg_attr(not(feature = "db-tests"), ignore = ...)]`. The bot runs without a database; a suite that hard-fails without postgres contradicts what it tests, and 20 red `PoolTimedOut` tests per checkout say nothing about the change under review. `cfg_attr(..., ignore)` rather than `cfg(...)` so the tests are still **compiled** and cannot rot. CI provisions postgres and passes the features, so coverage there is unchanged. `docs/testing.md` records it.

```
before:  101 passed; 20 failed;  1 ignored
after:   101 passed;  0 failed; 21 ignored
```

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all --all-targets -- -D clippy::all -D warnings` — clean
- `cargo test --workspace` with no database — green except two pre-existing `crack-testing` failures (`test_resolve_track`, `test_enqueue_query`) that make live YouTube calls. Same two fail on master; untouched here.
- `cargo test -p crack-core --features db-tests -- --ignored --list` — confirms the feature un-ignores all 20.
- `scripts/cracktunes.sh` exercised in all three states: degraded preflight reports both problems in one run and exits 1; `ps` warns twice and still runs; `up` still refuses at the first guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)