### PR TITLE
fix: nothing played — repin rusty_ytdl, play through yt-dlp, ship a runnable one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@
 - [ ] Support discordbotlist.com (voting service).
 - [ ] Decide on whether to use ephemeral for admin messages.
 
+## v0.6.1 (2026/09/05)
+
+### Fixed
+
+- **Nothing played.** Every track failed with songbird reporting `Preparing -> Errored`
+  and `play_time: 0ns`, which `/gp` faithfully reported as "never played" and which the
+  music commands reported as nothing at all. Three separate faults, all in the path
+  between a resolved track and audio:
+  - `rusty_ytdl` was pinned to a fork last pushed 2025-02-01, which asks YouTube's
+    `youtubei/v1/player` with the WEB client context. That now returns HTTP 400. Repinned
+    to upstream `bfd7fed` ("use android_sdkless player by default"), which gets past it.
+  - Past the 400, the googlevideo URL `rusty_ytdl` hands back is fetched as `c=ANDROID`
+    and returns HTTP 403. songbird then has an empty stream and symphonia reports
+    `probe reach EOF at 0 bytes` followed by `no suitable format reader found` -- which
+    reads like a codec fault and is a fetch fault. Playback now goes through songbird's
+    `YoutubeDl` (yt-dlp), whose URL serves 206.
+  - yt-dlp could never have run anyway: the image installed `yt-dlp_linux`, the glibc
+    build, onto an Alpine (musl) base, so the binary was present and unexecutable. It is
+    `yt-dlp_musllinux` now, and the build asserts `yt-dlp --version` so choosing the wrong
+    build fails the build rather than the bot.
+- `deno` is in the image. YouTube extraction without a JavaScript runtime is deprecated
+  upstream and silently drops formats. Alpine's build is musl-native, unlike deno's own
+  releases.
+
+### Changed
+
+- Every playback path now builds its songbird `Track` through `build_track`.
+  `queue_resolved_track_back` and `resolve_query_to_tracks` each constructed their own
+  source inline, so changing the source in `build_track` fixed `/gp` and left `/play`
+  silent. One construction site now, and the duplicated `TrackData` assembly is gone.
+
 ## v0.6.0 (2026/09/05)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,14 +1094,14 @@ dependencies = [
 
 [[package]]
 name = "crack-bf"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "crack-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "crack-gpt"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-openai",
  "const_format",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "crack-osint"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "crack-types",
  "ipinfo",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "crack-sleevenote"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "crack-testing"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "crack-types"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "humantime",
  "poise",
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "crack-voting"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "dbl-rs",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "cracktunes"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "config-file",
  "crack-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "once_cell",
- "phf",
+ "phf 0.11.3",
  "rustc-hash",
  "static_assertions",
 ]
@@ -1372,14 +1372,14 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.34.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
+checksum = "5b3df4f93e5fbbe73ec01ec8d3f68bba73107993a5b1e7519273c32db9b0d5be"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.11.3",
  "smallvec",
 ]
 
@@ -1841,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "ego-tree"
-version = "0.10.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
+checksum = "12a0bb14ac04a9fcf170d0bbbef949b44cc492f4452bd20c095636956f653642"
 
 [[package]]
 name = "either"
@@ -2672,22 +2672,10 @@ checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
 dependencies = [
  "log",
  "mac",
- "markup5ever 0.12.1",
+ "markup5ever",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "html5ever"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
-dependencies = [
- "log",
- "mac",
- "markup5ever 0.14.1",
- "match_token",
 ]
 
 [[package]]
@@ -2896,13 +2884,12 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.3.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "utf8_iter",
  "yoke 0.8.3",
  "zerofrom",
  "zerovec 0.11.8",
@@ -2916,6 +2903,7 @@ checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap 0.8.3",
+ "serde",
  "tinystr 0.8.4",
  "writeable 0.6.4",
  "zerovec 0.11.8",
@@ -2974,13 +2962,14 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+checksum = "8b24a59706036ba941c9476a55cd57b82b77f38a3c667d637ee7cabbc85eaedc"
 dependencies = [
- "icu_collections 2.3.0",
- "icu_normalizer_data 2.3.0",
- "icu_properties 2.3.0",
+ "displaydoc",
+ "icu_collections 2.0.0",
+ "icu_normalizer_data 2.0.0",
+ "icu_properties 2.0.2",
  "icu_provider 2.3.1",
  "smallvec",
  "zerovec 0.11.8",
@@ -2994,9 +2983,9 @@ checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.3.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
@@ -3015,15 +3004,16 @@ dependencies = [
 
 [[package]]
 name = "icu_properties"
-version = "2.3.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+checksum = "f5a97b8ac6235e69506e8dacfb2adf38461d2ce6d3e9bd9c94c4cbc3cd4400a4"
 dependencies = [
  "displaydoc",
- "icu_collections 2.3.0",
+ "icu_collections 2.0.0",
  "icu_locale_core",
- "icu_properties_data 2.3.0",
+ "icu_properties_data 2.0.1",
  "icu_provider 2.3.1",
+ "potential_utf",
  "zerotrie",
  "zerovec 0.11.8",
 ]
@@ -3036,9 +3026,9 @@ checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_properties_data"
-version = "2.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -3065,6 +3055,8 @@ checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable 0.6.4",
  "yoke 0.8.3",
  "zerofrom",
@@ -3102,12 +3094,12 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
- "icu_normalizer 2.3.0",
- "icu_properties 2.3.0",
+ "icu_normalizer 2.0.1",
+ "icu_properties 2.0.2",
 ]
 
 [[package]]
@@ -3663,7 +3655,7 @@ version = "0.1.8"
 source = "git+https://github.com/cycle-five/spotify-player?branch=master#7cf3e1892dbb4171cbc7f1524bdd12175393317f"
 dependencies = [
  "anyhow",
- "html5ever 0.27.0",
+ "html5ever",
  "log",
  "markup5ever_rcdom",
  "reqwest 0.12.28",
@@ -3693,22 +3685,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
 dependencies = [
  "log",
- "phf",
- "phf_codegen",
- "string_cache",
- "string_cache_codegen",
- "tendril",
-]
-
-[[package]]
-name = "markup5ever"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
-dependencies = [
- "log",
- "phf",
- "phf_codegen",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
  "string_cache",
  "string_cache_codegen",
  "tendril",
@@ -3720,21 +3698,10 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edaa21ab3701bfee5099ade5f7e1f84553fd19228cf332f13cd6e964bf59be18"
 dependencies = [
- "html5ever 0.27.0",
- "markup5ever 0.12.1",
+ "html5ever",
+ "markup5ever",
  "tendril",
  "xml5ever",
-]
-
-[[package]]
-name = "match_token"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -4282,12 +4249,31 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
 ]
 
 [[package]]
@@ -4296,8 +4282,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -4306,7 +4302,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.7",
 ]
 
@@ -4316,11 +4312,20 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -4329,7 +4334,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher",
+ "siphasher 1.0.3",
 ]
 
 [[package]]
@@ -5100,9 +5105,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.4.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5115,9 +5120,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-retry"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
+checksum = "a83df1aaec00176d0fabb65dea13f832d2a446ca99107afc17c5d2d4981221d0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5129,7 +5134,6 @@ dependencies = [
  "reqwest 0.12.28",
  "reqwest-middleware",
  "retry-policies",
- "thiserror 1.0.69",
  "tokio",
  "tracing",
  "wasm-timer",
@@ -5470,7 +5474,7 @@ dependencies = [
 [[package]]
 name = "rusty_ytdl"
 version = "0.7.4"
-source = "git+https://github.com/cycle-five/rusty_ytdl?branch=main#af8e0bdc84be46d953ff46d81996b9b7499d0bac"
+source = "git+https://github.com/Mithronn/rusty_ytdl?rev=bfd7fedb8#bfd7fedb8e871fb26b528cada0a4c837e645182a"
 dependencies = [
  "aes",
  "async-trait",
@@ -5492,7 +5496,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "thiserror 2.0.20",
+ "thiserror 1.0.69",
  "tokio",
  "url",
  "urlencoding",
@@ -5563,15 +5567,16 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraper"
-version = "0.22.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3d051b884f40e309de6c149734eab57aa8cc1347992710dc80bcc1c2194c15"
+checksum = "b90460b31bfe1fc07be8262e42c665ad97118d4585869de9345a84d501a9eaf0"
 dependencies = [
+ "ahash 0.8.12",
  "cssparser",
  "ego-tree",
  "getopts",
- "html5ever 0.29.1",
- "precomputed-hash",
+ "html5ever",
+ "once_cell",
  "selectors",
  "tendril",
 ]
@@ -5651,9 +5656,9 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.26.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
+checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
 dependencies = [
  "bitflags 2.13.1",
  "cssparser",
@@ -5661,8 +5666,8 @@ dependencies = [
  "fxhash",
  "log",
  "new_debug_unreachable",
- "phf",
- "phf_codegen",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
  "precomputed-hash",
  "servo_arc",
  "smallvec",
@@ -5854,9 +5859,9 @@ dependencies = [
 
 [[package]]
 name = "servo_arc"
-version = "0.4.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+checksum = "d036d71a959e00c77a63538b90a6c2390969f9772b096ea837205c6bd0491a44"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -5968,6 +5973,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
@@ -6365,7 +6376,7 @@ checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot 0.12.5",
- "phf_shared",
+ "phf_shared 0.11.3",
  "precomputed-hash",
  "serde",
 ]
@@ -6376,8 +6387,8 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
 ]
@@ -6883,6 +6894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec 0.11.8",
 ]
 
@@ -8279,7 +8291,7 @@ checksum = "9bbb26405d8e919bc1547a5aa9abc95cbfa438f04844f5fdd9dc7596b748bf69"
 dependencies = [
  "log",
  "mac",
- "markup5ever 0.12.1",
+ "markup5ever",
 ]
 
 [[package]]
@@ -8399,6 +8411,7 @@ dependencies = [
  "displaydoc",
  "yoke 0.8.3",
  "zerofrom",
+ "zerovec 0.11.8",
 ]
 
 [[package]]
@@ -8418,6 +8431,7 @@ version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
+ "serde",
  "yoke 0.8.3",
  "zerofrom",
  "zerovec-derive 0.11.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,6 @@ inherits = "release-with-performance"
 lto = "thin"
 
 [patch.crates-io]
-rusty_ytdl = { git = "https://github.com/cycle-five/rusty_ytdl", branch = "main" }
+rusty_ytdl = { git = "https://github.com/Mithronn/rusty_ytdl", rev = "bfd7fedb8" }
 poise = { git = "https://github.com/serenity-rs/poise", branch = "serenity-next" }
 serenity = { git = "https://github.com/serenity-rs/serenity", branch = "next" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,13 +30,29 @@ FROM alpine:3.22 AS runner
 WORKDIR /app
 
 # RUN apk add --no-cache ffmpeg curl
+# `deno` is a JavaScript runtime for yt-dlp, not for us: YouTube extraction
+# without one is deprecated upstream and silently drops formats ("No supported
+# JavaScript runtime could be found"). Alpine ships a musl-native build, so it
+# needs no special handling -- unlike deno's own releases, which are glibc.
+# It is ~89 MB, which is most of this image.
 RUN apk add --no-cache \
   ffmpeg \
-  curl
+  curl \
+  deno
 
 ADD ./data /data
-RUN curl -sSL --output /usr/local/bin/yt-dlp https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux \
-  && chmod +x /usr/local/bin/yt-dlp
+# 🪤 `yt-dlp_musllinux`, NOT `yt-dlp_linux`. This base is Alpine, so it is musl,
+# and the glibc build cannot execute at all: it fails with "No such file or
+# directory" -- pointing at the missing ELF interpreter, not at a missing file,
+# which is a genuinely confusing way to be told you picked the wrong build. It
+# shipped that way and yt-dlp was dead in every image until 2026-09-05.
+#
+# The `--version` is a build-time assertion, not a nicety: it is what turns
+# picking the wrong build back into a failed build rather than a bot that
+# cannot play anything.
+RUN curl -sSL --fail --output /usr/local/bin/yt-dlp https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_musllinux \
+  && chmod +x /usr/local/bin/yt-dlp \
+  && /usr/local/bin/yt-dlp --version
 # Copy the binary from the builder stage
 COPY --from=builder /app/target/dist/cracktunes /app/app
 # Copy the start script from the builder stage

--- a/crack-bf/Cargo.toml
+++ b/crack-bf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-bf"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-cli/Cargo.toml
+++ b/crack-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "cracktunes"
-version = "0.6.0"
+version = "0.6.1"
 description = "Cracktunes is a hassle-free, highly performant, host-it-yourself, cracking smoking, discord-music-bot."
 publish = true
 edition = "2021"

--- a/crack-core/Cargo.toml
+++ b/crack-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-core"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 edition = "2021"
 description = "Core module for the cracking smoking, discord-music-bot Cracktunes."

--- a/crack-core/src/commands/music/doplay.rs
+++ b/crack-core/src/commands/music/doplay.rs
@@ -2,7 +2,7 @@ use crate::commands::{cmd_check_music, help};
 use crate::music::query::query_type_from_url;
 use crate::music::queue::{get_mode, get_msg, queue_track_back};
 use crate::music::NewQueryType;
-use crate::utils::{edit_embed_response2, TrackData};
+use crate::utils::edit_embed_response2;
 use crate::{commands::get_call_or_join_author, http_utils::SendMessageParams};
 use crate::{
     errors::{verify, CrackedError},
@@ -34,7 +34,7 @@ use songbird::tracks::Track;
 use songbird::{tracks::TrackHandle, Call};
 use std::borrow::Cow;
 use std::{cmp::Ordering, sync::Arc, time::Duration};
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::Mutex;
 
 /// Get the guild name.
 #[cfg(not(tarpaulin_include))]
@@ -525,19 +525,8 @@ pub async fn resolve_query_to_tracks(
     //let tracks = client.resolve_track(query_type).await?;
     let mut track_handles = Vec::new();
     for track in tracks.iter() {
-        let ytdl = RustyYoutubeSearch::new_with_stuff(
-            client.req_client.clone(),
-            query_type.clone(),
-            track.metadata.clone(),
-            track.video.clone(),
-        )?;
-        let resolved_clone = &track.clone();
-        let track_data = Arc::new(TrackData {
-            user_id: Arc::new(RwLock::new(Some(resolved_clone.clone().user_id))),
-            aux_metadata: Arc::new(RwLock::new(resolved_clone.metadata.clone())),
-        });
-        let track2 = Track::new_with_data(ytdl.clone().into(), track_data);
-        track_handles.push(track2);
+        // Through `build_track`, not a third copy of it -- see the note there.
+        track_handles.push(crate::music::queue::build_track(track, &client.req_client)?);
     }
     Ok(track_handles)
 }
@@ -754,7 +743,7 @@ async fn build_queued_embed<'att>(
         .footer(CreateEmbedFooter::new(Cow::Owned(footer_text)))
 }
 
-use crate::sources::rusty_ytdl::{RequestOptionsBuilder, RustyYoutubeSearch};
+use crate::sources::rusty_ytdl::RequestOptionsBuilder;
 use rusty_ytdl::search::YouTube;
 /// Add tracks to the queue from aux_metadata.
 #[cfg(not(tarpaulin_include))]

--- a/crack-core/src/music/queue.rs
+++ b/crack-core/src/music/queue.rs
@@ -14,7 +14,7 @@ use serenity::{
     small_fixed_array::FixedString,
 };
 use songbird::{
-    input::Input as SongbirdInput,
+    input::{Input as SongbirdInput, YoutubeDl},
     tracks::{Queued, Track, TrackHandle},
     Call,
 };
@@ -96,13 +96,16 @@ pub(crate) fn build_track(
     resolved: &ResolvedTrack<'static>,
     http_client: &reqwest::Client,
 ) -> Result<Track, CrackedError> {
-    let query = QueryType::VideoLink(resolved.get_url());
-    let ytdl = RustyYoutubeSearch::new_with_stuff(
-        http_client.clone(),
-        query,
-        resolved.metadata.clone(),
-        resolved.video.clone(),
-    )?;
+    // yt-dlp, not rusty_ytdl. rusty_ytdl resolves fine but the googlevideo URL
+    // it hands back is rejected: `c=ANDROID` fetches 403, songbird gets an empty
+    // stream, and symphonia reports it as "no suitable format reader found",
+    // which reads like a codec problem and is not one. yt-dlp negotiates a
+    // client whose URL actually serves (`c=VISIONOS` at the time of writing) and
+    // keeps up with YouTube's changes, which is the whole reason it exists.
+    //
+    // Needs `yt-dlp` on PATH -- see the Dockerfile, and note it must be the musl
+    // build on this Alpine base.
+    let ytdl = YoutubeDl::new(http_client.clone(), resolved.get_url());
     let track_data = Arc::new(TrackData {
         user_id: Arc::new(RwLock::new(Some(resolved.user_id))),
         aux_metadata: Arc::new(RwLock::new(resolved.metadata.clone())),
@@ -462,7 +465,6 @@ pub async fn queue_vec_query_type(
 }
 
 use crate::http_utils;
-use crack_types::YoutubeDl;
 /// Queue a list of queries to be played with a given offset.
 /// N.B. The offset must be 0 < offset < queue.len() + 1
 #[cfg(not(tarpaulin_include))]

--- a/crack-core/src/music/queue.rs
+++ b/crack-core/src/music/queue.rs
@@ -3,7 +3,6 @@ use crate::{
     handlers::track_end::update_queue_messages,
     http_utils::CacheHttpExt,
     music::NewQueryType,
-    sources::rusty_ytdl::RustyYoutubeSearch,
     utils::{set_track_handle_metadata, set_track_handle_requesting_user, TrackData},
     Context as CrackContext, Error,
 };
@@ -33,22 +32,11 @@ pub async fn queue_resolved_track_back(
     track_resolved: ResolvedTrack<'static>,
     http_client: reqwest::Client,
 ) -> Result<Vec<TrackHandle>, CrackedError> {
+    // Through `build_track`, not a second copy of it. This function used to
+    // construct its own `RustyYoutubeSearch` inline, which is why fixing the
+    // source in `build_track` fixed `/gp` and left `/play` still silent.
+    let track = build_track(&track_resolved, &http_client)?;
     let mut handler = call.lock().await;
-    //let ytdl = YoutubeDl::new(http_client.clone(), track.get_url());
-    let query = QueryType::VideoLink(track_resolved.get_url());
-    let track2 = track_resolved.clone();
-    let ytdl = RustyYoutubeSearch::new_with_stuff(
-        http_client.clone(),
-        query,
-        track2.metadata,
-        track2.video,
-    )?;
-    let resolved_clone = &track_resolved.clone();
-    let track_data = Arc::new(TrackData {
-        user_id: Arc::new(RwLock::new(Some(resolved_clone.clone().user_id))),
-        aux_metadata: Arc::new(RwLock::new(resolved_clone.metadata.clone())),
-    });
-    let track = Track::new_with_data(ytdl.clone().into(), track_data);
     let _track_handle = handler.enqueue(track).await;
     // .enqueue_input(Into::<SongbirdInput>::into(track))
     let new_q = handler.queue().current_queue();
@@ -87,9 +75,13 @@ pub async fn queue_resolved_track_back_old(
 
 /// Build the songbird [`Track`] for an already-resolved track.
 ///
-/// This performs no I/O: [`RustyYoutubeSearch`] is a lazy [`Compose`], so the
-/// actual stream (and any metadata we don't already hold) is fetched when the
-/// track reaches the front of the queue rather than when it is enqueued.
+/// This performs no I/O: [`YoutubeDl`] is a lazy [`Compose`], so yt-dlp is not
+/// run and the stream is not opened until the track reaches the front of the
+/// queue.
+///
+/// Every playback path goes through here. Two of them used to build their own
+/// source inline instead, which is how `/play` stayed broken after `/gp` was
+/// fixed -- keep it that way.
 ///
 /// [`Compose`]: songbird::input::Compose
 pub(crate) fn build_track(

--- a/crack-gpt/Cargo.toml
+++ b/crack-gpt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-gpt"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-osint/Cargo.toml
+++ b/crack-osint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-osint"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-sleevenote/Cargo.toml
+++ b/crack-sleevenote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-sleevenote"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-testing/Cargo.toml
+++ b/crack-testing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "crack-testing"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/crack-types/Cargo.toml
+++ b/crack-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-types"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-voting/Cargo.toml
+++ b/crack-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-voting"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true


### PR DESCRIPTION
v0.6.0 shipped `/gp` on a playback path that could not play anything. Every track failed with songbird reporting `Preparing -> Errored` and `play_time: 0ns`. `/gp` reported that faithfully as "never played"; the music commands reported nothing at all.

Three faults, all between a resolved track and audio, each hiding the next.

**1. `youtubei/v1/player` returns 400.** `rusty_ytdl` was pinned to `cycle-five/rusty_ytdl@af8e0bd`, last pushed 2025-02-01, which asks for the player with the WEB client context. Repinned to upstream `bfd7fed` (#58, "use android_sdkless player by default").

The fork carries no source changes — its entire diff from upstream is `Cargo.toml`, seven commits of dependency bumps — so nothing is lost by pointing at upstream directly. Not `main`: #59 moves to reqwest 0.13 and renames `rustls-tls` → `rustls`, which this workspace cannot take yet.

**2. The stream URL returns 403.** Past the 400, the googlevideo URL is fetched as `c=ANDROID` and rejected. songbird then has an empty stream and symphonia reports `probe reach EOF at 0 bytes` followed by `no suitable format reader found` — which reads like a codec fault and is a fetch fault. Playback goes through songbird's `YoutubeDl` now. Measured on the same video: rusty_ytdl's URL 403s, yt-dlp's returns 206 with `1a 45 df a3`, the EBML magic.

**3. yt-dlp could never have run.** The image installed `yt-dlp_linux`, the glibc build, onto an Alpine (musl) base, so a 40 MB executable sat there failing with "No such file or directory" — for the ELF interpreter, not the file. Now `yt-dlp_musllinux`, and the build asserts `yt-dlp --version` so picking the wrong build fails the build rather than the bot. `deno` comes with it: extraction without a JS runtime is deprecated upstream and silently drops formats, and Alpine's build is musl-native unlike deno's own releases.

**Also: one construction site.** `queue_resolved_track_back` and `resolve_query_to_tracks` each built their own source inline rather than calling `build_track`. That is why fixing the source fixed `/gp` — the only caller — and left `/play` silent through a whole deploy cycle. All three go through `build_track` now, and the duplicated `TrackData` assembly is gone with them.

## Verification

Build, `fmt --check` and clippy clean; 175 passed / 0 failed.

Isolated off the bot before changing anything: `cargo test -p crack-testing` reproduced the 400 on any host, and reproduced it on master at `156f263` before `/gp` existed — which is what ruled out #422 as the cause.

Confirmed live on the bots VM: `/play`, `/spotify` and `/gp` all play.

Known follow-up, unchanged: #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8PrF3gizKqXCStjCuWL3d