### PR TITLE
fix: a partly-recovered Spotify listing is not a broken lookup

### DIFF
--- a/crack-core/src/messaging/messages.rs
+++ b/crack-core/src/messaging/messages.rs
@@ -190,6 +190,12 @@ pub const SPOTIFY_TIMEOUT: &str = "⏳ **Spotify took too long to answer.**\nTry
 // Deliberately offers no retry: the lookup service stopped matching Spotify's
 // page, so retrying the same link fails identically until it is fixed.
 pub const SPOTIFY_LOOKUP_BROKEN: &str = "⚠️ **Spotify lookup is broken right now.**\nThis has been logged. Search for the track by name and I'll play it.";
+// Distinct from the above, and the distinction is the whole reason sleevenote
+// keeps these two apart: something *was* recovered, just not all of it. The
+// service returns the shortfall rather than a partial listing, so there is
+// nothing to queue -- but "broken" overstates it, and the reader has a real
+// alternative rather than nothing to try.
+pub const SPOTIFY_PARTIAL_LISTING: &str = "⚠️ **Spotify only gave me part of that list.**\nI won't queue half a playlist, so nothing was added. Albums and individual tracks resolve reliably; large editorial playlists often don't.";
 pub const SPOTIFY_LOOKUP_FAILED: &str =
     "⚠️ **Spotify lookup failed.**\nSearch for the track by name and I'll play it.";
 // The wire call succeeded and the answer was empty -- a podcast-only playlist,

--- a/crack-core/src/sources/sleevenote.rs
+++ b/crack-core/src/sources/sleevenote.rs
@@ -24,7 +24,8 @@ use crate::errors::CrackedError;
 use crate::http_utils;
 use crate::messaging::messages::{
     SPOTIFY_INVALID_QUERY, SPOTIFY_LOOKUP_BROKEN, SPOTIFY_LOOKUP_FAILED, SPOTIFY_NOTHING_PLAYABLE,
-    SPOTIFY_NOT_CONFIGURED, SPOTIFY_NOT_FOUND, SPOTIFY_TIMEOUT, SPOTIFY_UNREACHABLE,
+    SPOTIFY_NOT_CONFIGURED, SPOTIFY_NOT_FOUND, SPOTIFY_PARTIAL_LISTING, SPOTIFY_TIMEOUT,
+    SPOTIFY_UNREACHABLE,
 };
 use crack_sleevenote::{Client as Sleevenote, Error as SleevenoteError, Track, BASE_URL_ENV};
 use crack_types::NewAuxMetadata;
@@ -382,9 +383,16 @@ pub fn user_message(err: &SleevenoteError) -> &'static str {
         SleevenoteError::Timeout(_) => SPOTIFY_TIMEOUT,
         // Not the caller's fault and not retryable by them: the service
         // stopped matching Spotify's page. Offering a retry would be a lie.
-        SleevenoteError::ExtractionEmpty(_) | SleevenoteError::ExtractionIncomplete(_) => {
-            tracing::error!("sleevenote extraction failed: {err}");
+        SleevenoteError::ExtractionEmpty(_) => {
+            tracing::error!("sleevenote extraction returned nothing: {err}");
             SPOTIFY_LOOKUP_BROKEN
+        },
+        // Something was recovered, just not all of it -- a different fact, and
+        // in practice a routine one for large editorial playlists rather than
+        // a sign anything is broken.
+        SleevenoteError::ExtractionIncomplete(_) => {
+            tracing::warn!("sleevenote extraction incomplete: {err}");
+            SPOTIFY_PARTIAL_LISTING
         },
         // The service is unreachable, which is different again from the
         // service answering with a failure -- and "never configured" is


### PR DESCRIPTION
Follow-up to #444, found by verifying against the **deployed sleevenote instance** rather than only against fixtures.

## What the live service actually says

`GET /v1/playlist/37i9dQZF1DXcBWIGoYBM5M` — Today's Top Hits, a playlist people actually paste:

```json
{"error":"extraction_incomplete","id":"37i9dQZF1DXcBWIGoYBM5M",
 "message":"playlist ... saw 25 of 50 declared tracks across recorded responses (25 well-formed) -- extraction was incomplete"}
```

The bot answered **"Spotify lookup is broken right now. This has been logged."** Nothing is broken, nothing needs logging, and the reader was left with no idea that an album or the individual tracks would have worked.

They do. Checked against the same instance:

| request | result |
| --- | --- |
| `/health` | `sleevenote ok` |
| `/v1/track/4PTG3Z6ehGkBFwjybzWkR8` | resolves; response shape **byte-for-byte the same keys and types** as the vendored fixture |
| `/v1/album/5s5svl5DzlSmEvkjuL8Upw` | 60 tracks, 0 unresolved |
| `/v1/playlist/37i9dQZF1DXcBWIGoYBM5M` | `extraction_incomplete`, 25 of 50 |

That also confirms the fixture-based tests added in #444 are testing the contract the deployed service actually serves.

## The fix

`ExtractionEmpty` and `ExtractionIncomplete` had been sharing one message. Keeping those two apart is the reason sleevenote models them separately at all — one is *"our scraper broke"*, the other is *"we got some of it"*. The service returns the shortfall rather than a partial listing, so there is still nothing to queue either way; but they say different things about what the reader should do next, and only one of them is our bug.

The conflation **predates #444** — `/spotify` collapsed the same pair, and routing playback through the same mapping inherited it. Both are fixed here.

## Worth knowing separately

**Large editorial playlists are effectively unplayable.** sleevenote recovers a partial listing and returns the shortfall as a 502, so a caller cannot opt into the 25 tracks it did get. Whether that is the right call belongs in the sleevenote repo rather than here — this PR only stops us describing it as a breakage. Flagging it because "paste Today's Top Hits" is a plausible first thing a user tries.

No version bump: 0.7.0 is not tagged yet, so this rides along with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8PrF3gizKqXCStjCuWL3d