### PR TITLE
test: crack-testing's CLI tests reached live YouTube too

### DIFF
--- a/crack-testing/src/lib.rs
+++ b/crack-testing/src/lib.rs
@@ -670,6 +670,7 @@ mod tests {
 
     use super::*;
 
+    #[ignore = "hits live YouTube"]
     #[tokio::test]
     async fn test_cli() {
         let cli = Cli::parse_from(vec!["crack_testing", "suggest", "molly nilsson"]);
@@ -679,6 +680,7 @@ mod tests {
         }
     }
 
+    #[ignore = "hits live YouTube"]
     #[tokio::test]
     async fn test_cli2() {
         let cli = Cli::parse_from(vec![
@@ -689,6 +691,7 @@ mod tests {
         match_cli(cli).await.expect("asdf");
     }
 
+    #[ignore = "hits live YouTube"]
     #[tokio::test]
     async fn test_cli3() {
         let cli = Cli::parse_from(vec!["crack_testing", "suggest-new", "molly nilsson"]);
@@ -698,6 +701,7 @@ mod tests {
         }
     }
 
+    #[ignore = "hits live YouTube"]
     #[tokio::test]
     async fn test_cli4() {
         let cli = Cli::parse_from(vec!["crack_testing", "query", "molly nilsson"]);


### PR DESCRIPTION
Follow-up to #448, which covered `crack-core`. These four are the same class
in `crack-testing`, and `test_cli2` is the same defect exactly:

```rust
match_cli(cli).await.expect("asdf");   // against a live YouTube playlist URL
```

When YouTube changes its page shape or rate-limits the runner, that panics
with `asdf: PlaylistBodyCannotParsed` and fails `Build` — attributing the
redness to whichever PR happened to be running. Observed 2026-08-27:
dependabot #405 (`typemap_rev` 0.3→0.4) failed `Build` on this test while
#406, rebased onto an identical master and running the identical suite,
passed. `typemap_rev` is a type-map crate with no bearing on playlist parsing.

`test_cli`, `test_cli3` and `test_cli4` tolerate an `Err` by printing it — so
like three of the four in #448, they were never verifying anything either.

## Why these four and not the rest of the file

They were the **only** network tests in `crack-testing/src/lib.rs` with no
guard at all. The other six (`test_resolve_track`, `test_suggestion`,
`test_suggestion2`, `test_suggestion_function`, `test_enqueue_query`, and one
more) already return early on `env::var("CI")`. The omission reads as an
oversight, not a decision.

## Why `#[ignore]` and not that `env::var("CI")` guard

`#[ignore]` matches #448 and the convention in `crack-osint` and `crack-cli`.
The CI guard makes a test report as **PASSED** while executing nothing, which
is a worse signal than an honest `ignored` — the same FAIL-vs-SKIP argument.
The six existing guards are left alone; converting them is a separate call.

## Verification

`CI=1 cargo test -p crack-testing` → **15 passed, 0 failed, 4 ignored**, each
printing `ignored, hits live YouTube`. `cargo fmt --check` clean.

No version bump: test-only, ships no artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8PrF3gizKqXCStjCuWL3d