### PR TITLE
feat(gp): save games to Postgres so a restart does not end them

### DIFF
--- a/.sqlx/query-16d73d93557553ca31282cab1c53c27172b7d7056e1e2da5338182230a18b919.json
+++ b/.sqlx/query-16d73d93557553ca31282cab1c53c27172b7d7056e1e2da5338182230a18b919.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE gp_game\n               SET finished_at = now(), outcome = 'lost'\n               WHERE guild_id = $1 AND finished_at IS NULL AND started_at <> $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "16d73d93557553ca31282cab1c53c27172b7d7056e1e2da5338182230a18b919"
+}

--- a/.sqlx/query-1869996ea57f6e83a6031b0865b22a785fa416baf585a9cbcdc69f6d22334589.json
+++ b/.sqlx/query-1869996ea57f6e83a6031b0865b22a785fa416baf585a9cbcdc69f6d22334589.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE gp_game SET last_seen_at = now()\n           WHERE finished_at IS NULL AND guild_id = ANY($1)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8Array"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1869996ea57f6e83a6031b0865b22a785fa416baf585a9cbcdc69f6d22334589"
+}

--- a/.sqlx/query-1f6256c41b15046315e4c5d2abe43321d5644fb11a4376bb2de9044a574e1eab.json
+++ b/.sqlx/query-1f6256c41b15046315e4c5d2abe43321d5644fb11a4376bb2de9044a574e1eab.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT outcome FROM gp_game WHERE guild_id = 2 AND started_at = 1700000000",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "outcome",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "1f6256c41b15046315e4c5d2abe43321d5644fb11a4376bb2de9044a574e1eab"
+}

--- a/.sqlx/query-254842deee187bcada4ce18cdeac584d58cb9eb19a93ece94bc5997856796920.json
+++ b/.sqlx/query-254842deee187bcada4ce18cdeac584d58cb9eb19a93ece94bc5997856796920.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT outcome FROM gp_game WHERE guild_id = 4",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "outcome",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "254842deee187bcada4ce18cdeac584d58cb9eb19a93ece94bc5997856796920"
+}

--- a/.sqlx/query-27d054446a10c5f271f5d88cb8f61e63e9d0023d30e472dd22143deab1486969.json
+++ b/.sqlx/query-27d054446a10c5f271f5d88cb8f61e63e9d0023d30e472dd22143deab1486969.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE gp_game SET last_seen_at = now() - interval '10 minutes'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "27d054446a10c5f271f5d88cb8f61e63e9d0023d30e472dd22143deab1486969"
+}

--- a/.sqlx/query-2c1d1a99390740a460a8e949f687d399407735315a6e6c6c31d9acf52623a618.json
+++ b/.sqlx/query-2c1d1a99390740a460a8e949f687d399407735315a6e6c6c31d9acf52623a618.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO gp_game (\n                   guild_id, started_at, host_id, voice_channel_id, text_channel_id,\n                   category, phase, current_round, current_track, timer_secs,\n                   clip_start_secs, clip_length_secs, generation, last_seen_at\n               )\n               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, now())\n               ON CONFLICT (guild_id, started_at) DO UPDATE SET\n                   phase = EXCLUDED.phase,\n                   current_round = EXCLUDED.current_round,\n                   current_track = EXCLUDED.current_track,\n                   generation = EXCLUDED.generation,\n                   text_channel_id = EXCLUDED.text_channel_id,\n                   last_seen_at = now()\n               RETURNING id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8",
+        "Int8",
+        "Int8",
+        "Int8",
+        "Text",
+        "Text",
+        "Int4",
+        "Int4",
+        "Int8",
+        "Int8",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "2c1d1a99390740a460a8e949f687d399407735315a6e6c6c31d9acf52623a618"
+}

--- a/.sqlx/query-33d4a003dfd749ecd828d9973c37a433d67a742a8b93f9194d404ec9cb8ab2a2.json
+++ b/.sqlx/query-33d4a003dfd749ecd828d9973c37a433d67a742a8b93f9194d404ec9cb8ab2a2.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT round_idx, submitter_id, user_id, kind FROM gp_vote\n               WHERE game_id = $1 ORDER BY round_idx, submitter_id, user_id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "round_idx",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "submitter_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "user_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "kind",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "33d4a003dfd749ecd828d9973c37a433d67a742a8b93f9194d404ec9cb8ab2a2"
+}

--- a/.sqlx/query-3662a72f6549fc950c7ed0fae08cb230e519ad07f4dfc4be4a3e84431f054ba6.json
+++ b/.sqlx/query-3662a72f6549fc950c7ed0fae08cb230e519ad07f4dfc4be4a3e84431f054ba6.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO gp_track (\n                   game_id, round_idx, submitter_id, position, url, title, artist,\n                   duration_secs, play_full, message_channel_id, message_id\n               )\n               SELECT $1, * FROM UNNEST(\n                   $2::int[], $3::bigint[], $4::int[], $5::text[], $6::text[], $7::text[],\n                   $8::bigint[], $9::bool[], $10::bigint[], $11::bigint[]\n               )\n               ON CONFLICT (game_id, round_idx, submitter_id) DO UPDATE SET\n                   position = EXCLUDED.position,\n                   url = EXCLUDED.url,\n                   title = EXCLUDED.title,\n                   artist = EXCLUDED.artist,\n                   duration_secs = EXCLUDED.duration_secs,\n                   play_full = EXCLUDED.play_full,\n                   message_channel_id = EXCLUDED.message_channel_id,\n                   message_id = EXCLUDED.message_id",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int4Array",
+        "Int8Array",
+        "Int4Array",
+        "TextArray",
+        "TextArray",
+        "TextArray",
+        "Int8Array",
+        "BoolArray",
+        "Int8Array",
+        "Int8Array"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3662a72f6549fc950c7ed0fae08cb230e519ad07f4dfc4be4a3e84431f054ba6"
+}

--- a/.sqlx/query-3f1a3fadff8839fbadf2097bd6bf90513d215757c7af6b23ebd3df545c0ef652.json
+++ b/.sqlx/query-3f1a3fadff8839fbadf2097bd6bf90513d215757c7af6b23ebd3df545c0ef652.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO gp_like (game_id, round_idx, submitter_id, user_id)\n                   SELECT $1, * FROM UNNEST($2::int[], $3::bigint[], $4::bigint[])",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int4Array",
+        "Int8Array",
+        "Int8Array"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3f1a3fadff8839fbadf2097bd6bf90513d215757c7af6b23ebd3df545c0ef652"
+}

--- a/.sqlx/query-402f74f67438643c297ef696f831a7efd5847c9797299f9cd156e63b2b1fc70d.json
+++ b/.sqlx/query-402f74f67438643c297ef696f831a7efd5847c9797299f9cd156e63b2b1fc70d.json
@@ -1,0 +1,76 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT round_idx, submitter_id, position, url, title, artist, duration_secs,\n                      play_full, message_channel_id, message_id\n               FROM gp_track WHERE game_id = $1\n               ORDER BY round_idx, position NULLS LAST, submitter_id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "round_idx",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "submitter_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "position",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "artist",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "duration_secs",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 7,
+        "name": "play_full",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "message_channel_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 9,
+        "name": "message_id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "402f74f67438643c297ef696f831a7efd5847c9797299f9cd156e63b2b1fc70d"
+}

--- a/.sqlx/query-56c10b4d1d935bfc72cb74c5fa8783b7857ff6a0ca0b724d063157fd89571b7a.json
+++ b/.sqlx/query-56c10b4d1d935bfc72cb74c5fa8783b7857ff6a0ca0b724d063157fd89571b7a.json
@@ -1,0 +1,106 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, guild_id, started_at, host_id, voice_channel_id, text_channel_id,\n                      category, phase, current_round, current_track, timer_secs,\n                      clip_start_secs, clip_length_secs, generation,\n                      EXTRACT(EPOCH FROM now() - last_seen_at)::bigint AS \"last_seen_secs_ago!\"\n               FROM gp_game\n               WHERE guild_id = $1 AND finished_at IS NULL\n               ORDER BY started_at DESC\n               LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "guild_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "started_at",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "host_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "voice_channel_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "text_channel_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "category",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "phase",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "current_round",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "current_track",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "timer_secs",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "clip_start_secs",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 12,
+        "name": "clip_length_secs",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 13,
+        "name": "generation",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 14,
+        "name": "last_seen_secs_ago!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      null
+    ]
+  },
+  "hash": "56c10b4d1d935bfc72cb74c5fa8783b7857ff6a0ca0b724d063157fd89571b7a"
+}

--- a/.sqlx/query-589613365f4d9423d7cffffb394dc85c91255db7b2e609eee1b80cb4a5033e8a.json
+++ b/.sqlx/query-589613365f4d9423d7cffffb394dc85c91255db7b2e609eee1b80cb4a5033e8a.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT outcome FROM gp_game WHERE guild_id = 3 AND started_at = 1700000000",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "outcome",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "589613365f4d9423d7cffffb394dc85c91255db7b2e609eee1b80cb4a5033e8a"
+}

--- a/.sqlx/query-621364f69f5e214856e69eb41098f4c660812ba41adca32f68bc46a4ea1df70b.json
+++ b/.sqlx/query-621364f69f5e214856e69eb41098f4c660812ba41adca32f68bc46a4ea1df70b.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO gp_vote (game_id, round_idx, submitter_id, user_id, kind)\n                   SELECT $1, * FROM UNNEST($2::int[], $3::bigint[], $4::bigint[], $5::text[])",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int4Array",
+        "Int8Array",
+        "Int8Array",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "621364f69f5e214856e69eb41098f4c660812ba41adca32f68bc46a4ea1df70b"
+}

--- a/.sqlx/query-66963b79ab791231abe1e33120d6e1bcd49a1fc97c73fdfc5cbf90cf91efec3c.json
+++ b/.sqlx/query-66963b79ab791231abe1e33120d6e1bcd49a1fc97c73fdfc5cbf90cf91efec3c.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO gp_player (game_id, user_id, display_name, score)\n               SELECT $1, * FROM UNNEST($2::bigint[], $3::text[], $4::int[])\n               ON CONFLICT (game_id, user_id) DO UPDATE SET\n                   display_name = EXCLUDED.display_name,\n                   score = EXCLUDED.score",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8Array",
+        "TextArray",
+        "Int4Array"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "66963b79ab791231abe1e33120d6e1bcd49a1fc97c73fdfc5cbf90cf91efec3c"
+}

--- a/.sqlx/query-679743e579dfb5af461e79623c074eb4bfe462a2e4a4511584038949e071d7bc.json
+++ b/.sqlx/query-679743e579dfb5af461e79623c074eb4bfe462a2e4a4511584038949e071d7bc.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM gp_like WHERE game_id = $1 AND round_idx BETWEEN $2 AND $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "679743e579dfb5af461e79623c074eb4bfe462a2e4a4511584038949e071d7bc"
+}

--- a/.sqlx/query-69457aacc96c7f80ce2ffc7c5de9825512cb1f3745dbabf874b1c7137ec91096.json
+++ b/.sqlx/query-69457aacc96c7f80ce2ffc7c5de9825512cb1f3745dbabf874b1c7137ec91096.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXTRACT(EPOCH FROM now() - last_seen_at)::bigint AS \"ago!\"\n               FROM gp_game WHERE guild_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "ago!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "69457aacc96c7f80ce2ffc7c5de9825512cb1f3745dbabf874b1c7137ec91096"
+}

--- a/.sqlx/query-7cfebeaaa0f826a085768e24e00df3e756a24e51b8a064bbb594ddd6ba8c3b55.json
+++ b/.sqlx/query-7cfebeaaa0f826a085768e24e00df3e756a24e51b8a064bbb594ddd6ba8c3b55.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT round_idx, prompt, closes_at, prompt_channel_id, prompt_message_id\n               FROM gp_round WHERE game_id = $1 ORDER BY round_idx",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "round_idx",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "prompt",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "closes_at",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "prompt_channel_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "prompt_message_id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "7cfebeaaa0f826a085768e24e00df3e756a24e51b8a064bbb594ddd6ba8c3b55"
+}

--- a/.sqlx/query-8001ef8d90f13fe8fdbd2a2230e9e572abbe33415c4769861cd4ae57225205e4.json
+++ b/.sqlx/query-8001ef8d90f13fe8fdbd2a2230e9e572abbe33415c4769861cd4ae57225205e4.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO gp_guess (game_id, round_idx, submitter_id, guesser_id, guessed_id)\n                   SELECT $1, * FROM UNNEST($2::int[], $3::bigint[], $4::bigint[], $5::bigint[])",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int4Array",
+        "Int8Array",
+        "Int8Array",
+        "Int8Array"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8001ef8d90f13fe8fdbd2a2230e9e572abbe33415c4769861cd4ae57225205e4"
+}

--- a/.sqlx/query-95984e7ff1cb877fdc72a87f003eca43289e06d6c79fc2e1bee874a61c16fdf9.json
+++ b/.sqlx/query-95984e7ff1cb877fdc72a87f003eca43289e06d6c79fc2e1bee874a61c16fdf9.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM gp_guess WHERE game_id = $1 AND round_idx BETWEEN $2 AND $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "95984e7ff1cb877fdc72a87f003eca43289e06d6c79fc2e1bee874a61c16fdf9"
+}

--- a/.sqlx/query-9b77d361eddb51538b429318a7d0e82006423321aa0020b2c6b40d7f0e26736f.json
+++ b/.sqlx/query-9b77d361eddb51538b429318a7d0e82006423321aa0020b2c6b40d7f0e26736f.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM gp_vote WHERE game_id = $1 AND round_idx BETWEEN $2 AND $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9b77d361eddb51538b429318a7d0e82006423321aa0020b2c6b40d7f0e26736f"
+}

--- a/.sqlx/query-b339b0fbac0fd39f0ecd87612db90b0bd5b721743fa131b54804f525168da547.json
+++ b/.sqlx/query-b339b0fbac0fd39f0ecd87612db90b0bd5b721743fa131b54804f525168da547.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO gp_round (game_id, round_idx, prompt, closes_at, prompt_channel_id, prompt_message_id)\n               SELECT $1, * FROM UNNEST($2::int[], $3::text[], $4::bigint[], $5::bigint[], $6::bigint[])\n               ON CONFLICT (game_id, round_idx) DO UPDATE SET\n                   closes_at = EXCLUDED.closes_at,\n                   prompt_channel_id = EXCLUDED.prompt_channel_id,\n                   prompt_message_id = EXCLUDED.prompt_message_id",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int4Array",
+        "TextArray",
+        "Int8Array",
+        "Int8Array",
+        "Int8Array"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b339b0fbac0fd39f0ecd87612db90b0bd5b721743fa131b54804f525168da547"
+}

--- a/.sqlx/query-d3c72ba6c52573b9943269fb354f74962e66382de6718977691a10a655b58e30.json
+++ b/.sqlx/query-d3c72ba6c52573b9943269fb354f74962e66382de6718977691a10a655b58e30.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT round_idx, submitter_id, guesser_id, guessed_id FROM gp_guess\n               WHERE game_id = $1 ORDER BY round_idx, submitter_id, guesser_id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "round_idx",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "submitter_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "guesser_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "guessed_id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "d3c72ba6c52573b9943269fb354f74962e66382de6718977691a10a655b58e30"
+}

--- a/.sqlx/query-d4234613dbea843596a5324a03639e2475ed5bf9e319fed5476380ca5a477ef6.json
+++ b/.sqlx/query-d4234613dbea843596a5324a03639e2475ed5bf9e319fed5476380ca5a477ef6.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT user_id, display_name, score FROM gp_player WHERE game_id = $1 ORDER BY user_id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "user_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "score",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "d4234613dbea843596a5324a03639e2475ed5bf9e319fed5476380ca5a477ef6"
+}

--- a/.sqlx/query-d4abf616599ee19ee9664e9279edcbc72185d5de4c6e795b22b3363c58355492.json
+++ b/.sqlx/query-d4abf616599ee19ee9664e9279edcbc72185d5de4c6e795b22b3363c58355492.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT round_idx, submitter_id, user_id FROM gp_like\n               WHERE game_id = $1 ORDER BY round_idx, submitter_id, user_id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "round_idx",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "submitter_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "user_id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "d4abf616599ee19ee9664e9279edcbc72185d5de4c6e795b22b3363c58355492"
+}

--- a/.sqlx/query-f8d3591ea942595d64d6411cb3a92c859bca45bc995c1458e7145c69aac9ab9d.json
+++ b/.sqlx/query-f8d3591ea942595d64d6411cb3a92c859bca45bc995c1458e7145c69aac9ab9d.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE gp_game SET finished_at = now(), outcome = $3\n           WHERE guild_id = $1 AND started_at = $2 AND finished_at IS NULL",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f8d3591ea942595d64d6411cb3a92c859bca45bc995c1458e7145c69aac9ab9d"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### Added
 
+- **`/gp` games survive a restart.** A game is written to Postgres each time a
+  song is submitted and each time a song ends, and a bot that comes back within
+  five minutes picks it up where it was: a submission window with whatever time
+  was left on it, or the song that was playing from the top, with the scoreboard
+  intact. Nothing on the interaction or playback path waits on the database; a
+  single writer task drains the writes in order, and shutdown drains it before
+  the pool closes. A game down longer than five minutes, or whose voice channel
+  has emptied, is not brought back -- its scoreboard as it stood is posted with a
+  line saying it was lost to an outage. Guesses and 👍 on the song that was
+  playing are not saved: that song plays again and the room casts them again.
+  Every game ever played stays in the `gp_*` tables as history. Without
+  `DATABASE_URL` the game runs in memory exactly as before. (#431)
+
 - **Spotify links play.** Pasting a Spotify track, album or playlist link into
   `/play` or `/gp submit` now resolves it instead of failing. Resolution goes
   through [sleevenote](https://github.com/cycle-five/sleevenote), which needs no

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Everything below is optional, and the bot degrades rather than failing without i
 
 | variable | what you lose without it |
 | --- | --- |
-| `DATABASE_URL` | play history, track reactions, playlist storage, and guild settings that survive a restart |
+| `DATABASE_URL` | play history, track reactions, playlist storage, guild settings that survive a restart, and `/gp` games that survive one too |
 | `SLEEVENOTE_BASE_URL` | Spotify links in `/play`, `/gp submit`, `/spotify` and `/playlist loadspotify` |
 | `OPENAI_API_KEY` | ChatGPT commands |
 | `VIRUSTOTAL_API_KEY` | OSINT URL checking |

--- a/crack-core/src/commands/music/gp.rs
+++ b/crack-core/src/commands/music/gp.rs
@@ -4,13 +4,16 @@
 //! window for everyone in the voice channel to secretly submit a song. The
 //! round's songs then play back-to-back: guess the submitter from a dropdown,
 //! 👍 the ones you like, and the submitter is revealed when the song ends.
-//! Scores live in memory for the duration of the game.
+//! Scores live in memory for the duration of the game, and are written to
+//! Postgres at each submission and each song's end so a restart does not end
+//! the game -- see [`gp_persist`](super::gp_persist).
 
 use crate::{
     commands::cmd_check_music,
     commands::get_call_or_join_author,
     commands::music::gp_prompts::{draw_prompts, GpCategory},
     commands::music::skip::force_skip_top_track,
+    db::GpOutcome,
     errors::CrackedError,
     http_utils::SendMessageParams,
     messaging::message::CrackedMessage,
@@ -95,6 +98,14 @@ pub const GP_MAX_CLIP_LENGTH_SECS: u64 = 300;
 /// parked game itself. Only a backstop: the global track-end handler normally
 /// collects it within milliseconds.
 pub const GP_PARK_GRACE_SECS: u64 = 10;
+/// How long a game may be down before it is not brought back. Measured from the
+/// last time the *bot* saw the game -- a write or a heartbeat -- not from the
+/// game's own clock, so a quiet submission window still counts as seen. Past
+/// this the room has moved on, and a prompt reappearing twenty minutes later is
+/// worse than nothing.
+pub const GP_RESUME_WINDOW_SECS: i64 = 300;
+/// How often a live game says "still here" to the database.
+pub const GP_HEARTBEAT_SECS: u64 = 30;
 /// How much of a song has to have played before a failure counts as a song the
 /// room actually heard, and so as something to score. Below this an `Errored`
 /// track is treated as a dead link: nobody could have guessed it, so nobody is
@@ -282,6 +293,12 @@ impl GpRound {
 
 #[derive(Clone, Debug)]
 pub struct GpGame {
+    /// The guild the game is in -- also the map key, carried here so a game
+    /// removed from the map still knows where it was.
+    pub guild_id: GuildId,
+    /// Unix seconds of `/gp start`. With the guild, this names the game in the
+    /// database across restarts.
+    pub started_at: i64,
     pub host: UserId,
     pub voice_channel: ChannelId,
     pub text_channel: GenericChannelId,
@@ -311,7 +328,9 @@ pub struct GpGame {
 }
 
 impl GpGame {
+    #[allow(clippy::too_many_arguments)]
     fn new(
+        guild_id: GuildId,
         host: UserId,
         voice_channel: ChannelId,
         text_channel: GenericChannelId,
@@ -319,8 +338,11 @@ impl GpGame {
         prompts: Vec<String>,
         timer_secs: u64,
         clip: Option<GpClip>,
+        started_at: i64,
     ) -> Self {
         Self {
+            guild_id,
+            started_at,
             host,
             voice_channel,
             text_channel,
@@ -369,7 +391,7 @@ impl GpGame {
 
     /// Every player with their points, best first; ties broken by name so the
     /// order is stable between edits.
-    fn sorted_scores(&self) -> Vec<(UserId, u32)> {
+    pub(crate) fn sorted_scores(&self) -> Vec<(UserId, u32)> {
         let mut v: Vec<(UserId, u32)> = self
             .players
             .keys()
@@ -463,7 +485,7 @@ impl GpGame {
         }
     }
 
-    fn track_start(&self) -> GpTrackStart {
+    pub(crate) fn track_start(&self) -> GpTrackStart {
         let round = &self.rounds[self.current_round];
         let t = &round.tracks[self.current_track];
         GpTrackStart {
@@ -676,6 +698,7 @@ impl Data {
             return Err(CrackedError::Other("That category has no prompts."));
         }
         let mut game = GpGame::new(
+            guild_id,
             host,
             voice_channel,
             text_channel,
@@ -683,6 +706,7 @@ impl Data {
             prompts,
             timer_secs,
             clip,
+            now,
         );
         game.players.insert(host, host_name);
         let opened = game.open_window(now);
@@ -731,6 +755,8 @@ impl Data {
         let submitted = round.submissions.len();
         let everyone_in =
             !vc_members.is_empty() && vc_members.iter().all(|u| round.submissions.contains_key(u));
+        // A submission is one of the two moments the game is written down.
+        self.gp_snapshot(game);
         Ok(GpSubmitOutcome {
             replaced,
             submitted,
@@ -1163,6 +1189,9 @@ impl Data {
         } else {
             game.advance_round(now)
         };
+        // A song ending is the other moment the game is written down: the scores
+        // it just paid out, and the position the game moves to.
+        self.gp_snapshot(&game);
         Some(GpTrackResult {
             round_idx,
             total_rounds: game.rounds.len(),
@@ -1229,14 +1258,75 @@ impl Data {
             .get(&guild_id)
             .is_some_and(|g| g.parked_for_end);
         if parked {
-            self.gp_games.remove(&guild_id);
+            if let Some((_, game)) = self.gp_games.remove(&guild_id) {
+                self.gp_mark_finished(&game, GpOutcome::Ended);
+            }
         }
         parked
     }
 
     /// Remove the game unconditionally (game over, bot kicked from voice).
+    ///
+    /// The database is told the game is over, with why: a game that played out
+    /// finished, one parked by `/gp end` was ended, and anything else was
+    /// abandoned. Without this a game ended on purpose would still look live
+    /// after a redeploy and come back.
     pub fn gp_remove(&self, guild_id: GuildId) -> Option<GpGame> {
-        self.gp_games.remove(&guild_id).map(|(_, g)| g)
+        let (_, game) = self.gp_games.remove(&guild_id)?;
+        let outcome = if game.parked_for_end {
+            GpOutcome::Ended
+        } else if game.phase == GpPhase::Finished {
+            GpOutcome::Finished
+        } else {
+            GpOutcome::Abandoned
+        };
+        self.gp_mark_finished(&game, outcome);
+        Some(game)
+    }
+
+    /// Put a game loaded from the database back into the map. `false` if the
+    /// guild already has one, which means `/gp start` got there first.
+    pub fn gp_restore(&self, guild_id: GuildId, game: GpGame) -> bool {
+        match self.gp_games.entry(guild_id) {
+            dashmap::mapref::entry::Entry::Vacant(slot) => {
+                slot.insert(game);
+                true
+            },
+            dashmap::mapref::entry::Entry::Occupied(_) => false,
+        }
+    }
+
+    /// Start the current song over after a resume: the [`GpTrackStart`] to play
+    /// and the message the song had before the restart, whose dropdown is still
+    /// live and should be taken down before a new one is posted. Bumps the
+    /// generation so nothing from before the restart could match, though nothing
+    /// survived to try.
+    pub fn gp_resume_playing(
+        &self,
+        guild_id: GuildId,
+    ) -> Option<(GpTrackStart, Option<(GenericChannelId, MessageId)>)> {
+        let mut game = self.gp_games.get_mut(&guild_id)?;
+        if game.phase != GpPhase::Playing {
+            return None;
+        }
+        game.generation += 1;
+        let old = game
+            .rounds
+            .get(game.current_round)?
+            .tracks
+            .get(game.current_track)?
+            .message;
+        Some((game.track_start(), old))
+    }
+
+    /// Every game still being played, as (guild, started_at), for the heartbeat.
+    /// A finished or parked game is on its way out and is not kept alive.
+    pub fn gp_live_games(&self) -> Vec<(GuildId, i64)> {
+        self.gp_games
+            .iter()
+            .filter(|g| g.phase != GpPhase::Finished && !g.parked_for_end)
+            .map(|g| (*g.key(), g.started_at))
+            .collect()
     }
 
     /// Who may act in a running game: anyone who has submitted, plus the host, so
@@ -1768,8 +1858,22 @@ pub async fn gp_open_round(pb: &GpPlayback, opened: GpWindowOpened) -> Result<()
 /// The window timer: a heads-up 30 s before the end, then close. Both steps
 /// are no-ops if the window it was spawned for has already closed.
 pub fn gp_spawn_window_timer(pb: GpPlayback, opened: &GpWindowOpened) {
-    let (generation, timer, text_channel) =
-        (opened.generation, opened.timer_secs, opened.text_channel);
+    gp_spawn_window_timer_secs(
+        pb,
+        opened.generation,
+        opened.text_channel,
+        opened.timer_secs,
+    );
+}
+
+/// The same, for a window with `timer` seconds left on it -- the full timer
+/// when a round opens, whatever remains when a game is resumed.
+pub fn gp_spawn_window_timer_secs(
+    pb: GpPlayback,
+    generation: u64,
+    text_channel: GenericChannelId,
+    timer: u64,
+) {
     tokio::spawn(async move {
         let guild_id = pb.guild_id;
         if timer > GP_WARNING_SECS {

--- a/crack-core/src/commands/music/gp.rs
+++ b/crack-core/src/commands/music/gp.rs
@@ -781,7 +781,15 @@ impl Data {
         if game.phase != GpPhase::Submitting {
             return Err(CrackedError::WindowClosed);
         }
-        Ok(game.close_window(rng, now))
+        let closed = game.close_window(rng, now);
+        // Closing is a checkpoint: it is the moment a round stops being a set of
+        // submissions and becomes a play order, and the only writer of `phase =
+        // playing` and of `closes_at = None`. Until it lands the rows still say
+        // the window is open until a `closes_at` that has passed, so a resume
+        // during the round's first song would measure the outage from there and
+        // write off a game that was only away for seconds.
+        self.gp_snapshot(&game);
+        Ok(closed)
     }
 
     /// Close the window the timer (or "everyone submitted") was started for.
@@ -798,7 +806,10 @@ impl Data {
         if game.phase != GpPhase::Submitting || game.generation != generation {
             return None;
         }
-        Some(game.close_window(rng, now))
+        let closed = game.close_window(rng, now);
+        // A checkpoint for the same reason as `gp_close_window`.
+        self.gp_snapshot(&game);
+        Some(closed)
     }
 
     /// The 30-second heads-up, if the window it was spawned for is still open.
@@ -839,6 +850,14 @@ impl Data {
     }
 
     /// Remember where a song's message went so the reveal can edit it.
+    ///
+    /// Also a checkpoint, and the only one taken while a song plays. The id is
+    /// what a resume takes the pre-restart dropdown down by, and the checkpoint
+    /// before this one was the end of the *previous* song, when this track had no
+    /// message yet -- so without a write here the restarted game would never
+    /// learn which message to close, and the old one would sit there with a live
+    /// dropdown for the rest of the game, answering every click with a stale
+    /// round.
     pub fn gp_set_track_message(
         &self,
         guild_id: GuildId,
@@ -857,6 +876,7 @@ impl Data {
             .and_then(|r| r.tracks.get_mut(track_idx))
             .ok_or(CrackedError::StaleRound)?;
         t.message = Some((channel, message_id));
+        self.gp_snapshot(&game);
         Ok(())
     }
 
@@ -2340,8 +2360,12 @@ async fn author_display_name(ctx: Context<'_>) -> String {
 }
 
 /// Non-bot members of `vc`, from the cache. Empty if the guild isn't cached
-/// (then the window simply waits for the timer or the host).
+/// (then the window simply waits for the timer or the host). The bot is always
+/// in this channel and is excluded by id, not just by the member lookup, which
+/// answers "human" for anyone the cache is missing.
 fn gp_vc_members(ctx: Context<'_>, vc: ChannelId) -> Vec<UserId> {
+    // Read before the guild: no cache lock is held across the other lookup.
+    let me = ctx.serenity_context().cache.current_user().id;
     let Some(guild) = ctx.guild() else {
         return Vec::new();
     };
@@ -2349,6 +2373,7 @@ fn gp_vc_members(ctx: Context<'_>, vc: ChannelId) -> Vec<UserId> {
         .voice_states
         .iter()
         .filter(|vs| vs.channel_id == Some(vc))
+        .filter(|vs| vs.user_id != me)
         .filter(|vs| guild.members.get(&vs.user_id).is_none_or(|m| !m.user.bot()))
         .map(|vs| vs.user_id)
         .collect()

--- a/crack-core/src/commands/music/gp.rs
+++ b/crack-core/src/commands/music/gp.rs
@@ -98,14 +98,13 @@ pub const GP_MAX_CLIP_LENGTH_SECS: u64 = 300;
 /// parked game itself. Only a backstop: the global track-end handler normally
 /// collects it within milliseconds.
 pub const GP_PARK_GRACE_SECS: u64 = 10;
-/// How long a game may be down before it is not brought back. Measured from the
-/// last time the *bot* saw the game -- a write or a heartbeat -- not from the
-/// game's own clock, so a quiet submission window still counts as seen. Past
-/// this the room has moved on, and a prompt reappearing twenty minutes later is
-/// worse than nothing.
+/// How long a game may be down before it is not brought back. Past this the
+/// room has moved on, and a prompt reappearing twenty minutes later is worse
+/// than nothing. Measured against the last moment the game is known to have
+/// been alive: for an open submission window that is `closes_at`, which needs
+/// no write at all; otherwise it is `last_seen_at`, which a graceful shutdown
+/// stamps on the way down and which a hard crash leaves at the last song's end.
 pub const GP_RESUME_WINDOW_SECS: i64 = 300;
-/// How often a live game says "still here" to the database.
-pub const GP_HEARTBEAT_SECS: u64 = 30;
 /// How much of a song has to have played before a failure counts as a song the
 /// room actually heard, and so as something to score. Below this an `Errored`
 /// track is treated as a dead link: nobody could have guessed it, so nobody is
@@ -1317,16 +1316,6 @@ impl Data {
             .get(game.current_track)?
             .message;
         Some((game.track_start(), old))
-    }
-
-    /// Every game still being played, as (guild, started_at), for the heartbeat.
-    /// A finished or parked game is on its way out and is not kept alive.
-    pub fn gp_live_games(&self) -> Vec<(GuildId, i64)> {
-        self.gp_games
-            .iter()
-            .filter(|g| g.phase != GpPhase::Finished && !g.parked_for_end)
-            .map(|g| (*g.key(), g.started_at))
-            .collect()
     }
 
     /// Who may act in a running game: anyone who has submitted, plus the host, so

--- a/crack-core/src/commands/music/gp_persist.rs
+++ b/crack-core/src/commands/music/gp_persist.rs
@@ -20,14 +20,17 @@
 //! `finished_at` and an outcome. That write happens on every path that removes a
 //! game from the map, `/gp end` included -- it is not a checkpoint, but without
 //! it a game ended on purpose would still look live after a redeploy and come
-//! back. While a game is live the heartbeat bumps its `last_seen_at` every
-//! [`GP_HEARTBEAT_SECS`], so the gap the resume measures is the outage itself and
-//! not how long since somebody last submitted.
+//! back. There is no heartbeat: a graceful shutdown stamps `last_seen_at` on
+//! every live game as it drains, so for a redeploy -- the case that prompted
+//! this -- the gap the resume measures is the outage itself. A hard crash
+//! leaves `last_seen_at` at the last checkpoint, which errs toward not resuming.
 //!
 //! On the way back up, [`gp_resume_guild`] runs from the guild-create handler for
-//! each guild as it arrives. A live game not seen for [`GP_RESUME_WINDOW_SECS`],
-//! or whose voice channel is empty, is marked lost and its scoreboard posted
-//! with a line saying why. Anything else is put back into the map, the bot
+//! each guild as it arrives. A live game is brought back only if it can still be
+//! going: a submission window that is still open, or closed less than
+//! [`GP_RESUME_WINDOW_SECS`] ago by its own `closes_at`; a song whose game was
+//! seen within that long. Anything older, or whose voice channel is empty, is
+//! marked lost and its scoreboard posted with a line saying why. Anything else is put back into the map, the bot
 //! rejoins voice, and the game re-enters its phase: a submission window with
 //! whatever time `closes_at` says is left (or closes at once if that passed), a
 //! song from the top, with the pre-restart song message's dropdown taken down
@@ -35,12 +38,12 @@
 
 use super::gp::{
     gp_after_close, gp_play_track, gp_scoreboard_embed, gp_spawn_window_timer_secs, now, GpClip,
-    GpGame, GpPhase, GpPlayback, GpRound, GpTrack, GP_HEARTBEAT_SECS, GP_RESUME_WINDOW_SECS,
+    GpGame, GpPhase, GpPlayback, GpRound, GpTrack, GP_RESUME_WINDOW_SECS,
 };
 use super::gp_prompts::GpCategory;
 use crate::commands::music_utils::set_global_handlers_with;
 use crate::db::{
-    gp_heartbeat, gp_mark_finished, GpGameRow, GpOutcome, GpPlayerRow, GpRoundRow, GpSaved,
+    gp_mark_finished, gp_touch_live, GpGameRow, GpOutcome, GpPlayerRow, GpRoundRow, GpSaved,
     GpTrackRow,
 };
 use crate::messaging::messages::{
@@ -80,8 +83,8 @@ pub enum GpPersist {
         started_at: i64,
         outcome: GpOutcome,
     },
-    /// These games are still being played.
-    Heartbeat(Vec<(i64, i64)>),
+    /// The process is going down: every live game was alive until now.
+    Stopping,
     /// Reply once everything sent before this has been written.
     Flush(oneshot::Sender<()>),
 }
@@ -115,31 +118,16 @@ pub async fn run_gp_writer(mut rx: mpsc::UnboundedReceiver<GpPersist>, pool: PgP
                 Ok(false) => {},
                 Err(e) => tracing::warn!("gp: marking the game in {guild_id} over: {e}"),
             },
-            GpPersist::Heartbeat(games) => {
-                if let Err(e) = gp_heartbeat(&pool, &games).await {
-                    tracing::warn!("gp: heartbeat: {e}");
-                }
+            GpPersist::Stopping => match gp_touch_live(&pool).await {
+                Ok(n) if n > 0 => tracing::info!("gp: {n} live game(s) stamped for the restart"),
+                Ok(_) => {},
+                Err(e) => tracing::warn!("gp: stamping live games at shutdown: {e}"),
             },
             GpPersist::Flush(ack) => {
                 let _ = ack.send(());
             },
         }
     }
-}
-
-/// Keep the live games' `last_seen_at` fresh for as long as the process runs.
-pub fn spawn_gp_heartbeat(data: Data) {
-    if data.gp_persist.is_none() {
-        return;
-    }
-    tokio::spawn(async move {
-        let mut tick = tokio::time::interval(Duration::from_secs(GP_HEARTBEAT_SECS));
-        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        loop {
-            tick.tick().await;
-            data.gp_heartbeat_tick();
-        }
-    });
 }
 
 impl Data {
@@ -171,24 +159,16 @@ impl Data {
         });
     }
 
-    /// One heartbeat: every game still being played is still here.
-    pub fn gp_heartbeat_tick(&self) {
-        let live: Vec<(i64, i64)> = self
-            .gp_live_games()
-            .into_iter()
-            .map(|(g, s)| (game_id(g), s))
-            .collect();
-        if !live.is_empty() {
-            self.gp_persist_send(GpPersist::Heartbeat(live));
-        }
-    }
-
-    /// Wait until everything sent so far has been written, or `timeout` passes.
-    /// For the shutdown handler, which has a budget.
-    pub async fn gp_flush(&self, timeout: Duration) {
+    /// The process is shutting down: stamp the live games as seen now, then wait
+    /// until everything sent so far has been written, or `timeout` passes. For
+    /// the shutdown handler, which has a budget.
+    pub async fn gp_shutdown(&self, timeout: Duration) {
         let Some(tx) = &self.gp_persist else {
             return;
         };
+        if tx.send(GpPersist::Stopping).is_err() {
+            return;
+        }
         let (ack, done) = oneshot::channel();
         if tx.send(GpPersist::Flush(ack)).is_err() {
             return;
@@ -520,11 +500,19 @@ pub async fn gp_resume_guild(data: &Data, ctx: &SerenityContext, guild: &Guild) 
     };
     let text_channel = game.text_channel;
 
-    let too_late = loaded.last_seen_secs_ago > GP_RESUME_WINDOW_SECS;
+    // Alive until when? An open window says so itself: it was open until
+    // `closes_at` whatever happened to the bot. A song has no such clock, so the
+    // last time the bot wrote or stamped the game stands in.
+    let alive_until = match game.phase {
+        GpPhase::Submitting => game.rounds[game.current_round].closes_at.unwrap_or(0),
+        _ => now() - loaded.last_seen_secs_ago,
+    };
+    let down_for = now() - alive_until;
+    let too_late = down_for > GP_RESUME_WINDOW_SECS;
     let nobody = vc_members(guild, game.voice_channel) == 0;
     if too_late || nobody || game.phase == GpPhase::Finished {
         let why = if too_late {
-            format!("not seen for {}s", loaded.last_seen_secs_ago)
+            format!("gone for {down_for}s")
         } else if nobody {
             "the voice channel is empty".to_string()
         } else {
@@ -874,31 +862,32 @@ mod test {
         }
     }
 
-    #[test]
-    fn without_a_database_nothing_is_sent_and_nothing_panics() {
+    #[tokio::test]
+    async fn without_a_database_nothing_is_sent_and_nothing_panics() {
         let data = Data::default();
         start(&data, &["p0"]);
         data.gp_submit(G, A, "alice".into(), track("a"), &[])
             .unwrap();
-        data.gp_heartbeat_tick();
+        data.gp_shutdown(Duration::from_millis(10)).await;
         data.gp_remove(G);
     }
 
-    #[test]
-    fn the_heartbeat_names_games_still_being_played() {
+    #[tokio::test]
+    async fn shutdown_stamps_the_live_games_and_waits_for_the_writer() {
         let (data, mut rx) = recording();
-        data.gp_heartbeat_tick();
-        assert!(drain(&mut rx).is_empty(), "no games, no heartbeat");
-        start(&data, &["p0"]);
-        data.gp_heartbeat_tick();
+        // Nobody is draining: the flush times out rather than hanging shutdown.
+        let started = std::time::Instant::now();
+        data.gp_shutdown(Duration::from_millis(50)).await;
+        assert!(started.elapsed() >= Duration::from_millis(50));
         match &drain(&mut rx)[..] {
-            [GpPersist::Heartbeat(games)] => assert_eq!(games, &vec![(1, NOW)]),
+            [GpPersist::Stopping, GpPersist::Flush(_)] => {},
             other => panic!("{other:?}"),
         }
-        // Parked by `/gp end`: on its way out, not kept alive.
-        data.gp_park_for_end(G, A, false).unwrap();
-        data.gp_heartbeat_tick();
-        assert!(drain(&mut rx).is_empty());
+        // With the writer's end gone the flush returns at once.
+        drop(rx);
+        let started = std::time::Instant::now();
+        data.gp_shutdown(Duration::from_secs(5)).await;
+        assert!(started.elapsed() < Duration::from_secs(1));
     }
 
     /// Build a game through the real API into a mid-game state, then check the

--- a/crack-core/src/commands/music/gp_persist.rs
+++ b/crack-core/src/commands/music/gp_persist.rs
@@ -2,8 +2,9 @@
 //!
 //! A game lives in [`Data::gp_games`], in memory, and that stays the source of
 //! truth while it runs. It is written down at two moments -- when a song is
-//! submitted and when a song ends -- as a whole-game snapshot into the `gp_*`
-//! tables (see [`crate::db::gp`]). Guesses, likes and votes on the song that is
+//! submitted and when a song ends -- as a snapshot of the game into the `gp_*`
+//! tables (see [`crate::db::gp`], which writes only the rounds that can have
+//! changed since the last one). Guesses, likes and votes on the song that is
 //! playing are not written until it ends: after a resume that song plays again
 //! from the top and the room casts them again, so the worst a crash costs is one
 //! song's worth of guesses that people can re-cast, never a scoreboard.

--- a/crack-core/src/commands/music/gp_persist.rs
+++ b/crack-core/src/commands/music/gp_persist.rs
@@ -1,0 +1,1044 @@
+//! Saving `/gp` games to Postgres, and picking them up after a restart.
+//!
+//! A game lives in [`Data::gp_games`], in memory, and that stays the source of
+//! truth while it runs. It is written down at two moments -- when a song is
+//! submitted and when a song ends -- as a whole-game snapshot into the `gp_*`
+//! tables (see [`crate::db::gp`]). Guesses, likes and votes on the song that is
+//! playing are not written until it ends: after a resume that song plays again
+//! from the top and the room casts them again, so the worst a crash costs is one
+//! song's worth of guesses that people can re-cast, never a scoreboard.
+//!
+//! Nothing on the interaction or songbird path waits on the database. The
+//! `gp_*` mutations on [`Data`] clone the game and send it down a channel; one
+//! writer task per process drains that channel in order, so a later snapshot
+//! can never be overwritten by an earlier one. Shutdown drains the channel
+//! before the pool closes, which fits in Docker's ten-second stop grace because
+//! the queue is almost always already empty.
+//!
+//! A game leaves the live set with a tombstone rather than a snapshot: a
+//! `finished_at` and an outcome. That write happens on every path that removes a
+//! game from the map, `/gp end` included -- it is not a checkpoint, but without
+//! it a game ended on purpose would still look live after a redeploy and come
+//! back. While a game is live the heartbeat bumps its `last_seen_at` every
+//! [`GP_HEARTBEAT_SECS`], so the gap the resume measures is the outage itself and
+//! not how long since somebody last submitted.
+//!
+//! On the way back up, [`gp_resume_guild`] runs from the guild-create handler for
+//! each guild as it arrives. A live game not seen for [`GP_RESUME_WINDOW_SECS`],
+//! or whose voice channel is empty, is marked lost and its scoreboard posted
+//! with a line saying why. Anything else is put back into the map, the bot
+//! rejoins voice, and the game re-enters its phase: a submission window with
+//! whatever time `closes_at` says is left (or closes at once if that passed), a
+//! song from the top, with the pre-restart song message's dropdown taken down
+//! so there are not two live ones for the same song.
+
+use super::gp::{
+    gp_after_close, gp_play_track, gp_scoreboard_embed, gp_spawn_window_timer_secs, now, GpClip,
+    GpGame, GpPhase, GpPlayback, GpRound, GpTrack, GP_HEARTBEAT_SECS, GP_RESUME_WINDOW_SECS,
+};
+use super::gp_prompts::GpCategory;
+use crate::commands::music_utils::set_global_handlers_with;
+use crate::db::{
+    gp_heartbeat, gp_mark_finished, GpGameRow, GpOutcome, GpPlayerRow, GpRoundRow, GpSaved,
+    GpTrackRow,
+};
+use crate::messaging::messages::{
+    GP_LOST, GP_RESUMED, GP_RESUMED_SONG, GP_RESUMED_WINDOW, GP_RESUMED_WINDOW_CLOSED,
+    GP_SCOREBOARD,
+};
+use crate::Data;
+use ::serenity::{
+    all::{ChannelId, GenericChannelId, Guild, GuildId, MessageId, UserId},
+    builder::{CreateComponent, CreateMessage, EditMessage},
+};
+use crack_testing::ResolvedTrack;
+use crack_types::SavedTrack;
+use poise::serenity_prelude::Context as SerenityContext;
+use sqlx::PgPool;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    sync::Arc,
+    time::Duration,
+};
+use tokio::sync::{mpsc, oneshot};
+
+const PHASE_SUBMITTING: &str = "submitting";
+const PHASE_PLAYING: &str = "playing";
+const PHASE_FINISHED: &str = "finished";
+
+/// What the writer task is asked to do. Ordered: the channel is FIFO and there is
+/// one consumer, so a `Flush` answers only once everything before it is written.
+#[derive(Debug)]
+pub enum GpPersist {
+    /// The whole game as it stands.
+    Snapshot(Box<GpSaved>),
+    /// The game is over; take it out of the live set.
+    Finished {
+        guild_id: i64,
+        started_at: i64,
+        outcome: GpOutcome,
+    },
+    /// These games are still being played.
+    Heartbeat(Vec<(i64, i64)>),
+    /// Reply once everything sent before this has been written.
+    Flush(oneshot::Sender<()>),
+}
+
+/// Start the writer. Unbounded on purpose: the senders are synchronous `DashMap`
+/// mutations, some on songbird's event path, and must never wait; the queue is
+/// bounded in practice by how fast a room can submit songs.
+pub fn spawn_gp_writer(pool: PgPool) -> mpsc::UnboundedSender<GpPersist> {
+    let (tx, rx) = mpsc::unbounded_channel();
+    tokio::spawn(run_gp_writer(rx, pool));
+    tx
+}
+
+pub async fn run_gp_writer(mut rx: mpsc::UnboundedReceiver<GpPersist>, pool: PgPool) {
+    while let Some(msg) = rx.recv().await {
+        match msg {
+            GpPersist::Snapshot(saved) => {
+                let guild_id = saved.game.guild_id;
+                match saved.save(&pool).await {
+                    Ok(id) => tracing::trace!("gp: saved game {id} in {guild_id}"),
+                    Err(e) => tracing::warn!("gp: saving the game in {guild_id}: {e}"),
+                }
+            },
+            GpPersist::Finished {
+                guild_id,
+                started_at,
+                outcome,
+            } => match gp_mark_finished(&pool, guild_id, started_at, outcome).await {
+                Ok(true) => tracing::trace!("gp: game in {guild_id} {}", outcome.as_str()),
+                // Nobody ever submitted, so there was no row; or it was already over.
+                Ok(false) => {},
+                Err(e) => tracing::warn!("gp: marking the game in {guild_id} over: {e}"),
+            },
+            GpPersist::Heartbeat(games) => {
+                if let Err(e) = gp_heartbeat(&pool, &games).await {
+                    tracing::warn!("gp: heartbeat: {e}");
+                }
+            },
+            GpPersist::Flush(ack) => {
+                let _ = ack.send(());
+            },
+        }
+    }
+}
+
+/// Keep the live games' `last_seen_at` fresh for as long as the process runs.
+pub fn spawn_gp_heartbeat(data: Data) {
+    if data.gp_persist.is_none() {
+        return;
+    }
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(Duration::from_secs(GP_HEARTBEAT_SECS));
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tick.tick().await;
+            data.gp_heartbeat_tick();
+        }
+    });
+}
+
+impl Data {
+    fn gp_persist_send(&self, msg: GpPersist) {
+        if let Some(tx) = &self.gp_persist {
+            if tx.send(msg).is_err() {
+                tracing::warn!("gp: the persistence writer is gone; game state is not being saved");
+            }
+        }
+    }
+
+    /// Write the game down as it stands now. A no-op without a database.
+    pub(crate) fn gp_snapshot(&self, game: &GpGame) {
+        if self.gp_persist.is_none() {
+            return;
+        }
+        self.gp_persist_send(GpPersist::Snapshot(Box::new(game.to_saved())));
+    }
+
+    /// The game is over. A no-op without a database.
+    pub(crate) fn gp_mark_finished(&self, game: &GpGame, outcome: GpOutcome) {
+        if self.gp_persist.is_none() {
+            return;
+        }
+        self.gp_persist_send(GpPersist::Finished {
+            guild_id: game_id(game.guild_id),
+            started_at: game.started_at,
+            outcome,
+        });
+    }
+
+    /// One heartbeat: every game still being played is still here.
+    pub fn gp_heartbeat_tick(&self) {
+        let live: Vec<(i64, i64)> = self
+            .gp_live_games()
+            .into_iter()
+            .map(|(g, s)| (game_id(g), s))
+            .collect();
+        if !live.is_empty() {
+            self.gp_persist_send(GpPersist::Heartbeat(live));
+        }
+    }
+
+    /// Wait until everything sent so far has been written, or `timeout` passes.
+    /// For the shutdown handler, which has a budget.
+    pub async fn gp_flush(&self, timeout: Duration) {
+        let Some(tx) = &self.gp_persist else {
+            return;
+        };
+        let (ack, done) = oneshot::channel();
+        if tx.send(GpPersist::Flush(ack)).is_err() {
+            return;
+        }
+        if tokio::time::timeout(timeout, done).await.is_err() {
+            tracing::warn!("gp: the game writer did not drain within {timeout:?}");
+        }
+    }
+}
+
+fn game_id(guild_id: GuildId) -> i64 {
+    guild_id.get() as i64
+}
+
+fn user(id: i64) -> UserId {
+    UserId::new(id as u64)
+}
+
+fn chan(id: i64) -> GenericChannelId {
+    GenericChannelId::new(id as u64)
+}
+
+fn message(channel: Option<i64>, msg: Option<i64>) -> Option<(GenericChannelId, MessageId)> {
+    Some((chan(channel?), MessageId::new(msg? as u64)))
+}
+
+/// Why a saved game could not be turned back into one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GpLoadError(pub String);
+
+impl fmt::Display for GpLoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for GpLoadError {}
+
+impl GpGame {
+    /// The game as rows.
+    pub fn to_saved(&self) -> GpSaved {
+        let phase = match self.phase {
+            GpPhase::Submitting => PHASE_SUBMITTING,
+            GpPhase::Playing => PHASE_PLAYING,
+            GpPhase::Finished => PHASE_FINISHED,
+        };
+        let mut players: Vec<GpPlayerRow> = self
+            .players
+            .iter()
+            .map(|(id, name)| GpPlayerRow {
+                user_id: game_user(*id),
+                display_name: name.clone(),
+                score: self.scores.get(id).copied().unwrap_or(0) as i32,
+            })
+            .collect();
+        players.sort_by_key(|p| p.user_id);
+
+        let rounds = self
+            .rounds
+            .iter()
+            .enumerate()
+            .map(|(idx, r)| GpRoundRow {
+                round_idx: idx as i32,
+                prompt: r.prompt.clone(),
+                closes_at: r.closes_at,
+                prompt_channel_id: r.prompt_message.map(|(c, _)| c.get() as i64),
+                prompt_message_id: r.prompt_message.map(|(_, m)| m.get() as i64),
+            })
+            .collect();
+
+        let mut tracks = Vec::new();
+        for (idx, r) in self.rounds.iter().enumerate() {
+            let mut subs: Vec<(&UserId, &ResolvedTrack<'static>)> = r.submissions.iter().collect();
+            subs.sort_by_key(|(id, _)| **id);
+            for (submitter, track) in subs {
+                let saved = SavedTrack::from(track);
+                tracks.push(GpTrackRow {
+                    round_idx: idx as i32,
+                    submitter_id: game_user(*submitter),
+                    position: None,
+                    url: saved.url.clone(),
+                    title: saved.title.clone(),
+                    artist: saved.artist.clone(),
+                    duration_secs: saved.duration_secs(),
+                    play_full: false,
+                    message_channel_id: None,
+                    message_id: None,
+                    guesses: Vec::new(),
+                    likes: Vec::new(),
+                    skip_votes: Vec::new(),
+                    full_votes: Vec::new(),
+                });
+            }
+            for (pos, t) in r.tracks.iter().enumerate() {
+                let saved = SavedTrack::from(&t.track);
+                let mut guesses: Vec<(i64, i64)> = t
+                    .guesses
+                    .iter()
+                    .map(|(a, b)| (game_user(*a), game_user(*b)))
+                    .collect();
+                guesses.sort_unstable();
+                tracks.push(GpTrackRow {
+                    round_idx: idx as i32,
+                    submitter_id: game_user(t.submitter),
+                    position: Some(pos as i32),
+                    url: saved.url.clone(),
+                    title: saved.title.clone(),
+                    artist: saved.artist.clone(),
+                    duration_secs: saved.duration_secs(),
+                    play_full: t.play_full,
+                    message_channel_id: t.message.map(|(c, _)| c.get() as i64),
+                    message_id: t.message.map(|(_, m)| m.get() as i64),
+                    guesses,
+                    likes: sorted_users(&t.likes),
+                    skip_votes: sorted_users(&t.skip_votes),
+                    full_votes: sorted_users(&t.full_votes),
+                });
+            }
+        }
+
+        GpSaved {
+            game: GpGameRow {
+                guild_id: game_id(self.guild_id),
+                started_at: self.started_at,
+                host_id: game_user(self.host),
+                voice_channel_id: self.voice_channel.get() as i64,
+                text_channel_id: self.text_channel.get() as i64,
+                category: self.category.slug().to_string(),
+                phase: phase.to_string(),
+                current_round: self.current_round as i32,
+                current_track: self.current_track as i32,
+                timer_secs: self.timer_secs as i64,
+                clip_start_secs: self.clip.map(|c| c.start.as_secs() as i64),
+                clip_length_secs: self.clip.map(|c| c.length.as_secs() as i64),
+                generation: self.generation as i64,
+            },
+            players,
+            rounds,
+            tracks,
+        }
+    }
+
+    /// A game from its rows. Fails only on rows this code did not write: an
+    /// unknown category or phase, a round index with no round, a position past
+    /// the end of its round.
+    pub fn from_saved(saved: &GpSaved) -> Result<GpGame, GpLoadError> {
+        let g = &saved.game;
+        let category = GpCategory::from_slug(&g.category)
+            .ok_or_else(|| GpLoadError(format!("unknown category {:?}", g.category)))?;
+        let phase = match g.phase.as_str() {
+            PHASE_SUBMITTING => GpPhase::Submitting,
+            PHASE_PLAYING => GpPhase::Playing,
+            PHASE_FINISHED => GpPhase::Finished,
+            other => return Err(GpLoadError(format!("unknown phase {other:?}"))),
+        };
+        let clip = match (g.clip_start_secs, g.clip_length_secs) {
+            (Some(start), Some(length)) => Some(GpClip {
+                start: Duration::from_secs(start.max(0) as u64),
+                length: Duration::from_secs(length.max(0) as u64),
+            }),
+            _ => None,
+        };
+
+        let mut rounds: Vec<GpRound> = Vec::with_capacity(saved.rounds.len());
+        let mut sorted_rounds: Vec<&GpRoundRow> = saved.rounds.iter().collect();
+        sorted_rounds.sort_by_key(|r| r.round_idx);
+        for (expected, r) in sorted_rounds.iter().enumerate() {
+            if r.round_idx as usize != expected {
+                return Err(GpLoadError(format!(
+                    "round {} where round {expected} was expected",
+                    r.round_idx
+                )));
+            }
+            rounds.push(GpRound {
+                prompt: r.prompt.clone(),
+                submissions: HashMap::new(),
+                tracks: Vec::new(),
+                prompt_message: message(r.prompt_channel_id, r.prompt_message_id),
+                closes_at: r.closes_at,
+            });
+        }
+
+        // Tracks in play order: `load_live` orders by position, but do not rely
+        // on it -- `to_saved` may not be the only writer forever.
+        let mut ordered: Vec<&GpTrackRow> = saved.tracks.iter().collect();
+        ordered.sort_by_key(|t| (t.round_idx, t.position.unwrap_or(i32::MAX), t.submitter_id));
+        for t in ordered {
+            let round = rounds.get_mut(t.round_idx as usize).ok_or_else(|| {
+                GpLoadError(format!("track in round {} which has no round", t.round_idx))
+            })?;
+            let submitter = user(t.submitter_id);
+            let resolved = ResolvedTrack::from_saved(
+                &SavedTrack::from_secs(
+                    t.url.clone(),
+                    t.title.clone(),
+                    t.artist.clone(),
+                    t.duration_secs,
+                ),
+                submitter,
+            );
+            match t.position {
+                None => {
+                    round.submissions.insert(submitter, resolved);
+                },
+                Some(pos) => {
+                    if pos as usize != round.tracks.len() {
+                        return Err(GpLoadError(format!(
+                            "round {} track at position {pos} where {} was expected",
+                            t.round_idx,
+                            round.tracks.len()
+                        )));
+                    }
+                    round.tracks.push(GpTrack {
+                        submitter,
+                        track: resolved,
+                        guesses: t
+                            .guesses
+                            .iter()
+                            .map(|(a, b)| (user(*a), user(*b)))
+                            .collect(),
+                        likes: t.likes.iter().map(|u| user(*u)).collect(),
+                        skip_votes: t.skip_votes.iter().map(|u| user(*u)).collect(),
+                        full_votes: t.full_votes.iter().map(|u| user(*u)).collect(),
+                        play_full: t.play_full,
+                        message: message(t.message_channel_id, t.message_id),
+                    });
+                },
+            }
+        }
+
+        let current_round = g.current_round.max(0) as usize;
+        if phase != GpPhase::Finished && current_round >= rounds.len() {
+            return Err(GpLoadError(format!(
+                "current round {current_round} of {}",
+                rounds.len()
+            )));
+        }
+        let current_track = g.current_track.max(0) as usize;
+        if phase == GpPhase::Playing && current_track >= rounds[current_round].tracks.len() {
+            return Err(GpLoadError(format!(
+                "current track {current_track} of {} in round {current_round}",
+                rounds[current_round].tracks.len()
+            )));
+        }
+
+        let mut players = HashMap::new();
+        let mut scores = HashMap::new();
+        for p in &saved.players {
+            players.insert(user(p.user_id), p.display_name.clone());
+            if p.score > 0 {
+                scores.insert(user(p.user_id), p.score as u32);
+            }
+        }
+
+        Ok(GpGame {
+            guild_id: GuildId::new(g.guild_id as u64),
+            started_at: g.started_at,
+            host: user(g.host_id),
+            voice_channel: ChannelId::new(g.voice_channel_id as u64),
+            text_channel: chan(g.text_channel_id),
+            phase,
+            category,
+            rounds,
+            current_round,
+            current_track,
+            timer_secs: g.timer_secs.max(0) as u64,
+            clip,
+            generation: g.generation.max(0) as u64,
+            parked_for_end: false,
+            players,
+            scores,
+        })
+    }
+}
+
+fn game_user(id: UserId) -> i64 {
+    id.get() as i64
+}
+
+fn sorted_users(set: &HashSet<UserId>) -> Vec<i64> {
+    let mut v: Vec<i64> = set.iter().map(|u| game_user(*u)).collect();
+    v.sort_unstable();
+    v
+}
+
+/// The non-bot members of `vc`, from the guild as the gateway just described it.
+fn vc_members(guild: &Guild, vc: ChannelId) -> usize {
+    guild
+        .voice_states
+        .iter()
+        .filter(|vs| vs.channel_id == Some(vc))
+        .filter(|vs| guild.members.get(&vs.user_id).is_none_or(|m| !m.user.bot()))
+        .count()
+}
+
+/// Bring back the guild's live game, if it has one and it is worth bringing
+/// back. Called for every guild as it arrives after a (re)connect; a guild with
+/// a game already in memory, or with nothing saved, is a quick no.
+pub async fn gp_resume_guild(data: &Data, ctx: &SerenityContext, guild: &Guild) {
+    let Some(pool) = data.database_pool.as_ref() else {
+        return;
+    };
+    let guild_id = guild.id;
+    if data.gp_is_active(guild_id) {
+        return;
+    }
+    let loaded = match GpSaved::load_live(pool, game_id(guild_id)).await {
+        Ok(Some(l)) => l,
+        Ok(None) => return,
+        Err(e) => {
+            tracing::warn!("gp: looking for a saved game in {guild_id}: {e}");
+            return;
+        },
+    };
+    let started_at = loaded.saved.game.started_at;
+    let game = match GpGame::from_saved(&loaded.saved) {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::warn!(
+                "gp: the saved game in {guild_id} could not be loaded ({e}); dropping it"
+            );
+            if let Err(e) =
+                gp_mark_finished(pool, game_id(guild_id), started_at, GpOutcome::Lost).await
+            {
+                tracing::warn!("gp: marking the unloadable game in {guild_id} lost: {e}");
+            }
+            return;
+        },
+    };
+    let text_channel = game.text_channel;
+
+    let too_late = loaded.last_seen_secs_ago > GP_RESUME_WINDOW_SECS;
+    let nobody = vc_members(guild, game.voice_channel) == 0;
+    if too_late || nobody || game.phase == GpPhase::Finished {
+        let why = if too_late {
+            format!("not seen for {}s", loaded.last_seen_secs_ago)
+        } else if nobody {
+            "the voice channel is empty".to_string()
+        } else {
+            "it had already finished".to_string()
+        };
+        tracing::info!("gp: not resuming the game in {guild_id}: {why}");
+        if let Err(e) = gp_mark_finished(pool, game_id(guild_id), started_at, GpOutcome::Lost).await
+        {
+            tracing::warn!("gp: marking the game in {guild_id} lost: {e}");
+        }
+        if game.phase != GpPhase::Finished {
+            let scores = game.sorted_scores();
+            let msg = CreateMessage::new()
+                .content(GP_LOST)
+                .embed(gp_scoreboard_embed(&scores, GP_SCOREBOARD));
+            if let Err(e) = text_channel.send_message(&ctx.http, msg).await {
+                tracing::warn!("gp: posting the lost game's scoreboard in {guild_id}: {e}");
+            }
+        }
+        return;
+    }
+
+    let (phase, voice_channel, current_round) =
+        (game.phase, game.voice_channel, game.current_round);
+    let closes_at = game.rounds[current_round].closes_at;
+    if !data.gp_restore(guild_id, game) {
+        // `/gp start` beat us to it; that game's first snapshot closes this row.
+        return;
+    }
+    let call = match data.songbird.join(guild_id, voice_channel).await {
+        Ok(call) => call,
+        Err(e) => {
+            tracing::warn!("gp: rejoining {voice_channel} in {guild_id} to resume: {e}");
+            data.gp_games.remove(&guild_id);
+            if let Err(e) =
+                gp_mark_finished(pool, game_id(guild_id), started_at, GpOutcome::Lost).await
+            {
+                tracing::warn!("gp: marking the game in {guild_id} lost: {e}");
+            }
+            let _ = text_channel
+                .send_message(&ctx.http, CreateMessage::new().content(GP_LOST))
+                .await;
+            return;
+        },
+    };
+    set_global_handlers_with(
+        ctx,
+        Arc::new(data.clone()),
+        call.clone(),
+        guild_id,
+        text_channel,
+    )
+    .await;
+    let pb = GpPlayback {
+        data: Arc::new(data.clone()),
+        http: ctx.http.clone(),
+        call,
+        guild_id,
+    };
+    tracing::info!("gp: resuming the game in {guild_id} in {phase:?}, round {current_round}");
+
+    match phase {
+        GpPhase::Submitting => {
+            let remaining = closes_at.unwrap_or(0) - now();
+            let round_no = current_round + 1;
+            // The generation the restore left in the map is the one the timer
+            // must match; read it back rather than trusting the copy we had.
+            let generation = data
+                .gp_games
+                .get(&guild_id)
+                .map(|g| g.generation)
+                .unwrap_or(0);
+            if remaining <= 0 {
+                announce(
+                    &pb,
+                    text_channel,
+                    &GP_RESUMED_WINDOW_CLOSED.replace("{round}", &round_no.to_string()),
+                )
+                .await;
+                // Bound first: a `ThreadRng` temporary is not `Send`, and the
+                // condition of an `if let` lives across the body's await.
+                let closed = data.gp_close_window_if(guild_id, generation, &mut rand::rng(), now());
+                if let Some(closed) = closed {
+                    if let Err(e) = gp_after_close(pb, closed).await {
+                        tracing::warn!("gp: closing the resumed window in {guild_id}: {e}");
+                    }
+                }
+            } else {
+                announce(
+                    &pb,
+                    text_channel,
+                    &format!(
+                        "{GP_RESUMED_WINDOW} {round_no}, <t:{}:R>.",
+                        closes_at.unwrap_or(0)
+                    ),
+                )
+                .await;
+                gp_spawn_window_timer_secs(pb, generation, text_channel, remaining as u64);
+            }
+        },
+        GpPhase::Playing => {
+            let Some((start, old_message)) = data.gp_resume_playing(guild_id) else {
+                return;
+            };
+            announce(&pb, text_channel, GP_RESUMED_SONG).await;
+            // Restore the one-live-dropdown invariant: the reveal only edits the
+            // message the track remembers, which is about to be the new one.
+            if let Some((c, m)) = old_message {
+                if let Err(e) = c
+                    .edit_message(
+                        &pb.http,
+                        m,
+                        EditMessage::new().components(Vec::<CreateComponent<'_>>::new()),
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        "gp: taking down the pre-restart song message in {guild_id}: {e}"
+                    );
+                }
+            }
+            if let Err(e) = gp_play_track(&pb, start).await {
+                tracing::warn!("gp: restarting the song in {guild_id}: {e}");
+            }
+        },
+        GpPhase::Finished => unreachable!("finished games are not restored"),
+    }
+}
+
+async fn announce(pb: &GpPlayback, text_channel: GenericChannelId, what: &str) {
+    if let Err(e) = text_channel
+        .send_message(
+            &pb.http,
+            CreateMessage::new().content(format!("{GP_RESUMED} {what}")),
+        )
+        .await
+    {
+        tracing::warn!("gp: announcing the resume in {}: {e}", pb.guild_id);
+    }
+}
+
+// ------------------------------------------------------------------
+// Tests: what gets written, and that rows come back as the same game
+// ------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::DataInner;
+    use crack_types::{AuxMetadata, QueryType};
+    use rand::{rngs::StdRng, SeedableRng};
+
+    const G: GuildId = GuildId::new(1);
+    const VC: ChannelId = ChannelId::new(10);
+    const TC: GenericChannelId = GenericChannelId::new(20);
+    const A: UserId = UserId::new(100);
+    const B: UserId = UserId::new(200);
+    const C: UserId = UserId::new(300);
+    const NOW: i64 = 1_700_000_000;
+
+    /// A `Data` whose writes land in a channel instead of a database.
+    fn recording() -> (Data, mpsc::UnboundedReceiver<GpPersist>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let data = Data(Arc::new(DataInner {
+            gp_persist: Some(tx),
+            ..Default::default()
+        }));
+        (data, rx)
+    }
+
+    fn track(title: &str) -> ResolvedTrack<'static> {
+        ResolvedTrack::new(QueryType::VideoLink(format!(
+            "https://www.youtube.com/watch?v={title}"
+        )))
+        .with_metadata(AuxMetadata {
+            title: Some(title.to_string()),
+            artist: Some("artist".into()),
+            duration: Some(Duration::from_secs(180)),
+            source_url: Some(format!("https://www.youtube.com/watch?v={title}")),
+            ..Default::default()
+        })
+    }
+
+    fn start(data: &Data, prompts: &[&str]) {
+        data.gp_start(
+            G,
+            A,
+            "alice".into(),
+            VC,
+            TC,
+            GpCategory::Nostalgia,
+            prompts.iter().map(|s| s.to_string()).collect(),
+            120,
+            Some(GpClip {
+                start: Duration::from_secs(30),
+                length: Duration::from_secs(45),
+            }),
+            NOW,
+        )
+        .unwrap();
+    }
+
+    fn drain(rx: &mut mpsc::UnboundedReceiver<GpPersist>) -> Vec<GpPersist> {
+        let mut v = Vec::new();
+        while let Ok(m) = rx.try_recv() {
+            v.push(m);
+        }
+        v
+    }
+
+    fn snapshot(m: &GpPersist) -> &GpSaved {
+        match m {
+            GpPersist::Snapshot(s) => s,
+            other => panic!("expected a snapshot, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_submission_is_written_and_nothing_before_it_is() {
+        let (data, mut rx) = recording();
+        start(&data, &["p0", "p1"]);
+        assert!(drain(&mut rx).is_empty(), "starting a game writes nothing");
+
+        data.gp_submit(G, B, "bob".into(), track("b"), &[]).unwrap();
+        let msgs = drain(&mut rx);
+        assert_eq!(msgs.len(), 1);
+        let s = snapshot(&msgs[0]);
+        assert_eq!(s.game.guild_id, 1);
+        assert_eq!(s.game.started_at, NOW);
+        assert_eq!(s.game.phase, PHASE_SUBMITTING);
+        assert_eq!(s.rounds.len(), 2);
+        assert_eq!(s.rounds[0].closes_at, Some(NOW + 120));
+        assert_eq!(s.tracks.len(), 1);
+        assert_eq!(s.tracks[0].position, None, "still a submission");
+        assert_eq!(s.tracks[0].submitter_id, 200);
+        assert_eq!(s.tracks[0].title.as_deref(), Some("b"));
+        assert_eq!(s.players.len(), 2, "host and bob");
+
+        // Resubmitting replaces: still one track, new title.
+        data.gp_submit(G, B, "bob".into(), track("b2"), &[])
+            .unwrap();
+        let msgs = drain(&mut rx);
+        let s = snapshot(&msgs[0]);
+        assert_eq!(s.tracks.len(), 1);
+        assert_eq!(s.tracks[0].title.as_deref(), Some("b2"));
+    }
+
+    #[test]
+    fn closing_guessing_and_liking_write_nothing_but_a_song_ending_does() {
+        let (data, mut rx) = recording();
+        start(&data, &["p0"]);
+        data.gp_submit(G, A, "alice".into(), track("a"), &[])
+            .unwrap();
+        data.gp_submit(G, B, "bob".into(), track("b"), &[]).unwrap();
+        drain(&mut rx);
+
+        let closed = data
+            .gp_close_window(G, A, &mut StdRng::seed_from_u64(0), NOW)
+            .unwrap();
+        assert_eq!(closed.count, 2);
+        data.gp_set_track_message(G, 0, 0, TC, MessageId::new(555))
+            .unwrap();
+        let first = data.gp_games.get(&G).unwrap().rounds[0].tracks[0].submitter;
+        let guesser = if first == A { B } else { A };
+        data.gp_record_guess(G, 0, 0, guesser, "x".into(), first)
+            .unwrap();
+        data.gp_toggle_like(G, 0, 0, guesser, "x".into()).unwrap();
+        assert!(
+            drain(&mut rx).is_empty(),
+            "closing, guessing and liking are not checkpoints"
+        );
+
+        data.gp_reveal_and_advance(G, 0, 0, NOW + 200).unwrap();
+        let msgs = drain(&mut rx);
+        assert_eq!(msgs.len(), 1);
+        let s = snapshot(&msgs[0]);
+        assert_eq!(s.game.phase, PHASE_PLAYING);
+        assert_eq!(s.game.current_track, 1);
+        assert_eq!(s.tracks.len(), 2);
+        let t0 = s.tracks.iter().find(|t| t.position == Some(0)).unwrap();
+        assert_eq!(t0.submitter_id, first.get() as i64);
+        assert_eq!(t0.guesses, vec![(guesser.get() as i64, first.get() as i64)]);
+        assert_eq!(t0.likes, vec![guesser.get() as i64]);
+        assert_eq!(t0.message_id, Some(555));
+        let scores: HashMap<i64, i32> = s.players.iter().map(|p| (p.user_id, p.score)).collect();
+        assert_eq!(scores[&(guesser.get() as i64)], 100, "correct guess paid");
+        assert_eq!(scores[&(first.get() as i64)], 10, "one like paid");
+
+        // The last song: the snapshot says finished, and removing the game
+        // afterwards records that it finished.
+        data.gp_reveal_and_advance(G, 0, 1, NOW + 300).unwrap();
+        let msgs = drain(&mut rx);
+        assert_eq!(snapshot(&msgs[0]).game.phase, PHASE_FINISHED);
+        data.gp_remove(G);
+        match &drain(&mut rx)[..] {
+            [GpPersist::Finished {
+                guild_id: 1,
+                started_at: NOW,
+                outcome: GpOutcome::Finished,
+            }] => {},
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn ending_a_game_leaves_a_tombstone_however_it_goes() {
+        // `/gp end` mid-song: parked, then collected by the track-end handler.
+        let (data, mut rx) = recording();
+        start(&data, &["p0"]);
+        data.gp_submit(G, A, "alice".into(), track("a"), &[])
+            .unwrap();
+        drain(&mut rx);
+        data.gp_park_for_end(G, A, false).unwrap();
+        assert!(drain(&mut rx).is_empty(), "parking is not a checkpoint");
+        assert!(data.gp_remove_if_parked(G));
+        match &drain(&mut rx)[..] {
+            [GpPersist::Finished {
+                outcome: GpOutcome::Ended,
+                ..
+            }] => {},
+            other => panic!("{other:?}"),
+        }
+
+        // `/gp end` with nothing playing: removed directly, still "ended".
+        let (data, mut rx) = recording();
+        start(&data, &["p0"]);
+        data.gp_park_for_end(G, A, false).unwrap();
+        data.gp_remove(G);
+        match &drain(&mut rx)[..] {
+            [GpPersist::Finished {
+                outcome: GpOutcome::Ended,
+                ..
+            }] => {},
+            other => panic!("{other:?}"),
+        }
+
+        // Torn down for any other reason.
+        let (data, mut rx) = recording();
+        start(&data, &["p0"]);
+        data.gp_remove(G);
+        match &drain(&mut rx)[..] {
+            [GpPersist::Finished {
+                outcome: GpOutcome::Abandoned,
+                ..
+            }] => {},
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn without_a_database_nothing_is_sent_and_nothing_panics() {
+        let data = Data::default();
+        start(&data, &["p0"]);
+        data.gp_submit(G, A, "alice".into(), track("a"), &[])
+            .unwrap();
+        data.gp_heartbeat_tick();
+        data.gp_remove(G);
+    }
+
+    #[test]
+    fn the_heartbeat_names_games_still_being_played() {
+        let (data, mut rx) = recording();
+        data.gp_heartbeat_tick();
+        assert!(drain(&mut rx).is_empty(), "no games, no heartbeat");
+        start(&data, &["p0"]);
+        data.gp_heartbeat_tick();
+        match &drain(&mut rx)[..] {
+            [GpPersist::Heartbeat(games)] => assert_eq!(games, &vec![(1, NOW)]),
+            other => panic!("{other:?}"),
+        }
+        // Parked by `/gp end`: on its way out, not kept alive.
+        data.gp_park_for_end(G, A, false).unwrap();
+        data.gp_heartbeat_tick();
+        assert!(drain(&mut rx).is_empty());
+    }
+
+    /// Build a game through the real API into a mid-game state, then check the
+    /// rows come back as the same game -- compared as rows, since neither
+    /// `GpGame` nor `ResolvedTrack` compares.
+    #[test]
+    fn a_mid_game_round_trips_through_its_rows() {
+        let (data, mut rx) = recording();
+        start(&data, &["p0", "p1", "p2"]);
+        data.gp_submit(G, A, "alice".into(), track("a0"), &[])
+            .unwrap();
+        data.gp_submit(G, B, "bob".into(), track("b0"), &[])
+            .unwrap();
+        data.gp_submit(G, C, "carol".into(), track("c0"), &[])
+            .unwrap();
+        data.gp_set_prompt_message(G, 0, TC, MessageId::new(1))
+            .unwrap();
+        data.gp_close_window(G, A, &mut StdRng::seed_from_u64(7), NOW)
+            .unwrap();
+        let order: Vec<UserId> = data.gp_games.get(&G).unwrap().rounds[0]
+            .tracks
+            .iter()
+            .map(|t| t.submitter)
+            .collect();
+        // Song 0: everyone else guesses right, one like, then it ends.
+        for u in [A, B, C].into_iter().filter(|u| *u != order[0]) {
+            data.gp_record_guess(G, 0, 0, u, "n".into(), order[0])
+                .unwrap();
+        }
+        let liker = [A, B, C].into_iter().find(|u| *u != order[0]).unwrap();
+        data.gp_toggle_like(G, 0, 0, liker, "n".into()).unwrap();
+        data.gp_set_track_message(G, 0, 0, TC, MessageId::new(2))
+            .unwrap();
+        data.gp_reveal_and_advance(G, 0, 0, NOW + 100).unwrap();
+        // Song 1 is playing: a vote to hear it in full, and a guess nobody has
+        // seen paid yet.
+        let voter = [A, B, C].into_iter().find(|u| *u != order[1]).unwrap();
+        data.gp_vote_full(G, voter, "n".into(), &[A, B, C]).unwrap();
+        data.gp_record_guess(G, 0, 1, voter, "n".into(), order[0])
+            .unwrap();
+        data.gp_set_track_message(G, 0, 1, TC, MessageId::new(3))
+            .unwrap();
+        drain(&mut rx);
+
+        let game = data.gp_games.get(&G).unwrap().clone();
+        let saved = game.to_saved();
+        let back = GpGame::from_saved(&saved).expect("loads");
+        assert_eq!(back.to_saved(), saved);
+
+        // And the things the resume reads off it are what they were.
+        assert_eq!(back.guild_id, G);
+        assert_eq!(back.phase, GpPhase::Playing);
+        assert_eq!((back.current_round, back.current_track), (0, 1));
+        assert_eq!(back.rounds.len(), 3);
+        assert_eq!(back.rounds[0].prompt_message, Some((TC, MessageId::new(1))));
+        assert_eq!(
+            back.rounds[0].tracks[1].message,
+            Some((TC, MessageId::new(3)))
+        );
+        assert_eq!(back.rounds[0].tracks[1].full_votes.len(), 1);
+        assert_eq!(back.rounds[0].tracks[0].likes.len(), 1);
+        assert_eq!(back.rounds[0].tracks[0].guesses.len(), 2);
+        assert_eq!(back.scores, game.scores);
+        assert_eq!(back.players, game.players);
+        assert_eq!(back.clip, game.clip);
+        assert!(!back.parked_for_end);
+        let t = &back.rounds[0].tracks[0].track;
+        assert_eq!(t.get_title(), game.rounds[0].tracks[0].track.get_title());
+        assert_eq!(t.get_url(), game.rounds[0].tracks[0].track.get_url());
+        assert_eq!(
+            t.get_metadata().and_then(|m| m.duration),
+            Some(Duration::from_secs(180))
+        );
+        // The rebuilt song still knows how long it is, so the clip fits to it.
+        let start = back.track_start();
+        assert_eq!(start.clip.map(|c| c.length), Some(Duration::from_secs(45)));
+        assert_eq!(start.players.len(), 3);
+    }
+
+    #[test]
+    fn a_submitting_game_round_trips_with_its_open_window() {
+        let (data, _rx) = recording();
+        start(&data, &["p0", "p1"]);
+        data.gp_submit(G, B, "bob".into(), track("b0"), &[])
+            .unwrap();
+        let game = data.gp_games.get(&G).unwrap().clone();
+        let saved = game.to_saved();
+        let back = GpGame::from_saved(&saved).unwrap();
+        assert_eq!(back.to_saved(), saved);
+        assert_eq!(back.phase, GpPhase::Submitting);
+        assert_eq!(back.rounds[0].closes_at, Some(NOW + 120));
+        assert_eq!(back.rounds[0].submissions.len(), 1);
+        assert!(back.rounds[0].tracks.is_empty());
+        assert_eq!(back.rounds[1].closes_at, None);
+    }
+
+    #[test]
+    fn rows_this_code_would_not_write_are_refused_not_trusted() {
+        let (data, _rx) = recording();
+        start(&data, &["p0"]);
+        data.gp_submit(G, B, "bob".into(), track("b0"), &[])
+            .unwrap();
+        let good = data.gp_games.get(&G).unwrap().to_saved();
+
+        let mut s = good.clone();
+        s.game.category = "🎲 Mixed".into();
+        assert!(
+            GpGame::from_saved(&s).is_err(),
+            "display name is not the slug"
+        );
+
+        let mut s = good.clone();
+        s.game.phase = "paused".into();
+        assert!(GpGame::from_saved(&s).is_err());
+
+        let mut s = good.clone();
+        s.tracks[0].round_idx = 5;
+        assert!(
+            GpGame::from_saved(&s).is_err(),
+            "track in a round that is not there"
+        );
+
+        let mut s = good.clone();
+        s.game.phase = PHASE_PLAYING.into();
+        assert!(
+            GpGame::from_saved(&s).is_err(),
+            "playing with no track in play order"
+        );
+
+        let mut s = good.clone();
+        s.rounds.remove(0);
+        s.tracks.clear();
+        assert!(
+            GpGame::from_saved(&s).is_err(),
+            "current round past the end"
+        );
+
+        // Finished games may point past the last round; that is what finished means.
+        let mut s = good;
+        s.game.phase = PHASE_FINISHED.into();
+        s.game.current_round = 1;
+        assert!(GpGame::from_saved(&s).is_ok());
+    }
+}

--- a/crack-core/src/commands/music/gp_persist.rs
+++ b/crack-core/src/commands/music/gp_persist.rs
@@ -1,8 +1,9 @@
 //! Saving `/gp` games to Postgres, and picking them up after a restart.
 //!
 //! A game lives in [`Data::gp_games`], in memory, and that stays the source of
-//! truth while it runs. It is written down at two moments -- when a song is
-//! submitted and when a song ends -- as a snapshot of the game into the `gp_*`
+//! truth while it runs. It is written down at the four moments its shape
+//! changes -- a song is submitted, the window closes on a round, a song's
+//! message is posted, a song ends -- as a snapshot of the game into the `gp_*`
 //! tables (see [`crate::db::gp`], which writes only the rounds that can have
 //! changed since the last one). Guesses, likes and votes on the song that is
 //! playing are not written until it ends: after a resume that song plays again
@@ -21,9 +22,10 @@
 //! game from the map, `/gp end` included -- it is not a checkpoint, but without
 //! it a game ended on purpose would still look live after a redeploy and come
 //! back. There is no heartbeat: a graceful shutdown stamps `last_seen_at` on
-//! every live game as it drains, so for a redeploy -- the case that prompted
-//! this -- the gap the resume measures is the outage itself. A hard crash
-//! leaves `last_seen_at` at the last checkpoint, which errs toward not resuming.
+//! the games this process is actually running as it drains, so for a redeploy
+//! -- the case that prompted this -- the gap the resume measures is the outage
+//! itself. A hard crash leaves `last_seen_at` at the last checkpoint, which
+//! errs toward not resuming.
 //!
 //! On the way back up, [`gp_resume_guild`] runs from the guild-create handler for
 //! each guild as it arrives. A live game is brought back only if it can still be
@@ -83,8 +85,8 @@ pub enum GpPersist {
         started_at: i64,
         outcome: GpOutcome,
     },
-    /// The process is going down: every live game was alive until now.
-    Stopping,
+    /// The process is going down: the games listed were alive until now.
+    Stopping { guild_ids: Vec<i64> },
     /// Reply once everything sent before this has been written.
     Flush(oneshot::Sender<()>),
 }
@@ -118,7 +120,7 @@ pub async fn run_gp_writer(mut rx: mpsc::UnboundedReceiver<GpPersist>, pool: PgP
                 Ok(false) => {},
                 Err(e) => tracing::warn!("gp: marking the game in {guild_id} over: {e}"),
             },
-            GpPersist::Stopping => match gp_touch_live(&pool).await {
+            GpPersist::Stopping { guild_ids } => match gp_touch_live(&pool, &guild_ids).await {
                 Ok(n) if n > 0 => tracing::info!("gp: {n} live game(s) stamped for the restart"),
                 Ok(_) => {},
                 Err(e) => tracing::warn!("gp: stamping live games at shutdown: {e}"),
@@ -159,14 +161,17 @@ impl Data {
         });
     }
 
-    /// The process is shutting down: stamp the live games as seen now, then wait
-    /// until everything sent so far has been written, or `timeout` passes. For
-    /// the shutdown handler, which has a budget.
+    /// The process is shutting down: stamp this process's live games as seen
+    /// now, then wait until everything sent so far has been written, or
+    /// `timeout` passes. For the shutdown handler, which has a budget.
     pub async fn gp_shutdown(&self, timeout: Duration) {
         let Some(tx) = &self.gp_persist else {
             return;
         };
-        if tx.send(GpPersist::Stopping).is_err() {
+        // Only the games in the map: a live row without one is a leftover, and
+        // vouching for it would keep a game nobody is playing resumable forever.
+        let guild_ids: Vec<i64> = self.gp_games.iter().map(|g| game_id(*g.key())).collect();
+        if tx.send(GpPersist::Stopping { guild_ids }).is_err() {
             return;
         }
         let (ack, done) = oneshot::channel();
@@ -360,15 +365,14 @@ impl GpGame {
                 GpLoadError(format!("track in round {} which has no round", t.round_idx))
             })?;
             let submitter = user(t.submitter_id);
-            let resolved = ResolvedTrack::from_saved(
-                &SavedTrack::from_secs(
-                    t.url.clone(),
-                    t.title.clone(),
-                    t.artist.clone(),
-                    t.duration_secs,
-                ),
-                submitter,
-            );
+            // The submitter is the game's, kept on the `GpTrack` and as the
+            // submissions key; it is deliberately never put on the track itself.
+            let resolved = ResolvedTrack::from_saved(&SavedTrack::from_secs(
+                t.url.clone(),
+                t.title.clone(),
+                t.artist.clone(),
+                t.duration_secs,
+            ));
             match t.position {
                 None => {
                     round.submissions.insert(submitter, resolved);
@@ -455,11 +459,19 @@ fn sorted_users(set: &HashSet<UserId>) -> Vec<i64> {
 }
 
 /// The non-bot members of `vc`, from the guild as the gateway just described it.
-fn vc_members(guild: &Guild, vc: ChannelId) -> usize {
+///
+/// `me` is checked by id rather than left to the member lookup: `guild.members`
+/// arrives truncated for a large guild, and an absent member is read as human so
+/// that a player the payload left out still counts. The bot's own voice state
+/// from the session that just died is usually still in the payload, and counting
+/// it would let the "nobody is left in the channel" check pass on the bot's own
+/// ghost -- resuming the game to an empty room.
+fn vc_members(guild: &Guild, vc: ChannelId, me: UserId) -> usize {
     guild
         .voice_states
         .iter()
         .filter(|vs| vs.channel_id == Some(vc))
+        .filter(|vs| vs.user_id != me)
         .filter(|vs| guild.members.get(&vs.user_id).is_none_or(|m| !m.user.bot()))
         .count()
 }
@@ -509,7 +521,7 @@ pub async fn gp_resume_guild(data: &Data, ctx: &SerenityContext, guild: &Guild) 
     };
     let down_for = now() - alive_until;
     let too_late = down_for > GP_RESUME_WINDOW_SECS;
-    let nobody = vc_members(guild, game.voice_channel) == 0;
+    let nobody = vc_members(guild, game.voice_channel, ctx.cache.current_user().id) == 0;
     if too_late || nobody || game.phase == GpPhase::Finished {
         let why = if too_late {
             format!("gone for {down_for}s")
@@ -519,11 +531,19 @@ pub async fn gp_resume_guild(data: &Data, ctx: &SerenityContext, guild: &Guild) 
             "it had already finished".to_string()
         };
         tracing::info!("gp: not resuming the game in {guild_id}: {why}");
-        if let Err(e) = gp_mark_finished(pool, game_id(guild_id), started_at, GpOutcome::Lost).await
-        {
-            tracing::warn!("gp: marking the game in {guild_id} lost: {e}");
-        }
-        if game.phase != GpPhase::Finished {
+        // Say so only once. `on_guild_create` runs again on every reconnect, and
+        // while the tombstone is not written the row is still live and still
+        // hopeless -- so posting regardless would put a fresh scoreboard in the
+        // channel each time the gateway blinked.
+        let marked =
+            match gp_mark_finished(pool, game_id(guild_id), started_at, GpOutcome::Lost).await {
+                Ok(_) => true,
+                Err(e) => {
+                    tracing::warn!("gp: marking the game in {guild_id} lost: {e}");
+                    false
+                },
+            };
+        if marked && game.phase != GpPhase::Finished {
             let scores = game.sorted_scores();
             let msg = CreateMessage::new()
                 .content(GP_LOST)
@@ -761,7 +781,7 @@ mod test {
     }
 
     #[test]
-    fn closing_guessing_and_liking_write_nothing_but_a_song_ending_does() {
+    fn closing_and_the_song_message_are_written_but_guesses_wait_for_the_song() {
         let (data, mut rx) = recording();
         start(&data, &["p0"]);
         data.gp_submit(G, A, "alice".into(), track("a"), &[])
@@ -769,12 +789,39 @@ mod test {
         data.gp_submit(G, B, "bob".into(), track("b"), &[]).unwrap();
         drain(&mut rx);
 
+        // Closing writes the play order and the phase, so a resume during the
+        // round's first song does not read the passed `closes_at` as an outage.
         let closed = data
             .gp_close_window(G, A, &mut StdRng::seed_from_u64(0), NOW)
             .unwrap();
         assert_eq!(closed.count, 2);
+        let msgs = drain(&mut rx);
+        assert_eq!(msgs.len(), 1);
+        let s = snapshot(&msgs[0]);
+        assert_eq!(s.game.phase, PHASE_PLAYING);
+        assert_eq!(s.rounds[0].closes_at, None, "the window is not open");
+        assert_eq!(
+            s.tracks.iter().filter(|t| t.position.is_some()).count(),
+            2,
+            "both songs have their place in the round"
+        );
+
+        // And the song's message, which is what a resume takes the pre-restart
+        // dropdown down by.
         data.gp_set_track_message(G, 0, 0, TC, MessageId::new(555))
             .unwrap();
+        let msgs = drain(&mut rx);
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(
+            snapshot(&msgs[0])
+                .tracks
+                .iter()
+                .find(|t| t.position == Some(0))
+                .unwrap()
+                .message_id,
+            Some(555)
+        );
+
         let first = data.gp_games.get(&G).unwrap().rounds[0].tracks[0].submitter;
         let guesser = if first == A { B } else { A };
         data.gp_record_guess(G, 0, 0, guesser, "x".into(), first)
@@ -782,7 +829,7 @@ mod test {
         data.gp_toggle_like(G, 0, 0, guesser, "x".into()).unwrap();
         assert!(
             drain(&mut rx).is_empty(),
-            "closing, guessing and liking are not checkpoints"
+            "guessing and liking are not checkpoints"
         );
 
         data.gp_reveal_and_advance(G, 0, 0, NOW + 200).unwrap();
@@ -873,16 +920,30 @@ mod test {
     }
 
     #[tokio::test]
-    async fn shutdown_stamps_the_live_games_and_waits_for_the_writer() {
+    async fn shutdown_stamps_this_process_games_and_waits_for_the_writer() {
         let (data, mut rx) = recording();
         // Nobody is draining: the flush times out rather than hanging shutdown.
         let started = std::time::Instant::now();
         data.gp_shutdown(Duration::from_millis(50)).await;
         assert!(started.elapsed() >= Duration::from_millis(50));
         match &drain(&mut rx)[..] {
-            [GpPersist::Stopping, GpPersist::Flush(_)] => {},
+            [GpPersist::Stopping { guild_ids }, GpPersist::Flush(_)] => {
+                assert!(guild_ids.is_empty(), "no games, nothing to vouch for");
+            },
             other => panic!("{other:?}"),
         }
+
+        // With a game running, that guild -- and only that guild -- is stamped.
+        start(&data, &["p0"]);
+        data.gp_shutdown(Duration::from_millis(10)).await;
+        match &drain(&mut rx)[..] {
+            [GpPersist::Stopping { guild_ids }, GpPersist::Flush(_)] => {
+                assert_eq!(guild_ids, &[1]);
+            },
+            other => panic!("{other:?}"),
+        }
+        data.gp_remove(G);
+        drain(&mut rx);
         // With the writer's end gone the flush returns at once.
         drop(rx);
         let started = std::time::Instant::now();
@@ -967,6 +1028,31 @@ mod test {
         assert_eq!(start.players.len(), 3);
     }
 
+    /// The reveal is the whole game, and a song that names its submitter gives
+    /// it away. The live path deliberately leaves the requester off a game's
+    /// tracks -- the now-playing embed renders the sentinel as "(auto)" -- and a
+    /// song rebuilt after a restart must not put it back, or `/np` would out
+    /// every submitter for the rest of the game.
+    #[test]
+    fn a_song_rebuilt_from_its_rows_does_not_name_its_submitter() {
+        let (data, _rx) = recording();
+        start(&data, &["p0"]);
+        data.gp_submit(G, B, "bob".into(), track("b0"), &[])
+            .unwrap();
+        data.gp_close_window(G, A, &mut StdRng::seed_from_u64(3), NOW)
+            .unwrap();
+        let saved = data.gp_games.get(&G).unwrap().to_saved();
+
+        let back = GpGame::from_saved(&saved).unwrap();
+        let t = &back.rounds[0].tracks[0];
+        assert_eq!(t.submitter, B, "the game still knows whose song it is");
+        assert_eq!(
+            t.track.get_requesting_user(),
+            UserId::new(1),
+            "the song itself does not"
+        );
+    }
+
     #[test]
     fn a_submitting_game_round_trips_with_its_open_window() {
         let (data, _rx) = recording();
@@ -978,6 +1064,11 @@ mod test {
         let back = GpGame::from_saved(&saved).unwrap();
         assert_eq!(back.to_saved(), saved);
         assert_eq!(back.phase, GpPhase::Submitting);
+        assert_eq!(
+            back.rounds[0].submissions[&B].get_requesting_user(),
+            UserId::new(1),
+            "a submission does not name its submitter either"
+        );
         assert_eq!(back.rounds[0].closes_at, Some(NOW + 120));
         assert_eq!(back.rounds[0].submissions.len(), 1);
         assert!(back.rounds[0].tracks.is_empty());

--- a/crack-core/src/commands/music/gp_prompts.rs
+++ b/crack-core/src/commands/music/gp_prompts.rs
@@ -100,6 +100,38 @@ impl GpCategory {
         })
     }
 
+    /// Every category, for [`Self::from_slug`].
+    pub const ALL: [GpCategory; 18] = [
+        Self::Nostalgia,
+        Self::Dangerous,
+        Self::GoodGame,
+        Self::Car,
+        Self::Chill,
+        Self::Emotional,
+        Self::BadMusic,
+        Self::HyperSpecific,
+        Self::Revealing,
+        Self::Chaos,
+        Self::OneWorders,
+        Self::Social,
+        Self::Guilty,
+        Self::Romance,
+        Self::Damage,
+        Self::Funny,
+        Self::Personality,
+        Self::Mixed,
+    ];
+
+    /// A stable name for storage: the prompt-file key, and `mixed` for Mixed.
+    /// Not [`Self::display`], whose emoji and wording are free to change.
+    pub fn slug(self) -> &'static str {
+        self.key().unwrap_or("mixed")
+    }
+
+    pub fn from_slug(slug: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|c| c.slug() == slug)
+    }
+
     /// The display name (with emoji), as Discord shows it.
     pub fn display(self) -> &'static str {
         self.name()
@@ -149,6 +181,15 @@ mod test {
     use super::*;
     use rand::{rngs::StdRng, SeedableRng};
     use std::collections::HashSet;
+
+    #[test]
+    fn every_category_round_trips_through_its_slug() {
+        for c in GpCategory::ALL {
+            assert_eq!(GpCategory::from_slug(c.slug()), Some(c), "{c:?}");
+        }
+        assert_eq!(GpCategory::from_slug("mixed"), Some(GpCategory::Mixed));
+        assert_eq!(GpCategory::from_slug("🎲 Mixed"), None);
+    }
 
     #[test]
     fn prompt_data_is_valid() {

--- a/crack-core/src/commands/music/mod.rs
+++ b/crack-core/src/commands/music/mod.rs
@@ -7,6 +7,7 @@ pub mod dosearch;
 pub mod gambling;
 pub mod get_metadata;
 pub mod gp;
+pub mod gp_persist;
 pub mod gp_prompts;
 pub mod grab;
 pub mod leave;

--- a/crack-core/src/commands/music_utils.rs
+++ b/crack-core/src/commands/music_utils.rs
@@ -4,9 +4,9 @@ use crate::handlers::{IdleHandler, TrackEndHandler};
 use crate::messaging::message::CrackedMessage;
 use crate::poise_ext::PoiseContextExt;
 use crate::CrackedError;
-use crate::{Context, Error};
+use crate::{Context, Data, Error};
 // use crack_testing::ReplyHandleWrapper;
-use poise::serenity_prelude::Mentionable;
+use poise::serenity_prelude::{Context as SerenityContext, Mentionable};
 use serenity::all::{ChannelId, GenericChannelId, GuildId};
 use songbird::{Call, Event, TrackEvent};
 use std::{
@@ -23,7 +23,26 @@ pub async fn set_global_handlers(
     guild_id: GuildId,
     channel_id: GenericChannelId,
 ) {
-    let data = ctx.data();
+    set_global_handlers_with(
+        ctx.serenity_context(),
+        ctx.data(),
+        call,
+        guild_id,
+        channel_id,
+    )
+    .await
+}
+
+/// The same, from outside a command -- a `/gp` game being resumed after a
+/// restart joins voice from the guild-create handler, where there is no poise
+/// context to hand over.
+pub async fn set_global_handlers_with(
+    serenity_ctx: &SerenityContext,
+    data: Arc<Data>,
+    call: Arc<Mutex<Call>>,
+    guild_id: GuildId,
+    channel_id: GenericChannelId,
+) {
     let mut handler = call.lock().await;
 
     handler.remove_all_global_events();
@@ -38,7 +57,7 @@ pub async fn set_global_handlers(
         handler.add_global_event(
             Event::Periodic(Duration::from_secs(60), None),
             IdleHandler {
-                serenity_ctx: Arc::new(ctx.serenity_context().clone()),
+                serenity_ctx: Arc::new(serenity_ctx.clone()),
                 guild_id,
                 channel_id,
                 limit: timeout as usize,
@@ -52,10 +71,10 @@ pub async fn set_global_handlers(
         Event::Track(TrackEvent::End),
         TrackEndHandler {
             guild_id,
-            cache: ctx.serenity_context().cache.clone(),
-            http: ctx.serenity_context().http.clone(),
+            cache: serenity_ctx.cache.clone(),
+            http: serenity_ctx.http.clone(),
             call: call.clone(),
-            data: ctx.data().clone(),
+            data,
         },
     );
 

--- a/crack-core/src/config.rs
+++ b/crack-core/src/config.rs
@@ -281,7 +281,6 @@ pub async fn poise_framework(
         gp_persist,
         ..Default::default()
     }));
-    crate::commands::music::gp_persist::spawn_gp_heartbeat(data.clone());
 
     // No MESSAGE_CONTENT. The bot is Discord-verified without it, and it is not
     // coming back for an application in 100+ guilds without a review. Message
@@ -378,7 +377,7 @@ pub async fn poise_framework(
         // Whatever a `/gp` game has queued for the database goes first: the pool
         // is closed below, and a game written down is one a redeploy does not
         // end. Bounded, because Docker's stop grace is ten seconds in total.
-        data2.gp_flush(Duration::from_secs(5)).await;
+        data2.gp_shutdown(Duration::from_secs(5)).await;
         let guilds = data2.guild_settings_map.read().await.clone();
         let pool = data2.clone().database_pool.clone();
         let mut saved_guilds = Vec::with_capacity(guilds.len());

--- a/crack-core/src/config.rs
+++ b/crack-core/src/config.rs
@@ -263,6 +263,12 @@ pub async fn poise_framework(
         songbird::Config::default().decode_mode(DecodeMode::Decode(Default::default()));
     let manager: Arc<Songbird> = songbird::Songbird::serenity_from_config(songbird_config);
 
+    // `/gp` games are written to the database as they run, so a restart does not
+    // end them. Without a database the game runs in memory, as it always has.
+    let gp_persist = database_pool
+        .clone()
+        .map(crate::commands::music::gp_persist::spawn_gp_writer);
+
     let cloned_map = guild_settings_map.clone();
     let data = Data(Arc::new(DataInner {
         phone_data: PhoneCodeData::default(),
@@ -272,8 +278,10 @@ pub async fn poise_framework(
         event_log_async,
         database_pool,
         db_channel,
+        gp_persist,
         ..Default::default()
     }));
+    crate::commands::music::gp_persist::spawn_gp_heartbeat(data.clone());
 
     // No MESSAGE_CONTENT. The bot is Discord-verified without it, and it is not
     // coming back for an application in 100+ guilds without a review. Message
@@ -367,6 +375,10 @@ pub async fn poise_framework(
         }
 
         tracing::warn!("Received Ctrl-C, shutting down...");
+        // Whatever a `/gp` game has queued for the database goes first: the pool
+        // is closed below, and a game written down is one a redeploy does not
+        // end. Bounded, because Docker's stop grace is ten seconds in total.
+        data2.gp_flush(Duration::from_secs(5)).await;
         let guilds = data2.guild_settings_map.read().await.clone();
         let pool = data2.clone().database_pool.clone();
         let mut saved_guilds = Vec::with_capacity(guilds.len());

--- a/crack-core/src/db/gp.rs
+++ b/crack-core/src/db/gp.rs
@@ -1,12 +1,15 @@
 //! Rows for a `/gp` game -- see `migrations/20260908120000_gp_game.sql`.
 //!
 //! [`GpSaved`] is a whole game as rows: the game, its players, its rounds and
-//! every song with its guesses, likes and votes. [`GpSaved::save`] writes all
-//! of it in one transaction and is idempotent, so the caller can hand it the
-//! game as it stands at any moment and the tables end up describing exactly
-//! that. It is written a handful of statements at a time whatever the size of
-//! the game, because every table is loaded through `UNNEST` in one statement
-//! rather than a row at a time.
+//! every song with its guesses, likes and votes. [`GpSaved::save`] takes the
+//! game as it stands at any moment and, in one transaction, brings the tables
+//! to exactly that. It is a handful of statements whatever the size of the
+//! game, because every table is loaded through `UNNEST` in one statement rather
+//! than a row at a time, and it does not grow with the game either: a round is
+//! immutable once the game has moved past it, so only the songs and reactions
+//! of the rounds that can have changed since the last save are rewritten (see
+//! [`GpSaved::changed_rounds`]). Late in a 25-player, 20-round game that is a
+//! few hundred rows per save instead of the twelve thousand the whole game is.
 //!
 //! Nothing here knows about the in-memory game; `commands::music::gp_persist`
 //! converts in both directions. Keeping the persisted shape its own set of
@@ -116,6 +119,26 @@ const VOTE_SKIP: &str = "skip";
 const VOTE_FULL: &str = "full";
 
 impl GpSaved {
+    /// The rounds whose songs and reactions can differ from the last save: the
+    /// current one, and the one before it.
+    ///
+    /// A guess, like or vote is refused for anything but the song playing, and a
+    /// submission for anything but the open window, so a round is frozen once the
+    /// game moves past it. The one before the current round is included because
+    /// the save that happens when a round's last song ends runs *after* the game
+    /// has advanced: that finished song's payout and guesses belong to the round
+    /// just left. Players and rounds are always written whole -- they are one
+    /// row each and the scores live on the players.
+    ///
+    /// Every save since a game's first submission has covered its then-current
+    /// round, so rows for earlier rounds are already exactly right. A save from
+    /// anywhere else -- something that has not written every earlier round as
+    /// it went -- would need to write the whole game; nothing does that today.
+    pub fn changed_rounds(&self) -> std::ops::RangeInclusive<i32> {
+        let cur = self.game.current_round;
+        (cur - 1).max(0)..=cur
+    }
+
     /// Write the game as it stands. Returns the `gp_game.id`.
     ///
     /// Any *other* live row for the guild is closed as lost first: two games
@@ -234,11 +257,19 @@ impl GpSaved {
         Ok(())
     }
 
+    fn changed_tracks(&self) -> Vec<&GpTrackRow> {
+        let rounds = self.changed_rounds();
+        self.tracks
+            .iter()
+            .filter(|t| rounds.contains(&t.round_idx))
+            .collect()
+    }
+
     async fn save_tracks(&self, tx: &mut Transaction<'_, Postgres>, id: i64) -> sqlx::Result<()> {
-        if self.tracks.is_empty() {
+        let t = self.changed_tracks();
+        if t.is_empty() {
             return Ok(());
         }
-        let t = &self.tracks;
         let round_idxs: Vec<i32> = t.iter().map(|x| x.round_idx).collect();
         let submitters: Vec<i64> = t.iter().map(|x| x.submitter_id).collect();
         let positions: Vec<Option<i32>> = t.iter().map(|x| x.position).collect();
@@ -284,28 +315,46 @@ impl GpSaved {
         Ok(())
     }
 
-    /// Guesses, likes and votes: replaced wholesale. A like can be taken back and
-    /// a guess changed, so the sets are rewritten rather than merged; they are
-    /// small, and this keeps the tables equal to the game rather than a superset.
+    /// Guesses, likes and votes of the changed rounds: replaced wholesale. A like
+    /// can be taken back and a guess changed, so the sets are rewritten rather
+    /// than merged; within two rounds they are small, and this keeps the tables
+    /// equal to the game rather than a superset.
     async fn save_reactions(
         &self,
         tx: &mut Transaction<'_, Postgres>,
         id: i64,
     ) -> sqlx::Result<()> {
-        sqlx::query!("DELETE FROM gp_guess WHERE game_id = $1", id)
-            .execute(&mut **tx)
-            .await?;
-        sqlx::query!("DELETE FROM gp_like WHERE game_id = $1", id)
-            .execute(&mut **tx)
-            .await?;
-        sqlx::query!("DELETE FROM gp_vote WHERE game_id = $1", id)
-            .execute(&mut **tx)
-            .await?;
+        let rounds = self.changed_rounds();
+        let (first, last) = (*rounds.start(), *rounds.end());
+        sqlx::query!(
+            "DELETE FROM gp_guess WHERE game_id = $1 AND round_idx BETWEEN $2 AND $3",
+            id,
+            first,
+            last
+        )
+        .execute(&mut **tx)
+        .await?;
+        sqlx::query!(
+            "DELETE FROM gp_like WHERE game_id = $1 AND round_idx BETWEEN $2 AND $3",
+            id,
+            first,
+            last
+        )
+        .execute(&mut **tx)
+        .await?;
+        sqlx::query!(
+            "DELETE FROM gp_vote WHERE game_id = $1 AND round_idx BETWEEN $2 AND $3",
+            id,
+            first,
+            last
+        )
+        .execute(&mut **tx)
+        .await?;
 
         let mut g = (Vec::new(), Vec::new(), Vec::new(), Vec::new());
         let mut l = (Vec::new(), Vec::new(), Vec::new());
         let mut v = (Vec::new(), Vec::new(), Vec::new(), Vec::new());
-        for t in &self.tracks {
+        for t in self.changed_tracks() {
             for (guesser, guessed) in &t.guesses {
                 g.0.push(t.round_idx);
                 g.1.push(t.submitter_id);
@@ -742,6 +791,82 @@ mod tests {
                 .fetch_one(&pool)
                 .await?;
         assert_eq!(outcome.as_deref(), Some("finished"));
+        Ok(())
+    }
+
+    #[test]
+    fn the_changed_rounds_are_the_current_one_and_the_one_before() {
+        let mut s = saved(1, 1);
+        assert_eq!(s.changed_rounds(), 0..=0);
+        s.game.current_round = 1;
+        assert_eq!(s.changed_rounds(), 0..=1);
+        s.game.current_round = 7;
+        assert_eq!(s.changed_rounds(), 6..=7);
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
+    async fn only_the_rounds_that_can_have_changed_are_rewritten(pool: PgPool) -> sqlx::Result<()> {
+        // Round 0 is played out and the game has moved on to round 1: the save
+        // at round 0's last song end covers both rounds.
+        let mut s = saved(7, 1_700_000_000);
+        s.rounds.push(GpRoundRow {
+            round_idx: 2,
+            prompt: "p2".into(),
+            closes_at: None,
+            prompt_channel_id: None,
+            prompt_message_id: None,
+        });
+        s.game.phase = "submitting".into();
+        s.game.current_round = 1;
+        s.tracks = vec![track(0, 100, Some(0)), track(0, 200, Some(1))];
+        s.tracks[0].guesses = vec![(200, 100)];
+        s.tracks[0].likes = vec![200];
+        s.tracks[1].guesses = vec![(100, 200)];
+        s.save(&pool).await?;
+        assert_eq!(GpSaved::load_live(&pool, 7).await?.unwrap().saved, s);
+
+        // Two rounds later. Rows this struct carries for round 0 are now stale
+        // by construction -- a like removed, a guess changed, a track gone --
+        // and none of it may reach the table, because round 0 is frozen.
+        s.game.current_round = 2;
+        s.tracks[0].likes.clear();
+        s.tracks[0].guesses = vec![(200, 200)];
+        s.tracks.remove(1);
+        s.tracks.push(track(1, 100, Some(0)));
+        s.tracks.push(track(2, 300, None));
+        s.tracks[1].likes = vec![300];
+        s.save(&pool).await?;
+
+        let loaded = GpSaved::load_live(&pool, 7).await?.unwrap().saved;
+        let r0: Vec<&GpTrackRow> = loaded.tracks.iter().filter(|t| t.round_idx == 0).collect();
+        assert_eq!(r0.len(), 2, "round 0's tracks are as first written");
+        assert_eq!(r0[0].guesses, vec![(200, 100)]);
+        assert_eq!(r0[0].likes, vec![200]);
+        assert_eq!(r0[1].guesses, vec![(100, 200)]);
+        let r1: Vec<&GpTrackRow> = loaded.tracks.iter().filter(|t| t.round_idx == 1).collect();
+        assert_eq!(r1.len(), 1);
+        assert_eq!(r1[0].likes, vec![300]);
+        assert_eq!(
+            loaded.tracks.iter().filter(|t| t.round_idx == 2).count(),
+            1,
+            "the open round's submission is written"
+        );
+
+        // And within the changed rounds a like taken back is still gone.
+        s.tracks[1].likes.clear();
+        s.save(&pool).await?;
+        let loaded = GpSaved::load_live(&pool, 7).await?.unwrap().saved;
+        assert!(loaded
+            .tracks
+            .iter()
+            .find(|t| t.round_idx == 1)
+            .unwrap()
+            .likes
+            .is_empty());
         Ok(())
     }
 

--- a/crack-core/src/db/gp.rs
+++ b/crack-core/src/db/gp.rs
@@ -605,13 +605,27 @@ pub async fn gp_mark_finished(
     Ok(done)
 }
 
-/// Every live game was alive until now. For the shutdown handler: one bot runs
+/// The named games were alive until now. For the shutdown handler: one bot runs
 /// every game, so on its way down it can vouch for all of them at once, and the
 /// resume then measures the outage rather than the time since the last song.
-pub async fn gp_touch_live(pool: &PgPool) -> sqlx::Result<u64> {
-    let done = sqlx::query!("UPDATE gp_game SET last_seen_at = now() WHERE finished_at IS NULL")
-        .execute(pool)
-        .await?;
+///
+/// Scoped to the guilds whose games are actually in memory, never to every live
+/// row. A row can outlive its game -- the load that would have resumed it hit a
+/// database error, or the write that would have marked it over did -- and
+/// stamping one of those would keep a game nobody is playing permanently
+/// resumable: every later shutdown would refresh it, and a restart days on would
+/// find it seconds old, join voice and play it back at whoever is in the channel.
+pub async fn gp_touch_live(pool: &PgPool, guild_ids: &[i64]) -> sqlx::Result<u64> {
+    if guild_ids.is_empty() {
+        return Ok(0);
+    }
+    let done = sqlx::query!(
+        r#"UPDATE gp_game SET last_seen_at = now()
+           WHERE finished_at IS NULL AND guild_id = ANY($1)"#,
+        guild_ids,
+    )
+    .execute(pool)
+    .await?;
     Ok(done.rows_affected())
 }
 
@@ -638,6 +652,16 @@ mod tests {
             skip_votes: Vec::new(),
             full_votes: Vec::new(),
         }
+    }
+
+    async fn seen_secs_ago(pool: &PgPool, guild_id: i64) -> sqlx::Result<i64> {
+        sqlx::query_scalar!(
+            r#"SELECT EXTRACT(EPOCH FROM now() - last_seen_at)::bigint AS "ago!"
+               FROM gp_game WHERE guild_id = $1"#,
+            guild_id,
+        )
+        .fetch_one(pool)
+        .await
     }
 
     fn saved(guild_id: i64, started_at: i64) -> GpSaved {
@@ -866,23 +890,31 @@ mod tests {
         not(feature = "db-tests"),
         ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
     )]
-    async fn shutdown_stamps_live_games_and_leaves_finished_ones(pool: PgPool) -> sqlx::Result<()> {
+    async fn shutdown_stamps_this_process_games_and_leaves_the_rest(
+        pool: PgPool,
+    ) -> sqlx::Result<()> {
         saved(5, 1_700_000_000).save(&pool).await?;
         saved(6, 1_700_000_000).save(&pool).await?;
+        // 7 is live in the table but not in the bot's memory: a leftover from a
+        // game whose tombstone never landed.
+        saved(7, 1_700_000_000).save(&pool).await?;
         gp_mark_finished(&pool, 6, 1_700_000_000, GpOutcome::Ended).await?;
         sqlx::query!("UPDATE gp_game SET last_seen_at = now() - interval '10 minutes'")
             .execute(&pool)
             .await?;
-        assert_eq!(gp_touch_live(&pool).await?, 1);
+        assert_eq!(gp_touch_live(&pool, &[5, 6]).await?, 1);
         let five = GpSaved::load_live(&pool, 5).await?.expect("live");
         assert!(five.last_seen_secs_ago < 5);
-        let six: i64 = sqlx::query_scalar!(
-            r#"SELECT EXTRACT(EPOCH FROM now() - last_seen_at)::bigint AS "ago!"
-               FROM gp_game WHERE guild_id = 6"#
-        )
-        .fetch_one(&pool)
-        .await?;
-        assert!(six > 500, "a finished game is not touched");
+        assert!(
+            seen_secs_ago(&pool, 6).await? > 500,
+            "a finished game is not touched"
+        );
+        assert!(
+            seen_secs_ago(&pool, 7).await? > 500,
+            "nor is a live row this process was not running"
+        );
+        // And with nothing running, nothing is stamped at all.
+        assert_eq!(gp_touch_live(&pool, &[]).await?, 0);
         Ok(())
     }
 }

--- a/crack-core/src/db/gp.rs
+++ b/crack-core/src/db/gp.rs
@@ -605,22 +605,13 @@ pub async fn gp_mark_finished(
     Ok(done)
 }
 
-/// "Still here": bump `last_seen_at` on the live rows for these games.
-pub async fn gp_heartbeat(pool: &PgPool, games: &[(i64, i64)]) -> sqlx::Result<u64> {
-    if games.is_empty() {
-        return Ok(0);
-    }
-    let guilds: Vec<i64> = games.iter().map(|(g, _)| *g).collect();
-    let starts: Vec<i64> = games.iter().map(|(_, s)| *s).collect();
-    let done = sqlx::query!(
-        r#"UPDATE gp_game SET last_seen_at = now()
-           WHERE finished_at IS NULL
-             AND (guild_id, started_at) IN (SELECT * FROM UNNEST($1::bigint[], $2::bigint[]))"#,
-        &guilds,
-        &starts,
-    )
-    .execute(pool)
-    .await?;
+/// Every live game was alive until now. For the shutdown handler: one bot runs
+/// every game, so on its way down it can vouch for all of them at once, and the
+/// resume then measures the outage rather than the time since the last song.
+pub async fn gp_touch_live(pool: &PgPool) -> sqlx::Result<u64> {
+    let done = sqlx::query!("UPDATE gp_game SET last_seen_at = now() WHERE finished_at IS NULL")
+        .execute(pool)
+        .await?;
     Ok(done.rows_affected())
 }
 
@@ -875,18 +866,23 @@ mod tests {
         not(feature = "db-tests"),
         ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
     )]
-    async fn heartbeat_touches_only_the_named_live_games(pool: PgPool) -> sqlx::Result<()> {
+    async fn shutdown_stamps_live_games_and_leaves_finished_ones(pool: PgPool) -> sqlx::Result<()> {
         saved(5, 1_700_000_000).save(&pool).await?;
         saved(6, 1_700_000_000).save(&pool).await?;
+        gp_mark_finished(&pool, 6, 1_700_000_000, GpOutcome::Ended).await?;
         sqlx::query!("UPDATE gp_game SET last_seen_at = now() - interval '10 minutes'")
             .execute(&pool)
             .await?;
-        assert_eq!(gp_heartbeat(&pool, &[(5, 1_700_000_000), (7, 1)]).await?, 1);
+        assert_eq!(gp_touch_live(&pool).await?, 1);
         let five = GpSaved::load_live(&pool, 5).await?.expect("live");
-        let six = GpSaved::load_live(&pool, 6).await?.expect("live");
         assert!(five.last_seen_secs_ago < 5);
-        assert!(six.last_seen_secs_ago > 500);
-        assert_eq!(gp_heartbeat(&pool, &[]).await?, 0);
+        let six: i64 = sqlx::query_scalar!(
+            r#"SELECT EXTRACT(EPOCH FROM now() - last_seen_at)::bigint AS "ago!"
+               FROM gp_game WHERE guild_id = 6"#
+        )
+        .fetch_one(&pool)
+        .await?;
+        assert!(six > 500, "a finished game is not touched");
         Ok(())
     }
 }

--- a/crack-core/src/db/gp.rs
+++ b/crack-core/src/db/gp.rs
@@ -1,0 +1,767 @@
+//! Rows for a `/gp` game -- see `migrations/20260908120000_gp_game.sql`.
+//!
+//! [`GpSaved`] is a whole game as rows: the game, its players, its rounds and
+//! every song with its guesses, likes and votes. [`GpSaved::save`] writes all
+//! of it in one transaction and is idempotent, so the caller can hand it the
+//! game as it stands at any moment and the tables end up describing exactly
+//! that. It is written a handful of statements at a time whatever the size of
+//! the game, because every table is loaded through `UNNEST` in one statement
+//! rather than a row at a time.
+//!
+//! Nothing here knows about the in-memory game; `commands::music::gp_persist`
+//! converts in both directions. Keeping the persisted shape its own set of
+//! plain types is what lets a later write-behind send the same rows.
+
+use sqlx::{PgPool, Postgres, Transaction};
+
+/// How a game left the live set.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GpOutcome {
+    /// Every round played.
+    Finished,
+    /// `/gp end`.
+    Ended,
+    /// Torn down for any other reason: a message that could not be posted, the
+    /// bot removed from voice.
+    Abandoned,
+    /// Was live when the bot went down and was not resumed: too long an outage,
+    /// or nobody left in the voice channel.
+    Lost,
+}
+
+impl GpOutcome {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Finished => "finished",
+            Self::Ended => "ended",
+            Self::Abandoned => "abandoned",
+            Self::Lost => "lost",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GpGameRow {
+    pub guild_id: i64,
+    /// Unix seconds of `/gp start`; with `guild_id`, the game's identity.
+    pub started_at: i64,
+    pub host_id: i64,
+    pub voice_channel_id: i64,
+    pub text_channel_id: i64,
+    pub category: String,
+    /// `submitting` | `playing` | `finished`
+    pub phase: String,
+    pub current_round: i32,
+    pub current_track: i32,
+    pub timer_secs: i64,
+    pub clip_start_secs: Option<i64>,
+    pub clip_length_secs: Option<i64>,
+    pub generation: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GpPlayerRow {
+    pub user_id: i64,
+    pub display_name: String,
+    pub score: i32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GpRoundRow {
+    pub round_idx: i32,
+    pub prompt: String,
+    pub closes_at: Option<i64>,
+    pub prompt_channel_id: Option<i64>,
+    pub prompt_message_id: Option<i64>,
+}
+
+/// A song in a round, with everything the room did to it. `position` is `None`
+/// while it is still a submission in an open window.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GpTrackRow {
+    pub round_idx: i32,
+    pub submitter_id: i64,
+    pub position: Option<i32>,
+    pub url: String,
+    pub title: Option<String>,
+    pub artist: Option<String>,
+    pub duration_secs: Option<i64>,
+    pub play_full: bool,
+    pub message_channel_id: Option<i64>,
+    pub message_id: Option<i64>,
+    /// (guesser, guessed submitter)
+    pub guesses: Vec<(i64, i64)>,
+    pub likes: Vec<i64>,
+    pub skip_votes: Vec<i64>,
+    pub full_votes: Vec<i64>,
+}
+
+/// A whole game as rows.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GpSaved {
+    pub game: GpGameRow,
+    pub players: Vec<GpPlayerRow>,
+    pub rounds: Vec<GpRoundRow>,
+    pub tracks: Vec<GpTrackRow>,
+}
+
+/// A live game as loaded, with how long ago the bot last saw it.
+#[derive(Clone, Debug)]
+pub struct GpLoaded {
+    pub saved: GpSaved,
+    pub last_seen_secs_ago: i64,
+}
+
+const VOTE_SKIP: &str = "skip";
+const VOTE_FULL: &str = "full";
+
+impl GpSaved {
+    /// Write the game as it stands. Returns the `gp_game.id`.
+    ///
+    /// Any *other* live row for the guild is closed as lost first: two games
+    /// cannot run in one guild, so it can only be a leftover from a game that
+    /// died before it was written down as over.
+    pub async fn save(&self, pool: &PgPool) -> sqlx::Result<i64> {
+        let mut tx = pool.begin().await?;
+        let g = &self.game;
+
+        sqlx::query!(
+            r#"UPDATE gp_game
+               SET finished_at = now(), outcome = 'lost'
+               WHERE guild_id = $1 AND finished_at IS NULL AND started_at <> $2"#,
+            g.guild_id,
+            g.started_at,
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        let id = sqlx::query_scalar!(
+            r#"INSERT INTO gp_game (
+                   guild_id, started_at, host_id, voice_channel_id, text_channel_id,
+                   category, phase, current_round, current_track, timer_secs,
+                   clip_start_secs, clip_length_secs, generation, last_seen_at
+               )
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, now())
+               ON CONFLICT (guild_id, started_at) DO UPDATE SET
+                   phase = EXCLUDED.phase,
+                   current_round = EXCLUDED.current_round,
+                   current_track = EXCLUDED.current_track,
+                   generation = EXCLUDED.generation,
+                   text_channel_id = EXCLUDED.text_channel_id,
+                   last_seen_at = now()
+               RETURNING id"#,
+            g.guild_id,
+            g.started_at,
+            g.host_id,
+            g.voice_channel_id,
+            g.text_channel_id,
+            g.category,
+            g.phase,
+            g.current_round,
+            g.current_track,
+            g.timer_secs,
+            g.clip_start_secs,
+            g.clip_length_secs,
+            g.generation,
+        )
+        .fetch_one(&mut *tx)
+        .await?;
+
+        self.save_players(&mut tx, id).await?;
+        self.save_rounds(&mut tx, id).await?;
+        self.save_tracks(&mut tx, id).await?;
+        self.save_reactions(&mut tx, id).await?;
+
+        if g.phase == "finished" {
+            mark_finished_in(&mut tx, g.guild_id, g.started_at, GpOutcome::Finished).await?;
+        }
+        tx.commit().await?;
+        Ok(id)
+    }
+
+    async fn save_players(&self, tx: &mut Transaction<'_, Postgres>, id: i64) -> sqlx::Result<()> {
+        if self.players.is_empty() {
+            return Ok(());
+        }
+        let user_ids: Vec<i64> = self.players.iter().map(|p| p.user_id).collect();
+        let names: Vec<String> = self
+            .players
+            .iter()
+            .map(|p| p.display_name.clone())
+            .collect();
+        let scores: Vec<i32> = self.players.iter().map(|p| p.score).collect();
+        sqlx::query!(
+            r#"INSERT INTO gp_player (game_id, user_id, display_name, score)
+               SELECT $1, * FROM UNNEST($2::bigint[], $3::text[], $4::int[])
+               ON CONFLICT (game_id, user_id) DO UPDATE SET
+                   display_name = EXCLUDED.display_name,
+                   score = EXCLUDED.score"#,
+            id,
+            &user_ids,
+            &names,
+            &scores,
+        )
+        .execute(&mut **tx)
+        .await?;
+        Ok(())
+    }
+
+    async fn save_rounds(&self, tx: &mut Transaction<'_, Postgres>, id: i64) -> sqlx::Result<()> {
+        if self.rounds.is_empty() {
+            return Ok(());
+        }
+        let idxs: Vec<i32> = self.rounds.iter().map(|r| r.round_idx).collect();
+        let prompts: Vec<String> = self.rounds.iter().map(|r| r.prompt.clone()).collect();
+        let closes: Vec<Option<i64>> = self.rounds.iter().map(|r| r.closes_at).collect();
+        let chans: Vec<Option<i64>> = self.rounds.iter().map(|r| r.prompt_channel_id).collect();
+        let msgs: Vec<Option<i64>> = self.rounds.iter().map(|r| r.prompt_message_id).collect();
+        sqlx::query!(
+            r#"INSERT INTO gp_round (game_id, round_idx, prompt, closes_at, prompt_channel_id, prompt_message_id)
+               SELECT $1, * FROM UNNEST($2::int[], $3::text[], $4::bigint[], $5::bigint[], $6::bigint[])
+               ON CONFLICT (game_id, round_idx) DO UPDATE SET
+                   closes_at = EXCLUDED.closes_at,
+                   prompt_channel_id = EXCLUDED.prompt_channel_id,
+                   prompt_message_id = EXCLUDED.prompt_message_id"#,
+            id,
+            &idxs,
+            &prompts,
+            &closes as &[Option<i64>],
+            &chans as &[Option<i64>],
+            &msgs as &[Option<i64>],
+        )
+        .execute(&mut **tx)
+        .await?;
+        Ok(())
+    }
+
+    async fn save_tracks(&self, tx: &mut Transaction<'_, Postgres>, id: i64) -> sqlx::Result<()> {
+        if self.tracks.is_empty() {
+            return Ok(());
+        }
+        let t = &self.tracks;
+        let round_idxs: Vec<i32> = t.iter().map(|x| x.round_idx).collect();
+        let submitters: Vec<i64> = t.iter().map(|x| x.submitter_id).collect();
+        let positions: Vec<Option<i32>> = t.iter().map(|x| x.position).collect();
+        let urls: Vec<String> = t.iter().map(|x| x.url.clone()).collect();
+        let titles: Vec<Option<String>> = t.iter().map(|x| x.title.clone()).collect();
+        let artists: Vec<Option<String>> = t.iter().map(|x| x.artist.clone()).collect();
+        let durations: Vec<Option<i64>> = t.iter().map(|x| x.duration_secs).collect();
+        let fulls: Vec<bool> = t.iter().map(|x| x.play_full).collect();
+        let chans: Vec<Option<i64>> = t.iter().map(|x| x.message_channel_id).collect();
+        let msgs: Vec<Option<i64>> = t.iter().map(|x| x.message_id).collect();
+        sqlx::query!(
+            r#"INSERT INTO gp_track (
+                   game_id, round_idx, submitter_id, position, url, title, artist,
+                   duration_secs, play_full, message_channel_id, message_id
+               )
+               SELECT $1, * FROM UNNEST(
+                   $2::int[], $3::bigint[], $4::int[], $5::text[], $6::text[], $7::text[],
+                   $8::bigint[], $9::bool[], $10::bigint[], $11::bigint[]
+               )
+               ON CONFLICT (game_id, round_idx, submitter_id) DO UPDATE SET
+                   position = EXCLUDED.position,
+                   url = EXCLUDED.url,
+                   title = EXCLUDED.title,
+                   artist = EXCLUDED.artist,
+                   duration_secs = EXCLUDED.duration_secs,
+                   play_full = EXCLUDED.play_full,
+                   message_channel_id = EXCLUDED.message_channel_id,
+                   message_id = EXCLUDED.message_id"#,
+            id,
+            &round_idxs,
+            &submitters,
+            &positions as &[Option<i32>],
+            &urls,
+            &titles as &[Option<String>],
+            &artists as &[Option<String>],
+            &durations as &[Option<i64>],
+            &fulls,
+            &chans as &[Option<i64>],
+            &msgs as &[Option<i64>],
+        )
+        .execute(&mut **tx)
+        .await?;
+        Ok(())
+    }
+
+    /// Guesses, likes and votes: replaced wholesale. A like can be taken back and
+    /// a guess changed, so the sets are rewritten rather than merged; they are
+    /// small, and this keeps the tables equal to the game rather than a superset.
+    async fn save_reactions(
+        &self,
+        tx: &mut Transaction<'_, Postgres>,
+        id: i64,
+    ) -> sqlx::Result<()> {
+        sqlx::query!("DELETE FROM gp_guess WHERE game_id = $1", id)
+            .execute(&mut **tx)
+            .await?;
+        sqlx::query!("DELETE FROM gp_like WHERE game_id = $1", id)
+            .execute(&mut **tx)
+            .await?;
+        sqlx::query!("DELETE FROM gp_vote WHERE game_id = $1", id)
+            .execute(&mut **tx)
+            .await?;
+
+        let mut g = (Vec::new(), Vec::new(), Vec::new(), Vec::new());
+        let mut l = (Vec::new(), Vec::new(), Vec::new());
+        let mut v = (Vec::new(), Vec::new(), Vec::new(), Vec::new());
+        for t in &self.tracks {
+            for (guesser, guessed) in &t.guesses {
+                g.0.push(t.round_idx);
+                g.1.push(t.submitter_id);
+                g.2.push(*guesser);
+                g.3.push(*guessed);
+            }
+            for user in &t.likes {
+                l.0.push(t.round_idx);
+                l.1.push(t.submitter_id);
+                l.2.push(*user);
+            }
+            for (users, kind) in [(&t.skip_votes, VOTE_SKIP), (&t.full_votes, VOTE_FULL)] {
+                for user in users {
+                    v.0.push(t.round_idx);
+                    v.1.push(t.submitter_id);
+                    v.2.push(*user);
+                    v.3.push(kind.to_string());
+                }
+            }
+        }
+        if !g.0.is_empty() {
+            sqlx::query!(
+                r#"INSERT INTO gp_guess (game_id, round_idx, submitter_id, guesser_id, guessed_id)
+                   SELECT $1, * FROM UNNEST($2::int[], $3::bigint[], $4::bigint[], $5::bigint[])"#,
+                id,
+                &g.0,
+                &g.1,
+                &g.2,
+                &g.3,
+            )
+            .execute(&mut **tx)
+            .await?;
+        }
+        if !l.0.is_empty() {
+            sqlx::query!(
+                r#"INSERT INTO gp_like (game_id, round_idx, submitter_id, user_id)
+                   SELECT $1, * FROM UNNEST($2::int[], $3::bigint[], $4::bigint[])"#,
+                id,
+                &l.0,
+                &l.1,
+                &l.2,
+            )
+            .execute(&mut **tx)
+            .await?;
+        }
+        if !v.0.is_empty() {
+            sqlx::query!(
+                r#"INSERT INTO gp_vote (game_id, round_idx, submitter_id, user_id, kind)
+                   SELECT $1, * FROM UNNEST($2::int[], $3::bigint[], $4::bigint[], $5::text[])"#,
+                id,
+                &v.0,
+                &v.1,
+                &v.2,
+                &v.3,
+            )
+            .execute(&mut **tx)
+            .await?;
+        }
+        Ok(())
+    }
+
+    /// The guild's live game, if there is one.
+    pub async fn load_live(pool: &PgPool, guild_id: i64) -> sqlx::Result<Option<GpLoaded>> {
+        let Some(g) = sqlx::query!(
+            r#"SELECT id, guild_id, started_at, host_id, voice_channel_id, text_channel_id,
+                      category, phase, current_round, current_track, timer_secs,
+                      clip_start_secs, clip_length_secs, generation,
+                      EXTRACT(EPOCH FROM now() - last_seen_at)::bigint AS "last_seen_secs_ago!"
+               FROM gp_game
+               WHERE guild_id = $1 AND finished_at IS NULL
+               ORDER BY started_at DESC
+               LIMIT 1"#,
+            guild_id,
+        )
+        .fetch_optional(pool)
+        .await?
+        else {
+            return Ok(None);
+        };
+        let id = g.id;
+
+        let players = sqlx::query!(
+            r#"SELECT user_id, display_name, score FROM gp_player WHERE game_id = $1 ORDER BY user_id"#,
+            id
+        )
+        .fetch_all(pool)
+        .await?
+        .into_iter()
+        .map(|r| GpPlayerRow {
+            user_id: r.user_id,
+            display_name: r.display_name,
+            score: r.score,
+        })
+        .collect();
+
+        let rounds = sqlx::query!(
+            r#"SELECT round_idx, prompt, closes_at, prompt_channel_id, prompt_message_id
+               FROM gp_round WHERE game_id = $1 ORDER BY round_idx"#,
+            id
+        )
+        .fetch_all(pool)
+        .await?
+        .into_iter()
+        .map(|r| GpRoundRow {
+            round_idx: r.round_idx,
+            prompt: r.prompt,
+            closes_at: r.closes_at,
+            prompt_channel_id: r.prompt_channel_id,
+            prompt_message_id: r.prompt_message_id,
+        })
+        .collect();
+
+        let mut tracks: Vec<GpTrackRow> = sqlx::query!(
+            r#"SELECT round_idx, submitter_id, position, url, title, artist, duration_secs,
+                      play_full, message_channel_id, message_id
+               FROM gp_track WHERE game_id = $1
+               ORDER BY round_idx, position NULLS LAST, submitter_id"#,
+            id
+        )
+        .fetch_all(pool)
+        .await?
+        .into_iter()
+        .map(|r| GpTrackRow {
+            round_idx: r.round_idx,
+            submitter_id: r.submitter_id,
+            position: r.position,
+            url: r.url,
+            title: r.title,
+            artist: r.artist,
+            duration_secs: r.duration_secs,
+            play_full: r.play_full,
+            message_channel_id: r.message_channel_id,
+            message_id: r.message_id,
+            guesses: Vec::new(),
+            likes: Vec::new(),
+            skip_votes: Vec::new(),
+            full_votes: Vec::new(),
+        })
+        .collect();
+
+        fn find(
+            tracks: &mut [GpTrackRow],
+            round_idx: i32,
+            submitter_id: i64,
+        ) -> Option<&mut GpTrackRow> {
+            tracks
+                .iter_mut()
+                .find(|t| t.round_idx == round_idx && t.submitter_id == submitter_id)
+        }
+        for r in sqlx::query!(
+            r#"SELECT round_idx, submitter_id, guesser_id, guessed_id FROM gp_guess
+               WHERE game_id = $1 ORDER BY round_idx, submitter_id, guesser_id"#,
+            id
+        )
+        .fetch_all(pool)
+        .await?
+        {
+            if let Some(t) = find(&mut tracks, r.round_idx, r.submitter_id) {
+                t.guesses.push((r.guesser_id, r.guessed_id));
+            }
+        }
+        for r in sqlx::query!(
+            r#"SELECT round_idx, submitter_id, user_id FROM gp_like
+               WHERE game_id = $1 ORDER BY round_idx, submitter_id, user_id"#,
+            id
+        )
+        .fetch_all(pool)
+        .await?
+        {
+            if let Some(t) = find(&mut tracks, r.round_idx, r.submitter_id) {
+                t.likes.push(r.user_id);
+            }
+        }
+        for r in sqlx::query!(
+            r#"SELECT round_idx, submitter_id, user_id, kind FROM gp_vote
+               WHERE game_id = $1 ORDER BY round_idx, submitter_id, user_id"#,
+            id
+        )
+        .fetch_all(pool)
+        .await?
+        {
+            if let Some(t) = find(&mut tracks, r.round_idx, r.submitter_id) {
+                match r.kind.as_str() {
+                    VOTE_SKIP => t.skip_votes.push(r.user_id),
+                    VOTE_FULL => t.full_votes.push(r.user_id),
+                    _ => {},
+                }
+            }
+        }
+
+        Ok(Some(GpLoaded {
+            saved: GpSaved {
+                game: GpGameRow {
+                    guild_id: g.guild_id,
+                    started_at: g.started_at,
+                    host_id: g.host_id,
+                    voice_channel_id: g.voice_channel_id,
+                    text_channel_id: g.text_channel_id,
+                    category: g.category,
+                    phase: g.phase,
+                    current_round: g.current_round,
+                    current_track: g.current_track,
+                    timer_secs: g.timer_secs,
+                    clip_start_secs: g.clip_start_secs,
+                    clip_length_secs: g.clip_length_secs,
+                    generation: g.generation,
+                },
+                players,
+                rounds,
+                tracks,
+            },
+            last_seen_secs_ago: g.last_seen_secs_ago,
+        }))
+    }
+}
+
+async fn mark_finished_in(
+    tx: &mut Transaction<'_, Postgres>,
+    guild_id: i64,
+    started_at: i64,
+    outcome: GpOutcome,
+) -> sqlx::Result<bool> {
+    let done = sqlx::query!(
+        r#"UPDATE gp_game SET finished_at = now(), outcome = $3
+           WHERE guild_id = $1 AND started_at = $2 AND finished_at IS NULL"#,
+        guild_id,
+        started_at,
+        outcome.as_str(),
+    )
+    .execute(&mut **tx)
+    .await?;
+    Ok(done.rows_affected() > 0)
+}
+
+/// Take the game out of the live set. A game that never made it into the
+/// database -- nobody submitted -- has no row to mark, and that is fine. Once
+/// finished, a row stays finished: a later call with another outcome is a no-op,
+/// so the first reason a game ended is the one that is kept.
+pub async fn gp_mark_finished(
+    pool: &PgPool,
+    guild_id: i64,
+    started_at: i64,
+    outcome: GpOutcome,
+) -> sqlx::Result<bool> {
+    let mut tx = pool.begin().await?;
+    let done = mark_finished_in(&mut tx, guild_id, started_at, outcome).await?;
+    tx.commit().await?;
+    Ok(done)
+}
+
+/// "Still here": bump `last_seen_at` on the live rows for these games.
+pub async fn gp_heartbeat(pool: &PgPool, games: &[(i64, i64)]) -> sqlx::Result<u64> {
+    if games.is_empty() {
+        return Ok(0);
+    }
+    let guilds: Vec<i64> = games.iter().map(|(g, _)| *g).collect();
+    let starts: Vec<i64> = games.iter().map(|(_, s)| *s).collect();
+    let done = sqlx::query!(
+        r#"UPDATE gp_game SET last_seen_at = now()
+           WHERE finished_at IS NULL
+             AND (guild_id, started_at) IN (SELECT * FROM UNNEST($1::bigint[], $2::bigint[]))"#,
+        &guilds,
+        &starts,
+    )
+    .execute(pool)
+    .await?;
+    Ok(done.rows_affected())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    pub static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./test_migrations");
+
+    fn track(round_idx: i32, submitter_id: i64, position: Option<i32>) -> GpTrackRow {
+        GpTrackRow {
+            round_idx,
+            submitter_id,
+            position,
+            url: format!("https://www.youtube.com/watch?v=r{round_idx}u{submitter_id}"),
+            title: Some(format!("song {submitter_id}")),
+            artist: None,
+            duration_secs: Some(200),
+            play_full: false,
+            message_channel_id: None,
+            message_id: None,
+            guesses: Vec::new(),
+            likes: Vec::new(),
+            skip_votes: Vec::new(),
+            full_votes: Vec::new(),
+        }
+    }
+
+    fn saved(guild_id: i64, started_at: i64) -> GpSaved {
+        GpSaved {
+            game: GpGameRow {
+                guild_id,
+                started_at,
+                host_id: 100,
+                voice_channel_id: 10,
+                text_channel_id: 20,
+                category: "nostalgia".into(),
+                phase: "submitting".into(),
+                current_round: 0,
+                current_track: 0,
+                timer_secs: 120,
+                clip_start_secs: Some(30),
+                clip_length_secs: Some(45),
+                generation: 1,
+            },
+            players: vec![GpPlayerRow {
+                user_id: 100,
+                display_name: "alice".into(),
+                score: 0,
+            }],
+            rounds: vec![
+                GpRoundRow {
+                    round_idx: 0,
+                    prompt: "p0".into(),
+                    closes_at: Some(started_at + 120),
+                    prompt_channel_id: Some(20),
+                    prompt_message_id: Some(1),
+                },
+                GpRoundRow {
+                    round_idx: 1,
+                    prompt: "p1".into(),
+                    closes_at: None,
+                    prompt_channel_id: None,
+                    prompt_message_id: None,
+                },
+            ],
+            tracks: vec![track(0, 100, None)],
+        }
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
+    async fn a_game_round_trips_and_a_second_save_replaces_the_first(
+        pool: PgPool,
+    ) -> sqlx::Result<()> {
+        let mut s = saved(1, 1_700_000_000);
+        let id = s.save(&pool).await?;
+        let loaded = GpSaved::load_live(&pool, 1).await?.expect("live");
+        assert_eq!(loaded.saved, s);
+        assert!(loaded.last_seen_secs_ago < 5);
+
+        // The window closes: the submission becomes track 0, bob's song joins it,
+        // and alice's earlier submission is the same row with a position now.
+        s.game.phase = "playing".into();
+        s.rounds[0].closes_at = None;
+        s.tracks = vec![track(0, 200, Some(0)), track(0, 100, Some(1))];
+        s.tracks[0].guesses = vec![(100, 200)];
+        s.tracks[0].likes = vec![100];
+        s.tracks[0].full_votes = vec![100];
+        s.tracks[0].play_full = true;
+        s.players.push(GpPlayerRow {
+            user_id: 200,
+            display_name: "bob".into(),
+            score: 100,
+        });
+        assert_eq!(s.save(&pool).await?, id, "same game, same row");
+        let loaded = GpSaved::load_live(&pool, 1).await?.expect("live").saved;
+        assert_eq!(loaded, s);
+
+        // A like taken back is gone, not lingering from the earlier write.
+        s.tracks[0].likes.clear();
+        s.save(&pool).await?;
+        let loaded = GpSaved::load_live(&pool, 1).await?.expect("live").saved;
+        assert!(loaded.tracks[0].likes.is_empty());
+        assert_eq!(loaded.tracks[0].guesses, vec![(100, 200)]);
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
+    async fn finishing_leaves_history_and_no_live_game(pool: PgPool) -> sqlx::Result<()> {
+        let s = saved(2, 1_700_000_000);
+        s.save(&pool).await?;
+        assert!(gp_mark_finished(&pool, 2, 1_700_000_000, GpOutcome::Ended).await?);
+        assert!(GpSaved::load_live(&pool, 2).await?.is_none());
+        // Already finished: the first reason stands and nothing is touched.
+        assert!(!gp_mark_finished(&pool, 2, 1_700_000_000, GpOutcome::Lost).await?);
+        let outcome: Option<String> = sqlx::query_scalar!(
+            "SELECT outcome FROM gp_game WHERE guild_id = 2 AND started_at = 1700000000"
+        )
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(outcome.as_deref(), Some("ended"));
+        // Nothing to mark for a game that was never written.
+        assert!(!gp_mark_finished(&pool, 2, 1, GpOutcome::Abandoned).await?);
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
+    async fn a_new_game_in_the_guild_closes_a_stale_live_row_as_lost(
+        pool: PgPool,
+    ) -> sqlx::Result<()> {
+        saved(3, 1_700_000_000).save(&pool).await?;
+        saved(3, 1_700_009_000).save(&pool).await?;
+        let live = GpSaved::load_live(&pool, 3).await?.expect("live").saved;
+        assert_eq!(live.game.started_at, 1_700_009_000);
+        let outcome: Option<String> = sqlx::query_scalar!(
+            "SELECT outcome FROM gp_game WHERE guild_id = 3 AND started_at = 1700000000"
+        )
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(outcome.as_deref(), Some("lost"));
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
+    async fn a_finished_phase_is_written_as_finished(pool: PgPool) -> sqlx::Result<()> {
+        let mut s = saved(4, 1_700_000_000);
+        s.game.phase = "finished".into();
+        s.save(&pool).await?;
+        assert!(GpSaved::load_live(&pool, 4).await?.is_none());
+        let outcome: Option<String> =
+            sqlx::query_scalar!("SELECT outcome FROM gp_game WHERE guild_id = 4")
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(outcome.as_deref(), Some("finished"));
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    #[cfg_attr(
+        not(feature = "db-tests"),
+        ignore = "needs a postgres at DATABASE_URL; enable the db-tests feature"
+    )]
+    async fn heartbeat_touches_only_the_named_live_games(pool: PgPool) -> sqlx::Result<()> {
+        saved(5, 1_700_000_000).save(&pool).await?;
+        saved(6, 1_700_000_000).save(&pool).await?;
+        sqlx::query!("UPDATE gp_game SET last_seen_at = now() - interval '10 minutes'")
+            .execute(&pool)
+            .await?;
+        assert_eq!(gp_heartbeat(&pool, &[(5, 1_700_000_000), (7, 1)]).await?, 1);
+        let five = GpSaved::load_live(&pool, 5).await?.expect("live");
+        let six = GpSaved::load_live(&pool, 6).await?.expect("live");
+        assert!(five.last_seen_secs_ago < 5);
+        assert!(six.last_seen_secs_ago > 500);
+        assert_eq!(gp_heartbeat(&pool, &[]).await?, 0);
+        Ok(())
+    }
+}

--- a/crack-core/src/db/mod.rs
+++ b/crack-core/src/db/mod.rs
@@ -1,3 +1,4 @@
+pub mod gp;
 pub mod guild;
 pub mod metadata;
 pub mod play_log;
@@ -6,6 +7,7 @@ pub mod track_reaction;
 pub mod user;
 pub mod worker_pool;
 
+pub use gp::*;
 pub use guild::*;
 pub use metadata::*;
 pub use play_log::*;

--- a/crack-core/src/handlers/serenity.rs
+++ b/crack-core/src/handlers/serenity.rs
@@ -344,7 +344,7 @@ impl SerenityHandler {
     ///
     /// Per-guild work belongs on the per-guild event, where it is also correct for
     /// guilds that recover from an outage or are joined while running.
-    async fn on_guild_create(&self, _ctx: SerenityContext, guild: serenity::Guild) {
+    async fn on_guild_create(&self, ctx: SerenityContext, guild: serenity::Guild) {
         let prefix = self.data.bot_settings.get_prefix();
         let name = guild.name.clone();
         let settings = match self.data.database_pool.as_ref() {
@@ -374,6 +374,10 @@ impl SerenityHandler {
             .await
             .insert(guild.id, settings);
         tracing::info!("Loaded settings for guild {} ({})", guild.id, guild.name);
+
+        // A `/gp` game that was running when the bot went down comes back here,
+        // per guild, for the same reason the settings do.
+        crate::commands::music::gp_persist::gp_resume_guild(&self.data, &ctx, &guild).await;
     }
 
     // We use the cache_ready event just in case some cache operation is required in whatever use

--- a/crack-core/src/lib.rs
+++ b/crack-core/src/lib.rs
@@ -392,6 +392,10 @@ pub struct DataInner {
     pub guild_cnt_map: dashmap::DashMap<GuildId, u64>,
     /// Guilty pleasure games, one per guild. See `commands::music::gp`.
     pub gp_games: dashmap::DashMap<GuildId, commands::music::gp::GpGame>,
+    /// Where `gp_games` are written down, when there is a database. `None` runs
+    /// the game in memory only. See `commands::music::gp_persist`.
+    pub gp_persist:
+        Option<tokio::sync::mpsc::UnboundedSender<commands::music::gp_persist::GpPersist>>,
     // Option inside?
     #[cfg(feature = "crack-gpt")]
     pub gpt_ctx: Arc<RwLock<Option<GptContext>>>,
@@ -596,6 +600,7 @@ impl Default for DataInner {
             guild_command_msg_queue: Default::default(),
             guild_cnt_map: Default::default(),
             gp_games: Default::default(),
+            gp_persist: None,
             http_client: http_utils::get_client().clone(),
             event_log_async: EventLogAsync::default(),
             database_pool: None,

--- a/crack-core/src/messaging/messages.rs
+++ b/crack-core/src/messaging/messages.rs
@@ -302,6 +302,13 @@ pub const GP_GUESSED_RIGHT: &str = "Guessed right";
 pub const GP_NOBODY_GUESSED: &str = "nobody!";
 pub const GP_FOOLED_EVERYONE: &str = "🃏 Fooled everyone";
 pub const GP_SCOREBOARD: &str = "🏆 Scoreboard";
+pub const GP_RESUMED: &str =
+    "🔁 **We're back.** The bot restarted mid-game, and the game picks up where it was:";
+pub const GP_RESUMED_WINDOW: &str = "submissions are still open for round";
+pub const GP_RESUMED_WINDOW_CLOSED: &str =
+    "the submission window for round {round} closed while I was away, so it closes now.";
+pub const GP_RESUMED_SONG: &str = "the song that was playing starts again. Guess and 👍 it again — nothing cast before the restart counts.";
+pub const GP_LOST: &str = "💤 A game was running when the bot went down and could not be picked up again. Here is the scoreboard as it stood.";
 pub const GP_GAME_OVER: &str = "🏆 Game over — final scores";
 pub const GP_ROUND_SKIPPED: &str = "⏭️ Song skipped.";
 pub const GP_TRACK_FAILED: &str = "⚠️ Couldn't play this one";

--- a/crack-core/test_migrations/20260908120000_gp_game.sql
+++ b/crack-core/test_migrations/20260908120000_gp_game.sql
@@ -1,0 +1,109 @@
+-- `/gp` games, saved as they run so a redeploy or a crash does not end them.
+--
+-- One row per game. The live game for a guild is the row whose finished_at is
+-- NULL; every other row is history. A game is written at two points -- when a
+-- song is submitted and when a song ends -- and left alone in between, so the
+-- rows describe the game as it stood at the last of those. Guesses, likes and
+-- votes on the song that is still playing are not here: after a resume that
+-- song plays again from the top and the room casts them again.
+CREATE TABLE IF NOT EXISTS gp_game (
+    id BIGSERIAL PRIMARY KEY,
+    guild_id BIGINT NOT NULL,
+    -- Unix seconds of `/gp start`. With guild_id, names the game across restarts.
+    started_at BIGINT NOT NULL,
+    host_id BIGINT NOT NULL,
+    voice_channel_id BIGINT NOT NULL,
+    text_channel_id BIGINT NOT NULL,
+    -- GpCategory::slug()
+    category TEXT NOT NULL,
+    -- submitting | playing | finished
+    phase TEXT NOT NULL,
+    current_round INTEGER NOT NULL,
+    current_track INTEGER NOT NULL,
+    timer_secs BIGINT NOT NULL,
+    clip_start_secs BIGINT,
+    clip_length_secs BIGINT,
+    generation BIGINT NOT NULL,
+    -- Bumped on every write and on a heartbeat while the game is live; on
+    -- startup a game not seen for GP_RESUME_WINDOW_SECS is lost, not resumed.
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    finished_at TIMESTAMPTZ,
+    -- finished | ended | abandoned | lost
+    outcome TEXT,
+    UNIQUE (guild_id, started_at)
+);
+
+CREATE INDEX IF NOT EXISTS gp_game_live ON gp_game (guild_id) WHERE finished_at IS NULL;
+
+-- Everyone who has submitted, guessed or liked, with the display name seen and
+-- the score as it stood.
+CREATE TABLE IF NOT EXISTS gp_player (
+    game_id BIGINT NOT NULL REFERENCES gp_game (id) ON DELETE CASCADE,
+    user_id BIGINT NOT NULL,
+    display_name TEXT NOT NULL,
+    score INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (game_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS gp_round (
+    game_id BIGINT NOT NULL REFERENCES gp_game (id) ON DELETE CASCADE,
+    round_idx INTEGER NOT NULL,
+    prompt TEXT NOT NULL,
+    -- Unix seconds; set while the submission window is open.
+    closes_at BIGINT,
+    prompt_channel_id BIGINT,
+    prompt_message_id BIGINT,
+    PRIMARY KEY (game_id, round_idx)
+);
+
+-- One song per player per round: a submission while the window is open, and
+-- a track in play order (position) once it has closed. Resubmitting replaces.
+CREATE TABLE IF NOT EXISTS gp_track (
+    game_id BIGINT NOT NULL,
+    round_idx INTEGER NOT NULL,
+    submitter_id BIGINT NOT NULL,
+    position INTEGER,
+    url TEXT NOT NULL,
+    title TEXT,
+    artist TEXT,
+    duration_secs BIGINT,
+    play_full BOOLEAN NOT NULL DEFAULT FALSE,
+    message_channel_id BIGINT,
+    message_id BIGINT,
+    PRIMARY KEY (game_id, round_idx, submitter_id),
+    FOREIGN KEY (game_id, round_idx) REFERENCES gp_round (game_id, round_idx) ON DELETE CASCADE
+);
+
+-- guesser -> guessed submitter; the last guess wins, so one row per guesser.
+CREATE TABLE IF NOT EXISTS gp_guess (
+    game_id BIGINT NOT NULL,
+    round_idx INTEGER NOT NULL,
+    submitter_id BIGINT NOT NULL,
+    guesser_id BIGINT NOT NULL,
+    guessed_id BIGINT NOT NULL,
+    PRIMARY KEY (game_id, round_idx, submitter_id, guesser_id),
+    FOREIGN KEY (game_id, round_idx, submitter_id)
+        REFERENCES gp_track (game_id, round_idx, submitter_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS gp_like (
+    game_id BIGINT NOT NULL,
+    round_idx INTEGER NOT NULL,
+    submitter_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    PRIMARY KEY (game_id, round_idx, submitter_id, user_id),
+    FOREIGN KEY (game_id, round_idx, submitter_id)
+        REFERENCES gp_track (game_id, round_idx, submitter_id) ON DELETE CASCADE
+);
+
+-- skip: `/gp voteskip`; full: `/gp votefull`.
+CREATE TABLE IF NOT EXISTS gp_vote (
+    game_id BIGINT NOT NULL,
+    round_idx INTEGER NOT NULL,
+    submitter_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    kind TEXT NOT NULL CHECK (kind IN ('skip', 'full')),
+    PRIMARY KEY (game_id, round_idx, submitter_id, user_id, kind),
+    FOREIGN KEY (game_id, round_idx, submitter_id)
+        REFERENCES gp_track (game_id, round_idx, submitter_id) ON DELETE CASCADE
+);

--- a/crack-core/test_migrations/20260908120000_gp_game.sql
+++ b/crack-core/test_migrations/20260908120000_gp_game.sql
@@ -24,8 +24,9 @@ CREATE TABLE IF NOT EXISTS gp_game (
     clip_start_secs BIGINT,
     clip_length_secs BIGINT,
     generation BIGINT NOT NULL,
-    -- Bumped on every write and on a heartbeat while the game is live; on
-    -- startup a game not seen for GP_RESUME_WINDOW_SECS is lost, not resumed.
+    -- Bumped on every write, and on every live game when the bot shuts down
+    -- cleanly. A song whose game was not seen for GP_RESUME_WINDOW_SECS is not
+    -- resumed; an open submission window is judged by closes_at instead.
     last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     finished_at TIMESTAMPTZ,
     -- finished | ended | abandoned | lost

--- a/crack-testing/src/resolve.rs
+++ b/crack-testing/src/resolve.rs
@@ -1,5 +1,5 @@
 use crate::{UNKNOWN_DURATION, UNKNOWN_TITLE, UNKNOWN_URL};
-use crack_types::{get_human_readable_timestamp, AuxMetadata, QueryType};
+use crack_types::{get_human_readable_timestamp, AuxMetadata, QueryType, SavedTrack};
 use rusty_ytdl::{search, VideoDetails};
 use serenity::all::{AutocompleteChoice, AutocompleteValue, UserId};
 use std::{
@@ -57,6 +57,15 @@ impl ResolvedTrack<'_> {
     pub fn with_user_id(mut self, user_id: UserId) -> Self {
         self.user_id = user_id;
         self
+    }
+
+    /// Rebuild a track from what was saved of it. Carries only metadata, which is
+    /// all `build_track` reads: the URL to play and the fields the embeds show.
+    /// Nothing is resolved again, so this cannot fail and touches no network.
+    pub fn from_saved(saved: &SavedTrack, user_id: UserId) -> ResolvedTrack<'static> {
+        ResolvedTrack::new(QueryType::VideoLink(saved.url.clone()))
+            .with_metadata(saved.to_metadata())
+            .with_user_id(user_id)
     }
 
     /// Set the queued status of the track.
@@ -320,3 +329,16 @@ impl Display for ResolvedTrack<'_> {
 //         Ok(metadata)
 //     }
 // }
+
+/// What a track saves of itself: the URL it plays from and what the embeds show.
+impl From<&ResolvedTrack<'_>> for SavedTrack {
+    fn from(track: &ResolvedTrack<'_>) -> Self {
+        let metadata = track.get_metadata();
+        SavedTrack {
+            url: track.get_url(),
+            title: Some(track.get_title()).filter(|t| !t.is_empty()),
+            artist: metadata.as_ref().and_then(|m| m.artist.clone()),
+            duration: metadata.and_then(|m| m.duration),
+        }
+    }
+}

--- a/crack-testing/src/resolve.rs
+++ b/crack-testing/src/resolve.rs
@@ -59,13 +59,18 @@ impl ResolvedTrack<'_> {
         self
     }
 
-    /// Rebuild a track from what was saved of it. Carries only metadata, which is
-    /// all `build_track` reads: the URL to play and the fields the embeds show.
-    /// Nothing is resolved again, so this cannot fail and touches no network.
-    pub fn from_saved(saved: &SavedTrack, user_id: UserId) -> ResolvedTrack<'static> {
+    /// Rebuild a track from what was saved of it: the URL to play and the fields
+    /// the embeds show. Nothing is resolved again, so this cannot fail and
+    /// touches no network.
+    ///
+    /// Deliberately takes no requester, so the track keeps [`Self::new`]'s
+    /// sentinel. `build_track` copies `user_id` into the songbird track's data,
+    /// where the now-playing and queue embeds read it, and a guessing-game song
+    /// rebuilt with its submitter would name them in `/nowplaying` before the
+    /// reveal -- which is the whole secret of the game.
+    pub fn from_saved(saved: &SavedTrack) -> ResolvedTrack<'static> {
         ResolvedTrack::new(QueryType::VideoLink(saved.url.clone()))
             .with_metadata(saved.to_metadata())
-            .with_user_id(user_id)
     }
 
     /// Set the queued status of the track.

--- a/crack-types/src/lib.rs
+++ b/crack-types/src/lib.rs
@@ -7,6 +7,8 @@ pub mod metadata;
 pub use metadata::*;
 pub mod reply_handle;
 pub use reply_handle::*;
+pub mod saved_track;
+pub use saved_track::*;
 
 use rspotify::model::SimplifiedAlbum;
 use rspotify::model::SimplifiedArtist;

--- a/crack-types/src/saved_track.rs
+++ b/crack-types/src/saved_track.rs
@@ -1,0 +1,94 @@
+//! A track as data.
+//!
+//! A resolved track carries live handles -- a `rusty_ytdl::Video`, a songbird
+//! `YoutubeDl` -- that cannot be written down. Playing one back never needs
+//! them: `build_track` reads the URL and the display metadata and nothing else.
+//! This is that much of a track, in a shape a database row or a JSON blob can
+//! hold, and enough to rebuild a playable track from.
+//!
+//! It is what a `/gp` game saves for each song. Queue persistence, if it comes,
+//! saves the same thing.
+
+use crate::AuxMetadata;
+use std::time::Duration;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SavedTrack {
+    /// The source URL yt-dlp is handed to play it.
+    pub url: String,
+    pub title: Option<String>,
+    pub artist: Option<String>,
+    pub duration: Option<Duration>,
+}
+
+impl SavedTrack {
+    /// The metadata a rebuilt track carries: what the queue and the reveal show,
+    /// plus the URL `build_track` plays from.
+    pub fn to_metadata(&self) -> AuxMetadata {
+        AuxMetadata {
+            title: self.title.clone(),
+            artist: self.artist.clone(),
+            duration: self.duration,
+            source_url: Some(self.url.clone()),
+            ..AuxMetadata::default()
+        }
+    }
+
+    /// Whole seconds, for a `BIGINT` column. Sub-second precision is not worth a
+    /// float: nothing that reads it back needs better than a second.
+    pub fn duration_secs(&self) -> Option<i64> {
+        self.duration.map(|d| d.as_secs() as i64)
+    }
+
+    pub fn from_secs(
+        url: String,
+        title: Option<String>,
+        artist: Option<String>,
+        duration_secs: Option<i64>,
+    ) -> Self {
+        Self {
+            url,
+            title,
+            artist,
+            duration: duration_secs
+                .and_then(|s| u64::try_from(s).ok())
+                .map(Duration::from_secs),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_round_trips_through_seconds() {
+        let saved = SavedTrack {
+            url: "https://www.youtube.com/watch?v=abc".into(),
+            title: Some("A Song".into()),
+            artist: Some("Someone".into()),
+            duration: Some(Duration::from_secs(214)),
+        };
+        let back = SavedTrack::from_secs(
+            saved.url.clone(),
+            saved.title.clone(),
+            saved.artist.clone(),
+            saved.duration_secs(),
+        );
+        assert_eq!(back, saved);
+        let m = saved.to_metadata();
+        assert_eq!(
+            m.source_url.as_deref(),
+            Some("https://www.youtube.com/watch?v=abc")
+        );
+        assert_eq!(m.duration, Some(Duration::from_secs(214)));
+    }
+
+    #[test]
+    fn a_negative_duration_is_unknown_not_a_panic() {
+        assert_eq!(
+            SavedTrack::from_secs("u".into(), None, None, Some(-1)).duration,
+            None
+        );
+    }
+}

--- a/migrations/20260908120000_gp_game.sql
+++ b/migrations/20260908120000_gp_game.sql
@@ -1,0 +1,109 @@
+-- `/gp` games, saved as they run so a redeploy or a crash does not end them.
+--
+-- One row per game. The live game for a guild is the row whose finished_at is
+-- NULL; every other row is history. A game is written at two points -- when a
+-- song is submitted and when a song ends -- and left alone in between, so the
+-- rows describe the game as it stood at the last of those. Guesses, likes and
+-- votes on the song that is still playing are not here: after a resume that
+-- song plays again from the top and the room casts them again.
+CREATE TABLE IF NOT EXISTS gp_game (
+    id BIGSERIAL PRIMARY KEY,
+    guild_id BIGINT NOT NULL,
+    -- Unix seconds of `/gp start`. With guild_id, names the game across restarts.
+    started_at BIGINT NOT NULL,
+    host_id BIGINT NOT NULL,
+    voice_channel_id BIGINT NOT NULL,
+    text_channel_id BIGINT NOT NULL,
+    -- GpCategory::slug()
+    category TEXT NOT NULL,
+    -- submitting | playing | finished
+    phase TEXT NOT NULL,
+    current_round INTEGER NOT NULL,
+    current_track INTEGER NOT NULL,
+    timer_secs BIGINT NOT NULL,
+    clip_start_secs BIGINT,
+    clip_length_secs BIGINT,
+    generation BIGINT NOT NULL,
+    -- Bumped on every write and on a heartbeat while the game is live; on
+    -- startup a game not seen for GP_RESUME_WINDOW_SECS is lost, not resumed.
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    finished_at TIMESTAMPTZ,
+    -- finished | ended | abandoned | lost
+    outcome TEXT,
+    UNIQUE (guild_id, started_at)
+);
+
+CREATE INDEX IF NOT EXISTS gp_game_live ON gp_game (guild_id) WHERE finished_at IS NULL;
+
+-- Everyone who has submitted, guessed or liked, with the display name seen and
+-- the score as it stood.
+CREATE TABLE IF NOT EXISTS gp_player (
+    game_id BIGINT NOT NULL REFERENCES gp_game (id) ON DELETE CASCADE,
+    user_id BIGINT NOT NULL,
+    display_name TEXT NOT NULL,
+    score INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (game_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS gp_round (
+    game_id BIGINT NOT NULL REFERENCES gp_game (id) ON DELETE CASCADE,
+    round_idx INTEGER NOT NULL,
+    prompt TEXT NOT NULL,
+    -- Unix seconds; set while the submission window is open.
+    closes_at BIGINT,
+    prompt_channel_id BIGINT,
+    prompt_message_id BIGINT,
+    PRIMARY KEY (game_id, round_idx)
+);
+
+-- One song per player per round: a submission while the window is open, and
+-- a track in play order (position) once it has closed. Resubmitting replaces.
+CREATE TABLE IF NOT EXISTS gp_track (
+    game_id BIGINT NOT NULL,
+    round_idx INTEGER NOT NULL,
+    submitter_id BIGINT NOT NULL,
+    position INTEGER,
+    url TEXT NOT NULL,
+    title TEXT,
+    artist TEXT,
+    duration_secs BIGINT,
+    play_full BOOLEAN NOT NULL DEFAULT FALSE,
+    message_channel_id BIGINT,
+    message_id BIGINT,
+    PRIMARY KEY (game_id, round_idx, submitter_id),
+    FOREIGN KEY (game_id, round_idx) REFERENCES gp_round (game_id, round_idx) ON DELETE CASCADE
+);
+
+-- guesser -> guessed submitter; the last guess wins, so one row per guesser.
+CREATE TABLE IF NOT EXISTS gp_guess (
+    game_id BIGINT NOT NULL,
+    round_idx INTEGER NOT NULL,
+    submitter_id BIGINT NOT NULL,
+    guesser_id BIGINT NOT NULL,
+    guessed_id BIGINT NOT NULL,
+    PRIMARY KEY (game_id, round_idx, submitter_id, guesser_id),
+    FOREIGN KEY (game_id, round_idx, submitter_id)
+        REFERENCES gp_track (game_id, round_idx, submitter_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS gp_like (
+    game_id BIGINT NOT NULL,
+    round_idx INTEGER NOT NULL,
+    submitter_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    PRIMARY KEY (game_id, round_idx, submitter_id, user_id),
+    FOREIGN KEY (game_id, round_idx, submitter_id)
+        REFERENCES gp_track (game_id, round_idx, submitter_id) ON DELETE CASCADE
+);
+
+-- skip: `/gp voteskip`; full: `/gp votefull`.
+CREATE TABLE IF NOT EXISTS gp_vote (
+    game_id BIGINT NOT NULL,
+    round_idx INTEGER NOT NULL,
+    submitter_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    kind TEXT NOT NULL CHECK (kind IN ('skip', 'full')),
+    PRIMARY KEY (game_id, round_idx, submitter_id, user_id, kind),
+    FOREIGN KEY (game_id, round_idx, submitter_id)
+        REFERENCES gp_track (game_id, round_idx, submitter_id) ON DELETE CASCADE
+);

--- a/migrations/20260908120000_gp_game.sql
+++ b/migrations/20260908120000_gp_game.sql
@@ -24,8 +24,9 @@ CREATE TABLE IF NOT EXISTS gp_game (
     clip_start_secs BIGINT,
     clip_length_secs BIGINT,
     generation BIGINT NOT NULL,
-    -- Bumped on every write and on a heartbeat while the game is live; on
-    -- startup a game not seen for GP_RESUME_WINDOW_SECS is lost, not resumed.
+    -- Bumped on every write, and on every live game when the bot shuts down
+    -- cleanly. A song whose game was not seen for GP_RESUME_WINDOW_SECS is not
+    -- resumed; an open submission window is judged by closes_at instead.
     last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     finished_at TIMESTAMPTZ,
     -- finished | ended | abandoned | lost


### PR DESCRIPTION
For #431. Builds the shape the thread landed on, with the two choices from the follow-up conversation: **Postgres, not a file**, and **checkpoints at submission and song end**, rows rather than a blob.

## What it does

- A `/gp` game is written to the `gp_*` tables each time a song is **submitted** and each time a song **ends**. Memory stays the source of truth; the two `Data` mutations clone the game and send it down a channel, and one writer task per process drains it in order. Nothing on the interaction or songbird path waits on the database. Shutdown drains the channel (bounded at 5 s) before the pool closes.
- Guesses, 👍 and votes on the song that is **playing** are not written until it ends. After a resume that song plays again from the top and the room casts them again, so a crash costs at most one song's guesses, never a scoreboard.
- **Tombstones.** Every path that removes a game from the map writes `finished_at` + an outcome (`finished` / `ended` / `abandoned` / `lost`), `/gp end` included. Not a checkpoint, but without it a game ended on purpose would look live after a redeploy and come back. No heartbeat: the graceful shutdown stamps `last_seen_at` on every live game once, ahead of its flush, so a redeploy measures the outage exactly.
- **Resume** runs from `on_guild_create`, per guild, for the same reason settings load there. A game is resumed only if it can still be going, judged by its own clock where it has one: an open submission window by `closes_at` (still open, or closed under `GP_RESUME_WINDOW_SECS` = 5 min ago), a song by `last_seen_at`. Anything older, or whose voice channel is empty, is marked lost and its scoreboard posted with a line saying why. A hard crash mid-song leaves `last_seen_at` at the previous song's end, which errs toward not resuming. Otherwise the game goes back in the map, the bot rejoins voice by id (installing the global handlers a command join would have, so `/gp end` on a resumed game is still collected), and re-enters its phase: a window with the time `closes_at` says is left, or closed at once if that passed; a song from the top, with the pre-restart song message's dropdown taken down first so the one-live-dropdown invariant in `gp_play_track` holds.
- **`SavedTrack`** in `crack-types`: URL, title, artist, duration. `ResolvedTrack` does not serialise and neither does songbird's `AuxMetadata` (no derive in the pinned checkout), so the game saves this and rebuilds a `ResolvedTrack` from it with no network round trip, which is all `build_track` reads. It is the shared track-as-data type from the thread; queue persistence can save the same thing.
- Without `DATABASE_URL` the game runs in memory exactly as before.

## Schema

`gp_game` (one row per game; live = `finished_at IS NULL`, unique on `(guild_id, started_at)`), `gp_player`, `gp_round`, `gp_track` (a submission while the window is open, `position` set once it closes), `gp_guess`, `gp_like`, `gp_vote`. Each snapshot is ~10 statements regardless of game size (UNNEST per table), and it does not grow with the game: a round is frozen once the game moves past it, so only the current round and the one before it have their tracks and reactions rewritten (deleted and reinserted, so a like taken back is gone). Late in a 25-player, 20-round game that is a few hundred rows per save rather than ~12,000. Finished games stay as history for a later `/gp history` or leaderboard.

## Tests

- `db/gp.rs` (behind `db-tests`): round trip + second save replaces, finish leaves history and no live row, a new game closes a stale live row as lost, only the changed rounds are rewritten, the shutdown stamp touches live games only.
- `gp_persist.rs` (pure): a submission writes and start/close/guess/like do not; a song ending writes payout and position; every way a game ends leaves the right tombstone; shutdown stamps then flushes, bounded; mid-game and submitting games round-trip through their rows; malformed rows are refused.
- Full `crack-core` suite with `db-tests`: 184 passed. Clippy and fmt clean.

## Not in this PR

- No write on guess/like/votefull. `play_full` and `full_votes` are lost if the bot dies before the song ends, so a resumed song re-arms its clip timer and the room votes again. That is the two-checkpoint trade-off, on purpose.
- No `/gp history` or leaderboard; the rows are there for it.
- #434's playback lease: the resume just claims the voice channel, as that issue anticipated for the case where #431 lands first.



