### PR TITLE
chore(deps): drop warp's default features, removing warp's tungstenite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3780,24 +3780,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multer"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http 0.2.12",
- "httparse",
- "log",
- "memchr",
- "mime",
- "spin",
- "version_check",
-]
-
-[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6958,18 +6940,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.21.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
@@ -7286,25 +7256,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4189890526f0168710b6ee65ceaedf1460c48a14318ceec933cb26baa492096a"
 dependencies = [
  "linked-hash-map",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.5.0",
- "httparse",
- "log",
- "rand 0.8.7",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
 ]
 
 [[package]]
@@ -7688,7 +7639,6 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "multer",
  "percent-encoding",
  "pin-project",
  "scoped-tls",
@@ -7696,7 +7646,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-tungstenite 0.21.0",
  "tokio-util",
  "tower-service",
  "tracing",

--- a/crack-voting/Cargo.toml
+++ b/crack-voting/Cargo.toml
@@ -39,7 +39,7 @@ db-tests = []
 [dependencies]
 lazy_static = "1.5"
 dbl-rs = "0.4"
-warp = "0.3"
+warp = { version = "0.3", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
## `tokio-tungstenite` itself can't be removed

It isn't declared anywhere in the workspace — no `Cargo.toml`, no source reference. It's purely transitive, and two of its three copies are load-bearing:

| version | pulled by | what it does |
|---|---|---|
| 0.28.0 | **serenity** | the Discord gateway WebSocket |
| 0.26.2 | **songbird** | the voice gateway WebSocket |
| 0.21.0 | warp ← `crack-voting` | **nothing — unused** |

The first two are how the bot connects to Discord and how it carries audio. Removing them means removing serenity and songbird, i.e. removing the bot.

## The third one is removable, and this removes it

`crack-voting` uses warp purely as an HTTP JSON webhook receiver — `post`, `body::json`, `header`, `path!("health")`, `serve` — and never touches a websocket. But warp enables `websocket` (and `multipart`) by **default**, so it was dragging a whole websocket stack in for nothing:

```toml
-warp = "0.3"
+warp = { version = "0.3", default-features = false }
```

That drops `tokio-tungstenite` 0.21, `tungstenite` 0.21 and `multer` — **51 fewer lines of `Cargo.lock`**, and the tree goes from four tungstenite copies to two, both of them the gateway ones that have to stay.

If `crack-voting` ever needs multipart or websockets, the feature gets re-added explicitly and the build fails loudly in the meantime rather than silently carrying dead weight.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test --workspace` — 192 pass (139 in crack-core)

`crack-voting`'s own `test_log_headers` still compiles against `warp::test` without default features; it remains ignored for want of a Postgres at `DATABASE_URL`, exactly as on master.

The one `crack-testing` failure, `tests::test_enqueue_query`, is the pre-existing live-YouTube network test and fails identically on unmodified master.

No version bump, per the decision to hold 0.6.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8PrF3gizKqXCStjCuWL3d