### PR TITLE
chore: bump the workspace to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - [ ] Support discordbotlist.com (voting service).
 - [ ] Decide on whether to use ephemeral for admin messages.
 
-## Unreleased
+## v0.6.0 (2026/09/05)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,14 +1094,14 @@ dependencies = [
 
 [[package]]
 name = "crack-bf"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "crack-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "crack-gpt"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-openai",
  "const_format",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "crack-osint"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "crack-types",
  "ipinfo",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "crack-sleevenote"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "crack-testing"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "crack-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "humantime",
  "poise",
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "crack-voting"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "dbl-rs",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "cracktunes"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "config-file",
  "crack-core",

--- a/crack-bf/Cargo.toml
+++ b/crack-bf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-bf"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-cli/Cargo.toml
+++ b/crack-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "cracktunes"
-version = "0.5.0"
+version = "0.6.0"
 description = "Cracktunes is a hassle-free, highly performant, host-it-yourself, cracking smoking, discord-music-bot."
 publish = true
 edition = "2021"

--- a/crack-core/Cargo.toml
+++ b/crack-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-core"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 edition = "2021"
 description = "Core module for the cracking smoking, discord-music-bot Cracktunes."

--- a/crack-gpt/Cargo.toml
+++ b/crack-gpt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-gpt"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-osint/Cargo.toml
+++ b/crack-osint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-osint"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-sleevenote/Cargo.toml
+++ b/crack-sleevenote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-sleevenote"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-testing/Cargo.toml
+++ b/crack-testing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "crack-testing"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/crack-types/Cargo.toml
+++ b/crack-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-types"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-voting/Cargo.toml
+++ b/crack-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-voting"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true


### PR DESCRIPTION
`/gp` (#422) landed as a minor feature with the version deliberately untouched — the PR came from a fork, where bumping only produces a conflict, so the contributor was explicitly told to leave it. That makes the cadence's bump step a maintainer commit with no PR carrying it. This is that commit.

All nine members move together (`crack-cli`, `crack-core`, `crack-osint`, `crack-gpt`, `crack-sleevenote`, `crack-bf`, `crack-voting`, `crack-testing`, `crack-types`), plus `Cargo.lock`, and `CHANGELOG.md`'s `Unreleased` section becomes `v0.6.0 (2026/09/05)`.

Nine hand-edited copies with no `version.workspace = true` and no inter-crate version pins is exactly the shape that lets a partial bump compile clean — #424 tracks fixing it.

`cargo check --workspace --all-targets` is clean at 0.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8PrF3gizKqXCStjCuWL3d