### PR TITLE
docs: document the prebuilt binaries, and what is actually required to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,15 @@ Everything below is optional, and the bot degrades rather than failing without i
 
 | variable | what you lose without it |
 | --- | --- |
-| `DATABASE_URL`, `PG_USER`, `PG_PASSWORD` | play history, track reactions, playlist storage, and settings that persist across restarts |
+| `DATABASE_URL` | play history, track reactions, playlist storage, and guild settings that survive a restart |
 | `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` | Spotify link support |
 | `OPENAI_API_KEY` | ChatGPT commands |
 | `VIRUSTOTAL_API_KEY` | OSINT URL checking |
-| `DISCORD_APP_ID` | nothing — serenity derives it from the token |
+
+`DATABASE_URL` is the only database variable the bot reads. If you run the
+bundled Postgres from `docker-compose-postgres.yml`, `POSTGRES_USER` and
+`POSTGRES_PASSWORD` configure *that container* — the official Postgres image
+reads them, the bot does not.
 
 Use [.env.example](https://github.com/cycle-five/cracktunes/blob/master/.env.example) as a starting point.
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,15 @@ Everything below is optional, and the bot degrades rather than failing without i
 | variable | what you lose without it |
 | --- | --- |
 | `DATABASE_URL` | play history, track reactions, playlist storage, and guild settings that survive a restart |
-| `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` | Spotify link support |
 | `OPENAI_API_KEY` | ChatGPT commands |
 | `VIRUSTOTAL_API_KEY` | OSINT URL checking |
+
+Spotify needs no credentials. It is served by
+[sleevenote](https://github.com/cycle-five/sleevenote) rather than the Spotify
+Web API — which matters, because Spotify stopped accepting new Web API app
+registrations around December 2025, so `SPOTIFY_CLIENT_ID` and
+`SPOTIFY_CLIENT_SECRET` are not obtainable for a new self-hoster even if the old
+path were still wanted.
 
 `DATABASE_URL` is the only database variable the bot reads. If you run the
 bundled Postgres from `docker-compose-postgres.yml`, `POSTGRES_USER` and

--- a/README.md
+++ b/README.md
@@ -16,13 +16,39 @@ Thanks to the guys over at [alwaysdata](https://www.alwaysdata.com/) for hosting
 
 ### Usage
 
-- Create a bot account
-- Copy the **token** and **application id** to a `.env` with the `DISCORD_TOKEN` and `DISCORD_APP_ID` environment variables respectively.
-- Define `DATABASE_URL`, `PG_USER`, `PG_PASSWORD` for the Postgres database.
-- _Optional_ define `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` for Spotify support.
-- _Optional_ define `OPENAI_API_KEY` for chatgpt support.
-- _Optional_ define `VIRUSTOTAL_API_KEY` for osint URL checking.
-- Use [.env.example](https://github.com/cycle-five/cracktunes/blob/master/.env.example) as a starting point.
+- Create a bot account.
+- Put its **token** in a `.env` as `DISCORD_TOKEN`. **That is the only required
+  variable** — the bot starts and plays music with nothing else set.
+
+Everything below is optional, and the bot degrades rather than failing without it:
+
+| variable | what you lose without it |
+| --- | --- |
+| `DATABASE_URL`, `PG_USER`, `PG_PASSWORD` | play history, track reactions, playlist storage, and settings that persist across restarts |
+| `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` | Spotify link support |
+| `OPENAI_API_KEY` | ChatGPT commands |
+| `VIRUSTOTAL_API_KEY` | OSINT URL checking |
+| `DISCORD_APP_ID` | nothing — serenity derives it from the token |
+
+Use [.env.example](https://github.com/cycle-five/cracktunes/blob/master/.env.example) as a starting point.
+
+### Prebuilt binaries
+
+No Docker, no Rust toolchain. Each release publishes a static
+`x86_64-unknown-linux-gnu` build with an installer script and a `.sha256`
+alongside it:
+
+```shell
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/cycle-five/cracktunes/releases/latest/download/cracktunes-installer.sh | sh
+```
+
+Or take the tarball directly from the
+[latest release](https://github.com/cycle-five/cracktunes/releases/latest) if you
+would rather read the script first, or check the `.sha256` before running anything.
+`crack-testing` and `crack-voting` ship the same way.
+
+You still need a `.env` with `DISCORD_TOKEN`, and `yt-dlp` on `PATH` for playback.
 
 ### Docker
 


### PR DESCRIPTION
Came out of asking why release artifacts stopped being downloaded.

## The prebuilt binaries were never documented

Every release since v0.4.0 publishes an installer script, a static `x86_64-unknown-linux-gnu` tarball and a `.sha256` for each of `cracktunes`, `crack-testing` and `crack-voting`. The README has never mentioned them — the only documented paths were Docker and building from source.

The download numbers tell the story:

| release | assets | total downloads |
|---|---|---|
| v0.3.14 (Nov 2024, last before the hiatus) | 13 | **44** |
| v0.4.0 | 14 | 5 |
| v0.5.0 | 14 | 5 |
| v0.6.0 | 14 | 5 |

Identical counts across three consecutive releases is what crawlers produce. v0.3.14's 44 — 7 each on the cracktunes tarball and its installer — is what people produce. The artifacts were not unwanted, they were unadvertised, and then the project went quiet.

Adds a **Prebuilt binaries** section alongside Docker, with the installer one-liner, a pointer to the tarball for anyone who would rather read the script first, and the two things you still need (`DISCORD_TOKEN`, and `yt-dlp` on `PATH`).

## The required-variable list was wrong

It listed `DATABASE_URL`, `PG_USER` and `PG_PASSWORD` as though Postgres were mandatory, and `DISCORD_APP_ID` next to the token.

Neither is true. Since #420 the token is the only thing the bot cannot start without, and serenity derives the application id from it — the deployed instance runs with no `DATABASE_URL` at all. Telling someone they need to stand up Postgres before trying a music bot is a real barrier and an inaccurate one.

Replaced with a table of what each optional variable actually buys, so the cost of skipping one is legible rather than implied.

## Note

`/releases/latest/download/` currently resolves to **v0.6.1**, because the v0.6.2 and v0.6.3 releases were deleted after a release-workflow conflict. It will self-correct on the next release that runs the workflow cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8PrF3gizKqXCStjCuWL3d