### PR TITLE
fix: stop the startup log claiming Spotify links are broken

### DIFF
--- a/crack-core/src/handlers/serenity.rs
+++ b/crack-core/src/handlers/serenity.rs
@@ -122,12 +122,33 @@ impl SerenityHandler {
             }
         }
 
+        // Whether a Spotify LINK will resolve. This is the question an operator
+        // actually has at boot, and it is no longer the same question as the
+        // credentials check below: links go through sleevenote and need no
+        // credentials, while the credentials gate only autoplay. Reporting one
+        // and not the other is how "Spotify is broken" came to mean two
+        // unrelated things.
+        if crate::sources::sleevenote::is_configured() {
+            tracing::info!(
+                "{} {}",
+                crate::messaging::messages::SLEEVENOTE_CONFIGURED_LOG,
+                std::env::var(crack_sleevenote::BASE_URL_ENV).unwrap_or_default(),
+            );
+        } else {
+            tracing::warn!(
+                "{}",
+                crate::messaging::messages::SLEEVENOTE_UNCONFIGURED_LOG
+            );
+        }
+
         // Attempt to authenticate to Spotify, and SAY SO EITHER WAY.
         //
         // This result used to be stored and never read, so a bot booting with no
         // Spotify credentials looked identical to one booting with working ones.
         // The first anybody learned of it was a user pasting a Spotify link and
         // getting an error -- or, worse, autoplay quietly switching itself off.
+        //
+        // Credentials now gate AUTOPLAY ONLY; see SPOTIFY_DISABLED_LOG.
         let spotify_auth = Spotify::auth(None).await;
         match &spotify_auth {
             Ok(_) => tracing::info!("{}", crate::messaging::messages::SPOTIFY_ENABLED_LOG),

--- a/crack-core/src/messaging/messages.rs
+++ b/crack-core/src/messaging/messages.rs
@@ -167,14 +167,29 @@ pub const SKIPPED: &str = "⏭️ Skipped!";
 // operator without credentials often CANNOT obtain them, and sending them to the
 // dashboard wastes their time. Tell the person in the channel what they can
 // actually do instead; the operator gets the real diagnosis in the logs.
-pub const SPOTIFY_AUTH_FAILED: &str = "⚠️ **Spotify links aren't available right now.**\nI can't look this up, but I can still play it — try searching for the track or artist by name.";
+// Reachable only through autoplay now: link resolution moved to sleevenote and
+// raises its own errors. `track_end` maps this onto AUTOPLAY_DISABLED_SPOTIFY
+// before a user ever sees it, but the Display impl is what shows if
+// CrackedError::SpotifyAuth ever surfaces anywhere else -- so it must not claim
+// links are broken, because they are not.
+pub const SPOTIFY_AUTH_FAILED: &str = "⚠️ **I can't pick a next track right now.**\nThat needs Spotify recommendations, which aren't available. Queue something up and I'll keep playing.";
 pub const AUTOPLAY_DISABLED_SPOTIFY: &str = "🤖 **Autoplay is off.**\nPicking the next track needs Spotify, which isn't available right now. Queue something up and I'll keep playing.";
 pub const AUTOPLAY_DISABLED_ERROR: &str =
     "🤖 **Autoplay is off.**\nI couldn't work out what to play next.";
 // Operator-facing. Never sent to a channel -- this is the detail a person
 // running the bot needs, and the detail a Discord user cannot act on.
-pub const SPOTIFY_DISABLED_LOG: &str = "spotify: DISABLED -- Spotify links and autoplay will not work. Note that Spotify has blocked new Web API app creation since ~2025-12, so this may not be fixable simply by supplying credentials.";
-pub const SPOTIFY_ENABLED_LOG: &str = "spotify: enabled -- client credentials accepted";
+// ⚠️ These describe AUTOPLAY ONLY. Spotify *links* no longer need credentials
+// -- they resolve through sleevenote (`sources::sleevenote`). This message used
+// to say "Spotify links and autoplay will not work", which stopped being true
+// the moment link resolution moved, and sent an operator hunting for
+// credentials that cannot be obtained and would not have fixed links anyway.
+pub const SPOTIFY_DISABLED_LOG: &str = "spotify: autoplay DISABLED -- no client credentials, so recommendations are unavailable. Spotify LINKS are unaffected and resolve through sleevenote. Spotify has blocked new Web API app creation since ~2025-12, so this is probably not fixable by supplying credentials.";
+pub const SPOTIFY_ENABLED_LOG: &str = "spotify: autoplay enabled -- client credentials accepted";
+// The question an operator actually needs answered at boot: can this bot
+// resolve a Spotify link? That is now about sleevenote, not about credentials.
+pub const SLEEVENOTE_CONFIGURED_LOG: &str =
+    "sleevenote: configured -- Spotify links resolve through";
+pub const SLEEVENOTE_UNCONFIGURED_LOG: &str = "sleevenote: SLEEVENOTE_BASE_URL is not set, so Spotify links will be tried against the default and will fail unless sleevenote runs beside this bot. Set it to your sleevenote deployment.";
 pub const SPOTIFY_INVALID_QUERY: &str =
     "⚠️ **Could not find any tracks with that link!**\nAre you sure that is a valid Spotify URL?";
 // Spotify resolution through sleevenote (`sources::sleevenote`). These stay

--- a/d preview
+++ b/d preview
@@ -1,0 +1,30 @@
+[0;1;32m●[0m psd.service - Profile-sync-daemon
+     Loaded: loaded (]8;;file://method/usr/lib/systemd/user/psd.service\/usr/lib/systemd/user/psd.service]8;;\; [0;1;32menabled[0m; preset: [0;1;32menabled[0m)
+     Active: [0;1;32mactive (exited)[0m since Sun 2026-09-06 12:18:50 EDT; 1 day 12h ago
+ Invocation: 1dba64e08c2b479bbf3712a5670524bb
+       Docs: ]8;;man:psd(1)\man:psd(1)]8;;\
+             ]8;;man:profile-sync-daemon(1)\man:profile-sync-daemon(1)]8;;\
+             ]8;;https://wiki.archlinux.org/index.php/Profile-sync-daemon\https://wiki.archlinux.org/index.php/Profile-sync-daemon]8;;\
+   Main PID: 904 (code=exited, status=0/SUCCESS)
+      Tasks: 7[0;38:5:245m (limit: 38133)[0m
+     Memory: 42.2M (peak: 519.5M, swap: 225.2M, swap peak: 237.6M)
+        CPU: 1min 11.987s
+     CGroup: /user.slice/user-1000.slice/user@1000.service/background.slice/psd.service
+             ├─[0;38:5:245m1379 fuse-overlayfs -o lowerdir=/home/lothrop/.config/chromium-backup,upperdir=/run/user/1000/psd/lothrop-chromium-rw,workdir=/run/user/1000/psd/.lothrop-chromium /run/user/1000/psd/lothrop-chromium[0m
+             ├─[0;38:5:245m1423 fuse-overlayfs -o "lowerdir=/home/lothrop/.mozilla/firefox/RcOAmF9U.Profile 1-backup,upperdir=/run/user/1000/psd/lothrop-firefox-RcOAmF9U.Profile 1-rw,workdir=/run/user/1000/psd/.lothrop-firefox-RcOAmF9U.Profile 1" "/run/user/1000/psd/lothrop-firefox-RcOAmF9U.Profile 1"[0m
+             ├─[0;38:5:245m1450 fuse-overlayfs -o "lowerdir=/home/lothrop/.mozilla/firefox/rMSFwrXw.Profile 1-backup,upperdir=/run/user/1000/psd/lothrop-firefox-rMSFwrXw.Profile 1-rw,workdir=/run/user/1000/psd/.lothrop-firefox-rMSFwrXw.Profile 1" "/run/user/1000/psd/lothrop-firefox-rMSFwrXw.Profile 1"[0m
+             ├─[0;38:5:245m1467 fuse-overlayfs -o lowerdir=/home/lothrop/.config/google-chrome-backup,upperdir=/run/user/1000/psd/lothrop-google-chrome-rw,workdir=/run/user/1000/psd/.lothrop-google-chrome /run/user/1000/psd/lothrop-google-chrome[0m
+             ├─[0;38:5:245m1490 fuse-overlayfs -o lowerdir=/home/lothrop/.config/opera-backup,upperdir=/run/user/1000/psd/lothrop-opera-rw,workdir=/run/user/1000/psd/.lothrop-opera /run/user/1000/psd/lothrop-opera[0m
+             ├─[0;38:5:245m1513 fuse-overlayfs -o lowerdir=/home/lothrop/.local/share/qutebrowser-backup,upperdir=/run/user/1000/psd/lothrop-qutebrowser-rw,workdir=/run/user/1000/psd/.lothrop-qutebrowser /run/user/1000/psd/lothrop-qutebrowser[0m
+             └─[0;38:5:245m1532 fuse-overlayfs -o lowerdir=/home/lothrop/.config/vivaldi-backup,upperdir=/run/user/1000/psd/lothrop-vivaldi-rw,workdir=/run/user/1000/psd/.lothrop-vivaldi /run/user/1000/psd/lothrop-vivaldi[0m
+
+Sep 06 12:18:50 method systemd[868]: Starting Profile-sync-daemon...
+Sep 06 12:18:50 method profile-sync-daemon[904]: psd startup check successful
+Sep 06 12:18:50 method profile-sync-daemon[1154]: chromium sync successful
+Sep 06 12:18:50 method profile-sync-daemon[1154]: firefox sync successful
+Sep 06 12:18:50 method profile-sync-daemon[1154]: firefox sync successful
+Sep 06 12:18:50 method profile-sync-daemon[1154]: google-chrome sync successful
+Sep 06 12:18:50 method profile-sync-daemon[1154]: opera sync successful
+Sep 06 12:18:50 method profile-sync-daemon[1154]: qutebrowser sync successful
+Sep 06 12:18:50 method profile-sync-daemon[1154]: vivaldi sync successful
+Sep 06 12:18:50 method systemd[868]: Finished Profile-sync-daemon.


### PR DESCRIPTION
Found by running the merged branch on the beta bot — which is the only way this was ever going to surface. It is a log line, and no test asserts on log lines.

## What it said

At boot:

```
spotify: DISABLED -- Spotify links and autoplay will not work.
```

That stopped being true in #444. Links no longer need Spotify credentials at all; they resolve through sleevenote. The credentials now gate exactly one thing — **autoplay's recommendations** — because sleevenote resolves ids to metadata and has no recommendations endpoint.

So an operator reads that line, concludes the feature is broken, and goes hunting for credentials that cannot be obtained (Spotify blocked new Web API app creation around 2025-12) and would not have fixed links even if they could.

I removed the rspotify link path in #444 and left every message that described it.

## What changed

| constant | before | after |
| --- | --- | --- |
| `SPOTIFY_DISABLED_LOG` | "Spotify links and autoplay will not work" | autoplay only; states plainly that links are unaffected |
| `SPOTIFY_ENABLED_LOG` | "spotify: enabled" | "spotify: autoplay enabled" |
| `SPOTIFY_AUTH_FAILED` | "Spotify links aren't available right now" | about picking a next track |

`SPOTIFY_AUTH_FAILED` is the `Display` for `CrackedError::SpotifyAuth`, which only autoplay raises now (`track_end.rs:363`). `track_end.rs:350` maps it onto `AUTOPLAY_DISABLED_SPOTIFY` before a user ever sees it — but the `Display` is what shows if it surfaces anywhere else, so it must not claim links are broken.

## And the line that was missing

Nothing at boot answered the question an operator actually has: **will a Spotify link resolve?** That is now a question about `SLEEVENOTE_BASE_URL`, not about credentials, and `sources::sleevenote::is_configured()` already answers it.

This is the same distinction the resolver draws at request time, where an unset variable means "not set up" rather than "temporarily unreachable" — both arrive as the same refused connection, and only the environment tells them apart. Reporting the credentials check and not this one is how "Spotify is broken" came to mean two unrelated things.

## Verification

`crack-core` 154 tests pass; `clippy -D warnings` and `fmt` clean.

The startup lines themselves need a restart of the beta bot to observe, which is pending — it is mid-test with the current build. Everything else on that run was healthy: 39 global commands registered, and **guild settings loaded per-guild from `GuildCreate` with no database**, which is v0.6.3's fix working in the configuration it was written for.

No version bump: master is already at 0.7.0 and untagged, so this rides along with it.

## Noted, not fixed here

`No database pool available` logs at **ERROR**, 13 times at boot — once per guild, a burst rather than a leak. Harmless, but ERROR is the wrong level for a configuration the operator chose deliberately. That deserves a decision about level and rate rather than a quick edit, and it is adjacent to the other unfiled `database_pool` call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8PrF3gizKqXCStjCuWL3d