### PR TITLE
test: stop verifying YouTube's mood on every CI run

### DIFF
--- a/crack-core/src/sources/rusty_ytdl.rs
+++ b/crack-core/src/sources/rusty_ytdl.rs
@@ -400,6 +400,18 @@ mod test {
     use rusty_ytdl::RequestOptions;
     use songbird::input::{Input, YoutubeDl};
 
+    // 🔑 THE `#[ignore]`d TESTS BELOW REACH LIVE YOUTUBE, so they answer a
+    // question about YouTube's mood on a shared CI runner, not about this
+    // code. Run them by hand when touching the search path:
+    //
+    //     cargo test -p crack-core --lib rusty_ytdl -- --ignored --nocapture
+    //
+    // `test_ytdl` was the one that could actually fail: it panics when a
+    // search returns `Ok(None)` -- YouTube answering with zero results --
+    // while treating a hard `Err` as acceptable. That inversion took the
+    // whole build matrix down three times in one hour, and never once
+    // pointed at a defect here.
+    #[ignore = "hits live YouTube"]
     #[tokio::test]
     async fn test_rusty_youtube_search() {
         let search_term = "The Night Chicago Died";
@@ -438,6 +450,7 @@ mod test {
         assert!(!input.is_playable());
     }
 
+    #[ignore = "hits live YouTube"]
     #[tokio::test]
     async fn test_ytdl() {
         let search = "The Night Chicago Died";
@@ -466,6 +479,7 @@ mod test {
     //     }
     // }
 
+    #[ignore = "hits live YouTube"]
     #[tokio::test]
     async fn test_rusty_ytdl_serial() {
         // let url = "https://www.youtube.com/watch?v=6n3pFFPSlW4".to_string();
@@ -498,6 +512,7 @@ mod test {
         }
     }
 
+    #[ignore = "hits live YouTube"]
     #[tokio::test]
     async fn test_ytdl_serial() {
         let phrase = "Sign in to confirm you’re not a bot.";


### PR DESCRIPTION
## What

Mark the four tests in `sources::rusty_ytdl::test` that reach **live YouTube**
as `#[ignore]`, and document how to run them by hand.

## Why

They answer a question about YouTube's mood on a shared CI runner, not about
this code. Only one of them could even fail:

| test | behaviour on a network hiccup |
| --- | --- |
| `test_ytdl` | **panics** on `Ok(None)` — YouTube answering with zero results — while treating a hard `Err` as acceptable |
| `test_rusty_youtube_search` | returns early on `Err`; asserts nothing |
| `test_rusty_ytdl_serial` | `assert!(res.is_ok() \|\| { println!(..); true })` — a tautology, cannot fail |
| `test_ytdl_serial` | no assertions at all |

Three of the four were never verifying anything. The fourth took the whole
build matrix down **three times in one hour** today — on #447, a PR that
deleted a stray file and touched no code, and again on master's `coverage`
run. Because `Build` uses matrix fail-fast, each flake also cancelled the
sibling job mid-compile, so one YouTube hiccup reads as two failures.

## Scope

`#[ignore]` is already this repo's convention for network-dependent tests
(`crack-osint/src/scan.rs`, `crack-osint/src/test/{socialmedia,phlookup}.rs`,
`crack-cli/src/test/utils.rs`, and `test_rusty_ytdl_plays` in this same
module). Nothing is deleted — they stay runnable:

```
cargo test -p crack-core --lib rusty_ytdl -- --ignored --nocapture
```

The tautological assert and the two assertion-free tests are left as they
are; making them assert something real is a separate call.

## Verification

`cargo test -p crack-core --lib` → **150 passed, 0 failed, 25 ignored**
(the 4 new + `test_rusty_ytdl_plays` + 20 `db::*` tests that need a Postgres
and are skipped locally but run in CI). `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8PrF3gizKqXCStjCuWL3d