### PR TITLE
Playback ownership: a per-guild lease for queue mutation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,14 +1012,14 @@ dependencies = [
 
 [[package]]
 name = "crack-bf"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "crack-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "crack-gpt"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-openai",
  "const_format",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "crack-osint"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "crack-types",
  "ipinfo",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "crack-sleevenote"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "crack-testing"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "crack-types"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "humantime",
  "poise",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "crack-voting"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "dbl-rs",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "cracktunes"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "config-file",
  "crack-core",

--- a/crack-bf/Cargo.toml
+++ b/crack-bf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-bf"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-cli/Cargo.toml
+++ b/crack-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "cracktunes"
-version = "0.8.0"
+version = "0.9.0"
 description = "Cracktunes is a hassle-free, highly performant, host-it-yourself, cracking smoking, discord-music-bot."
 publish = true
 edition = "2021"

--- a/crack-core/Cargo.toml
+++ b/crack-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-core"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 edition = "2021"
 description = "Core module for the cracking smoking, discord-music-bot Cracktunes."

--- a/crack-core/src/commands/music/clear.rs
+++ b/crack-core/src/commands/music/clear.rs
@@ -52,7 +52,7 @@ pub async fn clear_internal(ctx: Context<'_>) -> Result<(), Error> {
     // refetch the queue after modification
     let queue = handler.queue().current_queue();
     drop(handler);
-    assert!(queue.len() == 1);
+    debug_assert!(queue.len() == 1);
 
     send_reply(&ctx, CrackedMessage::Clear, true).await?;
     update_queue_messages(&ctx.serenity_context().http, ctx.data(), &queue, guild_id).await;

--- a/crack-core/src/commands/music/clear.rs
+++ b/crack-core/src/commands/music/clear.rs
@@ -3,6 +3,7 @@ use crate::{
     errors::{verify, CrackedError},
     handlers::track_end::update_queue_messages,
     messaging::message::CrackedMessage,
+    music::{clear_from, PlaybackOwner},
     utils::send_reply,
     Context, Error,
 };
@@ -34,17 +35,16 @@ pub async fn clear_internal(ctx: Context<'_>) -> Result<(), Error> {
     let manager = ctx.data().songbird.clone();
     let call = manager.get(guild_id).ok_or(CrackedError::NotConnected)?;
 
+    // Ordinary music commands mutate as `Free`; a guild a game owns refuses
+    // here, which is the same refusal GP_BLOCKED_COMMANDS gives earlier and
+    // more kindly. This one cannot be forgotten.
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let handler = call.lock().await;
     let queue = handler.queue().current_queue();
 
     verify(queue.len() > 1, CrackedError::QueueEmpty)?;
 
-    handler.queue().modify_queue(|v| {
-        v.drain(1..).for_each(|x| {
-            let _ = x.stop();
-            drop(x);
-        });
-    });
+    clear_from(&guard, &handler, 1);
 
     // refetch the queue after modification
     let queue = handler.queue().current_queue();

--- a/crack-core/src/commands/music/clear.rs
+++ b/crack-core/src/commands/music/clear.rs
@@ -45,6 +45,9 @@ pub async fn clear_internal(ctx: Context<'_>) -> Result<(), Error> {
     verify(queue.len() > 1, CrackedError::QueueEmpty)?;
 
     clear_from(&guard, &handler, 1);
+    // The guard is held only for the mutation, not across the Discord round
+    // trips below (`send_reply`, `update_queue_messages`) -- see lease.rs.
+    drop(guard);
 
     // refetch the queue after modification
     let queue = handler.queue().current_queue();

--- a/crack-core/src/commands/music/doplay.rs
+++ b/crack-core/src/commands/music/doplay.rs
@@ -3,6 +3,7 @@ use crate::music::query::{query_type_from_url, ResolvedQuery};
 use crate::music::queue::{get_mode, get_msg, queue_track_back};
 use crate::music::NewQueryType;
 use crate::utils::edit_embed_response2;
+use crate::CrackedResult;
 use crate::{commands::get_call_or_join_author, http_utils::SendMessageParams};
 use crate::{
     errors::{verify, CrackedError},
@@ -19,7 +20,6 @@ use crate::{
     utils::get_track_handle_metadata,
     Context, Data, Error,
 };
-use crate::{http_utils, CrackedResult};
 use ::serenity::all::CreateAutocompleteResponse;
 use ::serenity::{
     all::{CommandInteraction, Message},
@@ -95,7 +95,7 @@ pub async fn search(
     play_internal(ctx, Some("search".to_string()), None, Some(query)).await
 }
 
-use crack_testing::{suggestion2, ResolvedTrack};
+use crack_testing::suggestion2;
 
 /// Autocomplete to suggest a search query.
 pub async fn autocomplete<'a>(
@@ -185,34 +185,12 @@ pub async fn playfile(
     play_internal(ctx, None, Some(file), None).await
 }
 
-use songbird::input::{Input as SongbirdInput, YoutubeDl};
-
-/// Enqueue an extrernal queue of resolved tracks to the internal queue
-/// for the bot in songbird.
-pub async fn enqueue_resolved_tracks(
-    call: Arc<Mutex<Call>>,
-    tracks: Vec<ResolvedTrack<'_>>,
-    mode: crack_types::Mode,
-) -> Vec<TrackHandle> {
-    let mut handler = call.lock().await;
-    let http_client = http_utils::get_client_old();
-    let mut out_tracks: Vec<TrackHandle> = Vec::new();
-    match mode {
-        crack_types::Mode::End => {
-            for track in tracks.iter() {
-                let ytdl = YoutubeDl::new(http_client.clone(), track.get_url());
-                let res = handler
-                    .enqueue_input(Into::<SongbirdInput>::into(ytdl))
-                    .await;
-                //handler.queue()
-                out_tracks.push(res);
-            }
-        },
-        //crack_types::Mode::Next => {},
-        _ => unimplemented!(),
-    }
-    out_tracks
-}
+// `enqueue_resolved_tracks` (called `handler.enqueue_input(...)` directly,
+// bypassing the guard funnel) was removed here: both its call sites were
+// already commented out (below, and queue.rs's `queue_query_list_offset`),
+// and being `pub` it never tripped `dead_code`, so it sat as an unguarded
+// public escape hatch of exactly the class this funnel exists to close. Use
+// `enqueue_resolved_tracks_back` instead if this is ever needed again.
 
 // /// Pushes a track to the front of the queue, after readying it.
 // pub async fn queue_track_ready_front(

--- a/crack-core/src/commands/music/gp.rs
+++ b/crack-core/src/commands/music/gp.rs
@@ -1620,6 +1620,12 @@ impl Data {
                 // Reclaimed before anything is restored into the guild -- the
                 // arbitration #431 needed, so a resumed game and a restored
                 // queue cannot both take the voice channel.
+                //
+                // 🪤 This branch is unreachable today: `claim_playback` only
+                // errs for a *different* owner, and `Game` is the only owner
+                // that exists. It stays as deliberate defensive coding for
+                // when a second `PlaybackOwner` variant arrives -- not dead
+                // code to be simplified away.
                 if self.claim_playback(guild_id, PlaybackOwner::Game).is_err() {
                     return false;
                 }
@@ -5775,10 +5781,15 @@ mod test {
         assert_lease_agrees(&data, G);
     }
 
+    /// `gp_restore` returns false when `/gp start` got there first. This guards
+    /// the `Entry::Occupied` arm only: it must never claim, release, or
+    /// otherwise disturb the lease the running game already holds.
+    ///
+    /// 🪤 It does NOT exercise the Vacant-arm claim -- it structurally cannot
+    /// reach that branch. `gp_restore_claims_playback` covers that, and does
+    /// fail without the claim line.
     #[test]
-    fn a_refused_restore_does_not_claim() {
-        // `gp_restore` returns false when /gp start got there first. The lease
-        // is already held by that game; the refused restore must not touch it.
+    fn restoring_over_a_live_game_leaves_the_lease_alone() {
         let (data, _rx) = recording();
         start_a_game(&data, G);
         assert!(!data.gp_restore(G, a_game(G)));

--- a/crack-core/src/commands/music/gp.rs
+++ b/crack-core/src/commands/music/gp.rs
@@ -32,6 +32,7 @@ use crate::{
         SPOTIFY_NOTHING_PLAYABLE,
     },
     music::queue::build_track,
+    music::PlaybackOwner,
     poise_ext::PoiseContextExt,
     sources::sleevenote,
     Context, CrackedResult, Data, Error,
@@ -1021,6 +1022,10 @@ impl Data {
         );
         game.players.insert(host, host_name);
         let opened = game.open_window(now);
+        // 🔑 Claimed here, inside the branch that inserts, so the lease and the
+        // map move together. See music/lease.rs on why this must not be called
+        // from anywhere else.
+        self.claim_playback(guild_id, PlaybackOwner::Game)?;
         slot.insert(game);
         Ok(opened)
     }
@@ -1580,6 +1585,7 @@ impl Data {
             .is_some_and(|g| g.parked_for_end);
         if parked {
             if let Some((_, game)) = self.gp_games.remove(&guild_id) {
+                self.release_playback(guild_id);
                 self.gp_mark_finished(&game, GpOutcome::Ended);
             }
         }
@@ -1594,6 +1600,7 @@ impl Data {
     /// after a redeploy and come back.
     pub fn gp_remove(&self, guild_id: GuildId) -> Option<GpGame> {
         let (_, game) = self.gp_games.remove(&guild_id)?;
+        self.release_playback(guild_id);
         let outcome = if game.parked_for_end {
             GpOutcome::Ended
         } else if game.phase == GpPhase::Finished {
@@ -1610,6 +1617,12 @@ impl Data {
     pub fn gp_restore(&self, guild_id: GuildId, game: GpGame) -> bool {
         match self.gp_games.entry(guild_id) {
             dashmap::mapref::entry::Entry::Vacant(slot) => {
+                // Reclaimed before anything is restored into the guild -- the
+                // arbitration #431 needed, so a resumed game and a restored
+                // queue cannot both take the voice channel.
+                if self.claim_playback(guild_id, PlaybackOwner::Game).is_err() {
+                    return false;
+                }
                 slot.insert(game);
                 true
             },
@@ -5647,5 +5660,128 @@ mod test {
                 assert!(sub.parameters[1..].iter().all(|p| !p.required));
             }
         }
+    }
+
+    // --- Playback lease ------------------------------------------------
+    //
+    // The primitives (`claim_playback`, `release_playback`, `lock_queue`) have
+    // their own tests in `music/lease.rs`. These exercise the lease as wired
+    // into the five places that move `gp_games` in this file.
+
+    use crate::commands::music::gp_persist::GpPersist;
+    use tokio::sync::mpsc;
+
+    /// A `Data` whose persistence writes land in a channel rather than
+    /// Postgres. Mirrors `gp_persist::test::recording`.
+    fn recording() -> (Data, mpsc::UnboundedReceiver<GpPersist>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let data = Data(Arc::new(DataInner {
+            gp_persist: Some(tx),
+            ..Default::default()
+        }));
+        (data, rx)
+    }
+
+    /// A minimal game, enough for `gp_restore` to accept.
+    fn a_game(guild_id: GuildId) -> GpGame {
+        GpGame::new(
+            guild_id,
+            A,
+            VC,
+            TC,
+            GpCategory::Nostalgia,
+            prompts(&["p1"]),
+            TIMER,
+            None,
+            GpReveal::default(),
+            true,
+            NOW,
+        )
+    }
+
+    /// Starts a minimal game and asserts it succeeded, so the tests below read
+    /// as lifecycle rather than setup.
+    fn start_a_game(data: &Data, guild_id: GuildId) {
+        data.gp_start(
+            guild_id,
+            A,
+            "alice".into(),
+            VC,
+            TC,
+            GpCategory::Nostalgia,
+            prompts(&["p1"]),
+            TIMER,
+            None,
+            GpReveal::default(),
+            true,
+            NOW,
+        )
+        .expect("gp_start should succeed");
+    }
+
+    /// The lease and the games map must agree after EVERY game-lifecycle method.
+    /// This is the regression guard for the drift the co-location design exists
+    /// to prevent: a lease that outlives its game wedges /play forever, with no
+    /// game left to end.
+    fn assert_lease_agrees(data: &Data, guild_id: GuildId) {
+        let has_game = data.gp_games.contains_key(&guild_id);
+        let owned = data.playback_owner(guild_id) == PlaybackOwner::Game;
+        assert_eq!(
+            has_game, owned,
+            "gp_games says {has_game} but the lease says {owned} for {guild_id}"
+        );
+    }
+
+    #[test]
+    fn gp_start_claims_playback() {
+        let (data, _rx) = recording();
+        assert_lease_agrees(&data, G);
+        start_a_game(&data, G);
+        assert_eq!(data.playback_owner(G), PlaybackOwner::Game);
+        assert_lease_agrees(&data, G);
+    }
+
+    #[test]
+    fn gp_remove_releases_playback() {
+        let (data, _rx) = recording();
+        start_a_game(&data, G);
+        data.gp_remove(G);
+        assert_eq!(data.playback_owner(G), PlaybackOwner::Free);
+        assert_lease_agrees(&data, G);
+    }
+
+    #[test]
+    fn gp_remove_if_parked_releases_only_when_it_removes() {
+        let (data, _rx) = recording();
+        start_a_game(&data, G);
+
+        // Not parked: nothing is removed, so nothing is released.
+        assert!(!data.gp_remove_if_parked(G));
+        assert_eq!(data.playback_owner(G), PlaybackOwner::Game);
+        assert_lease_agrees(&data, G);
+
+        data.gp_park_for_end(G, A, true).expect("park");
+        assert!(data.gp_remove_if_parked(G));
+        assert_eq!(data.playback_owner(G), PlaybackOwner::Free);
+        assert_lease_agrees(&data, G);
+    }
+
+    #[test]
+    fn gp_restore_claims_playback() {
+        let (data, _rx) = recording();
+        let game = a_game(G);
+        assert!(data.gp_restore(G, game));
+        assert_eq!(data.playback_owner(G), PlaybackOwner::Game);
+        assert_lease_agrees(&data, G);
+    }
+
+    #[test]
+    fn a_refused_restore_does_not_claim() {
+        // `gp_restore` returns false when /gp start got there first. The lease
+        // is already held by that game; the refused restore must not touch it.
+        let (data, _rx) = recording();
+        start_a_game(&data, G);
+        assert!(!data.gp_restore(G, a_game(G)));
+        assert_lease_agrees(&data, G);
     }
 }

--- a/crack-core/src/commands/music/gp.rs
+++ b/crack-core/src/commands/music/gp.rs
@@ -3211,12 +3211,18 @@ pub async fn gp_skip(ctx: Context<'_>) -> Result<(), Error> {
         .get(guild_id)
         .ok_or(CrackedError::NotConnected)?;
     {
+        // `force_skip_top_track` now requires a `QueueGuard` -- Task 4/5's
+        // funnel work broke this call site mechanically. Locking as `Game`
+        // succeeds here because this guild's game already owns playback (see
+        // `the_owner_can_still_lock_its_own_queue` in lease.rs); the rest of
+        // this file's migration to the guard-taking helpers is Task 6's.
+        let guard = data.lock_queue(guild_id, PlaybackOwner::Game).await?;
         let handler = call.lock().await;
         if handler.queue().is_empty() {
             return Err(CrackedError::NothingPlaying.into());
         }
         // stop() fires TrackEvent::End, which is what advances the game.
-        force_skip_top_track(&handler).await?;
+        force_skip_top_track(&guard, &handler).await?;
     }
     ctx.send_reply(CrackedMessage::GpRoundSkipped, true).await?;
     Ok(())
@@ -3334,12 +3340,18 @@ async fn gp_voteskip_internal(ctx: Context<'_>) -> CrackedResult<GpVoteAnswer> {
             .songbird
             .get(guild_id)
             .ok_or(CrackedError::NotConnected)?;
+        // `force_skip_top_track` now requires a `QueueGuard` -- Task 4/5's
+        // funnel work broke this call site mechanically. Locking as `Game`
+        // succeeds here because this guild's game already owns playback (see
+        // `the_owner_can_still_lock_its_own_queue` in lease.rs); the rest of
+        // this file's migration to the guard-taking helpers is Task 6's.
+        let guard = data.lock_queue(guild_id, PlaybackOwner::Game).await?;
         let handler = call.lock().await;
         if handler.queue().is_empty() {
             return Err(CrackedError::NothingPlaying);
         }
         // stop() fires TrackEvent::End, which is what advances the game.
-        force_skip_top_track(&handler).await?;
+        force_skip_top_track(&guard, &handler).await?;
     }
     Ok(answer)
 }

--- a/crack-core/src/commands/music/gp.rs
+++ b/crack-core/src/commands/music/gp.rs
@@ -148,18 +148,21 @@ pub const GP_CUSTOM_ID_PREFIX: &str = "gp:";
 /// song. Matched against the command's *qualified* name so `gp skip` is not caught
 /// by `skip`.
 ///
-/// # The property this list has
+/// # What `blocklist_matches_registry` actually checks
 ///
-/// It is exactly **the registered music commands that take a [`QueueGuard`] as
-/// [`PlaybackOwner::Free`]** -- no more and no less. That is checkable rather
-/// than trusted: `grep -rln "lock_queue(guild_id, PlaybackOwner::Free)"
-/// crack-core/src/commands` names the files, and `blocklist_matches_registry`
-/// asserts every name here is registered and runs a check.
+/// Only that every name here is a registered music command that runs a check
+/// -- not that this is the exact set of commands that take a [`QueueGuard`] as
+/// [`PlaybackOwner::Free`]. The converse does not hold: `leave`, `summon`,
+/// `summonchannel`, `seek` and `repeat` are on this list and take no guard at
+/// all. See "What the funnel does NOT cover" in
+/// `docs/superpowers/specs/2026-09-10-playback-ownership-lease-design.md` for
+/// why voice-state and track-state commands are blocked here without one.
 ///
-/// Both halves matter, and each has already failed once. `remove` sat here from
-/// #422 with no `check = "cmd_check_music"`, so its entry never fired; `resume`
-/// took the guard but was absent from this list *and* from the funnel, which is
-/// the one case where a user could still land a mutation on a live round.
+/// Both halves the test *does* check have already failed once. `remove` sat
+/// here from #422 with no `check = "cmd_check_music"`, so its entry never
+/// fired; `resume` took the guard but was absent from this list *and* from the
+/// funnel, which is the one case where a user could still land a mutation on a
+/// live round.
 ///
 /// [`QueueGuard`]: crate::music::QueueGuard
 pub const GP_BLOCKED_COMMANDS: &[&str] = &[

--- a/crack-core/src/commands/music/gp.rs
+++ b/crack-core/src/commands/music/gp.rs
@@ -31,7 +31,7 @@ use crate::{
         GP_WINDOW_EMPTY, GP_WINDOW_WARNING, GP_WINDOW_WARNING_IN, SPOTIFY_GP_ONE_SONG,
         SPOTIFY_NOTHING_PLAYABLE,
     },
-    music::queue::build_track,
+    music::queue::{build_track, enqueue_track_back, stop_queue},
     music::PlaybackOwner,
     poise_ext::PoiseContextExt,
     sources::sleevenote,
@@ -2269,7 +2269,25 @@ async fn gp_abort(pb: &GpPlayback, text_channel: GenericChannelId, reason: &str)
         return;
     }
     tracing::warn!("gp: {reason} in {}, game discarded", pb.guild_id);
-    pb.call.lock().await.queue().stop();
+    // 🪤 ORDER MATTERS: lock as whoever holds the lease *at this line*.
+    // `gp_remove` four lines above already released it, so the guild is `Free`
+    // by the time we get here and `Free` is what must be passed. Locking as
+    // `Game` would be refused, and a refusal is silent -- the queue would
+    // simply play on under a game that no longer exists.
+    match pb.data.lock_queue(pb.guild_id, PlaybackOwner::Free).await {
+        Ok(guard) => {
+            let handler = pb.call.lock().await;
+            stop_queue(&guard, &handler);
+        },
+        Err(e) => tracing::warn!(
+            "gp: could not lock the queue to abort in {}: {e}",
+            pb.guild_id
+        ),
+    }
+    // Both the guard and the call lock are dropped above, before the Discord
+    // round trip below: `stop()` fires `End` inline on songbird's event task,
+    // and a handler awaiting `lock_queue` would park that task for the length
+    // of this send. See `stop_queue`.
     // Best effort: the channel is usually what just failed.
     if let Err(e) = text_channel
         .send_message(&pb.http, CreateMessage::new().content(GP_ABORTED))
@@ -2488,8 +2506,30 @@ pub async fn gp_play_track(pb: &GpPlayback, start: GpTrackStart) -> Result<(), E
     }
 
     let handle = {
-        let mut handler = pb.call.lock().await;
-        handler.enqueue(songbird_track).await
+        // The game still owns playback here: `gp_start` claimed the lease and
+        // nothing on this path has released it, so lock as `Game`. `Free` would
+        // be refused and the song would silently never be enqueued -- no `End`
+        // would ever arrive and the round would hang forever.
+        let guard = match pb.data.lock_queue(guild_id, PlaybackOwner::Game).await {
+            Ok(guard) => guard,
+            Err(e) => {
+                // Unreachable while `PlaybackOwner` has only `Free` and `Game`
+                // -- locking as `Game` matches both -- but a third owner is
+                // foreseeable, and a song that cannot be enqueued is fatal to
+                // the round in exactly the way the two aborts below are.
+                gp_abort(
+                    pb,
+                    start.text_channel,
+                    &format!("locking the queue to play failed: {e}"),
+                )
+                .await;
+                return Ok(());
+            },
+        };
+        enqueue_track_back(&guard, &pb.call, songbird_track).await
+        // The guard drops with this block, before the seek below: forcing the
+        // stream open is the slow leg, and `lease.rs` forbids holding exclusion
+        // across one. Nothing after this point mutates the queue.
     };
 
     // Arm every handler before awaiting anything. The seek below is the first
@@ -3015,14 +3055,26 @@ pub async fn gp_start(
         round_results,
         now(),
     )?;
+    // `data.gp_start` above claimed the lease, so the game owns playback by the
+    // time we reach here and this must lock as `Game`; `Free` would be refused
+    // and the previous queue would keep playing underneath the new game.
+    // 🪤 Do NOT reorder the claim below this call to make the guild `Free`
+    // here: creating the game first is load-bearing, for the reason the comment
+    // above `data.gp_start` gives. Locking as `Game` cannot be refused (`as_`
+    // matches both `Free` and `Game`), so this `?` cannot orphan the game that
+    // was just created.
+    let guard = data.lock_queue(guild_id, PlaybackOwner::Game).await?;
     let cleared_queue = {
         let handler = call.lock().await;
         let non_empty = !handler.queue().is_empty();
         if non_empty {
-            handler.queue().stop();
+            stop_queue(&guard, &handler);
         }
         non_empty
     };
+    // Released before the Discord round trip below -- `stop_queue` fires `End`
+    // inline on songbird's event task, which must not wait out a send.
+    drop(guard);
 
     ctx.send_reply(
         CrackedMessage::GpStarted {
@@ -3211,11 +3263,10 @@ pub async fn gp_skip(ctx: Context<'_>) -> Result<(), Error> {
         .get(guild_id)
         .ok_or(CrackedError::NotConnected)?;
     {
-        // `force_skip_top_track` now requires a `QueueGuard` -- Task 4/5's
-        // funnel work broke this call site mechanically. Locking as `Game`
-        // succeeds here because this guild's game already owns playback (see
-        // `the_owner_can_still_lock_its_own_queue` in lease.rs); the rest of
-        // this file's migration to the guard-taking helpers is Task 6's.
+        // Locking as `Game` succeeds here because this guild's game already
+        // owns playback and has not released it (see
+        // `the_owner_can_still_lock_its_own_queue` in lease.rs); `Free` would
+        // be refused and the skip would silently do nothing.
         let guard = data.lock_queue(guild_id, PlaybackOwner::Game).await?;
         let handler = call.lock().await;
         if handler.queue().is_empty() {
@@ -3340,11 +3391,10 @@ async fn gp_voteskip_internal(ctx: Context<'_>) -> CrackedResult<GpVoteAnswer> {
             .songbird
             .get(guild_id)
             .ok_or(CrackedError::NotConnected)?;
-        // `force_skip_top_track` now requires a `QueueGuard` -- Task 4/5's
-        // funnel work broke this call site mechanically. Locking as `Game`
-        // succeeds here because this guild's game already owns playback (see
-        // `the_owner_can_still_lock_its_own_queue` in lease.rs); the rest of
-        // this file's migration to the guard-taking helpers is Task 6's.
+        // Locking as `Game` succeeds here because this guild's game already
+        // owns playback and has not released it (see
+        // `the_owner_can_still_lock_its_own_queue` in lease.rs); `Free` would
+        // be refused and the skip would silently do nothing.
         let guard = data.lock_queue(guild_id, PlaybackOwner::Game).await?;
         let handler = call.lock().await;
         if handler.queue().is_empty() {
@@ -3443,10 +3493,17 @@ pub async fn gp_end(ctx: Context<'_>) -> Result<(), Error> {
     let game = data.gp_park_for_end(guild_id, ctx.author().id, is_admin)?;
     let was_playing = match data.songbird.get(guild_id) {
         Some(call) => {
+            // `gp_park_for_end` only sets a flag -- the game stays in the map,
+            // and with it the lease, until `gp_remove_if_parked` collects it in
+            // the track-end handler. So the game still owns playback here and
+            // this locks as `Game`; `Free` would be refused and the queue would
+            // never stop, leaving the parked game with no `End` to collect it.
+            let guard = data.lock_queue(guild_id, PlaybackOwner::Game).await?;
             let handler = call.lock().await;
             let playing = !handler.queue().is_empty();
-            handler.queue().stop();
+            stop_queue(&guard, &handler);
             playing
+            // Both locks drop with this arm, before the replies below.
         },
         None => false,
     };

--- a/crack-core/src/commands/music/gp.rs
+++ b/crack-core/src/commands/music/gp.rs
@@ -31,7 +31,7 @@ use crate::{
         GP_WINDOW_EMPTY, GP_WINDOW_WARNING, GP_WINDOW_WARNING_IN, SPOTIFY_GP_ONE_SONG,
         SPOTIFY_NOTHING_PLAYABLE,
     },
-    music::queue::{build_track, enqueue_track_back, stop_queue},
+    music::queue::{build_track, enqueue_track_back, preload_time, stop_queue},
     music::PlaybackOwner,
     poise_ext::PoiseContextExt,
     sources::sleevenote,
@@ -165,6 +165,7 @@ pub const GP_BLOCKED_COMMANDS: &[&str] = &[
     "seek",
     "repeat",
     "pause",
+    "resume",
     "summon",
     "summonchannel",
 ];
@@ -2526,10 +2527,14 @@ pub async fn gp_play_track(pb: &GpPlayback, start: GpTrackStart) -> Result<(), E
                 return Ok(());
             },
         };
-        enqueue_track_back(&guard, &pb.call, songbird_track).await
-        // The guard drops with this block, before the seek below: forcing the
-        // stream open is the slow leg, and `lease.rs` forbids holding exclusion
-        // across one. Nothing after this point mutates the queue.
+        // The preload time is computed from metadata already in hand rather
+        // than derived by songbird, which would spawn yt-dlp here, under the
+        // guard -- see `preload_time`.
+        enqueue_track_back(&guard, &pb.call, songbird_track, preload_time(&start.track)).await
+        // The guard drops with this block, before the seek below. Both are slow
+        // legs -- the enqueue above no longer is, now that it does not run
+        // yt-dlp -- and `lease.rs` forbids holding exclusion across either.
+        // Nothing after this point mutates the queue.
     };
 
     // Arm every handler before awaiting anything. The seek below is the first
@@ -5639,7 +5644,28 @@ mod test {
         // The game has its own `/gp voteskip`; the music one bypasses the majority.
         assert!(GP_BLOCKED_COMMANDS.contains(&"voteskip"));
         assert!(!GP_BLOCKED_COMMANDS.contains(&"gp"));
-        assert!(!GP_BLOCKED_COMMANDS.contains(&"resume"), "the escape hatch");
+        // `resume` used to be left off deliberately, as an escape hatch for a
+        // queue somebody had paused. The playback lease withdrew that: `/resume`
+        // mutates the queue, so it now takes a `QueueGuard` and a guild the game
+        // owns refuses it there whatever this list says. Leaving it off only
+        // bought a later, less explanatory refusal -- and until the guard
+        // existed it bought a real one, `queue.resume()` landing on a live round.
+        assert!(GP_BLOCKED_COMMANDS.contains(&"resume"));
+        // A blocked name does nothing unless its command actually runs the
+        // check. `remove` sat on this list for exactly that reason with no
+        // `check = "cmd_check_music"`, so its entry was inert.
+        let by_name: std::collections::HashMap<String, _> =
+            crate::commands::music::music_commands()
+                .into_iter()
+                .map(|c| (c.name.to_string(), c.checks.len()))
+                .collect();
+        for blocked in GP_BLOCKED_COMMANDS {
+            assert_ne!(
+                by_name.get(*blocked).copied().unwrap_or_default(),
+                0,
+                "{blocked} is blocked but runs no check, so the block never fires"
+            );
+        }
         for sub in &gp().subcommands {
             let qualified = format!("gp {}", sub.name);
             assert!(!GP_BLOCKED_COMMANDS.contains(&qualified.as_str()));

--- a/crack-core/src/commands/music/gp.rs
+++ b/crack-core/src/commands/music/gp.rs
@@ -147,6 +147,21 @@ pub const GP_CUSTOM_ID_PREFIX: &str = "gp:";
 /// The game's own `/gp skip` and `/gp voteskip` are the sanctioned ways to end a
 /// song. Matched against the command's *qualified* name so `gp skip` is not caught
 /// by `skip`.
+///
+/// # The property this list has
+///
+/// It is exactly **the registered music commands that take a [`QueueGuard`] as
+/// [`PlaybackOwner::Free`]** -- no more and no less. That is checkable rather
+/// than trusted: `grep -rln "lock_queue(guild_id, PlaybackOwner::Free)"
+/// crack-core/src/commands` names the files, and `blocklist_matches_registry`
+/// asserts every name here is registered and runs a check.
+///
+/// Both halves matter, and each has already failed once. `remove` sat here from
+/// #422 with no `check = "cmd_check_music"`, so its entry never fired; `resume`
+/// took the guard but was absent from this list *and* from the funnel, which is
+/// the one case where a user could still land a mutation on a live round.
+///
+/// [`QueueGuard`]: crate::music::QueueGuard
 pub const GP_BLOCKED_COMMANDS: &[&str] = &[
     "play",
     "playnext",
@@ -5651,6 +5666,18 @@ mod test {
         // bought a later, less explanatory refusal -- and until the guard
         // existed it bought a real one, `queue.resume()` landing on a live round.
         assert!(GP_BLOCKED_COMMANDS.contains(&"resume"));
+        // 🪤 `downvote` (`skip.rs`) belongs to this list by every property it
+        // has -- it takes the guard as `Free` and mutates the queue through
+        // `force_skip_top_track` -- and is deliberately absent, because it is
+        // registered nowhere: `music_commands()` does not list it, so
+        // `all_commands()` does not either, and the assertion above would
+        // reject it. Registering it is not a formality; as written it
+        // `.unwrap()`s `queue().current()` and would panic on an empty queue.
+        // The day it is registered, this fails and says what to do about it.
+        assert!(
+            !music.contains(&"downvote".to_string()),
+            "downvote is registered now -- add it to GP_BLOCKED_COMMANDS"
+        );
         // A blocked name does nothing unless its command actually runs the
         // check. `remove` sat on this list for exactly that reason with no
         // `check = "cmd_check_music"`, so its entry was inert.

--- a/crack-core/src/commands/music/gp_persist.rs
+++ b/crack-core/src/commands/music/gp_persist.rs
@@ -616,7 +616,14 @@ pub async fn gp_resume_guild(data: &Data, ctx: &SerenityContext, guild: &Guild) 
         Ok(call) => call,
         Err(e) => {
             tracing::warn!("gp: rejoining {voice_channel} in {guild_id} to resume: {e}");
-            data.gp_games.remove(&guild_id);
+            // Through the method, not the map: `gp_remove` is the one place a
+            // game ends, and it is what releases the playback lease. A raw
+            // remove here would leave the guild owned by a game that no longer
+            // exists, and /play refused forever. Its own bookkeeping write is
+            // superseded below: the free function is the authoritative
+            // database write for this path, since `gp_remove`'s in-memory
+            // `game` reflects the pre-rejoin-failure state.
+            data.gp_remove(guild_id);
             if let Err(e) =
                 gp_mark_finished(pool, game_id(guild_id), started_at, GpOutcome::Lost).await
             {

--- a/crack-core/src/commands/music/pause.rs
+++ b/crack-core/src/commands/music/pause.rs
@@ -2,6 +2,7 @@ use crate::{
     commands::cmd_check_music,
     errors::{verify, CrackedError},
     messaging::message::CrackedMessage,
+    music::{queue::pause_queue, PlaybackOwner},
     poise_ext::ContextExt,
     utils::send_reply,
     {Context, Error},
@@ -17,10 +18,27 @@ use crate::{
     guild_only
 )]
 pub async fn pause(ctx: Context<'_>) -> Result<(), Error> {
-    let queue = ctx.get_queue().await?;
+    // `get_call_guild_id`, not `get_queue`: a cloned `TrackQueue` is a handle to
+    // the same queue with no `Call` attached, and the guard-taking helpers need
+    // the `Call`. Cloning it was also what hid this mutation from every
+    // verification grep in this branch.
+    let (call, guild_id) = ctx.get_call_guild_id().await?;
 
-    verify(!queue.is_empty(), CrackedError::NothingPlaying)?;
-    verify(queue.pause(), CrackedError::Other("Failed to pause"))?;
+    // Ordinary music commands mutate as `Free`; a guild a game owns refuses
+    // here, which is the same refusal GP_BLOCKED_COMMANDS gives earlier and
+    // more kindly. This one cannot be forgotten.
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
+    {
+        let handler = call.lock().await;
+
+        verify(!handler.queue().is_empty(), CrackedError::NothingPlaying)?;
+        verify(
+            pause_queue(&guard, &handler),
+            CrackedError::Other("Failed to pause"),
+        )?;
+    }
+    // Held for the mutation, not across the reply below.
+    drop(guard);
 
     send_reply(&ctx, CrackedMessage::Pause, true).await?;
     Ok(())

--- a/crack-core/src/commands/music/remove.rs
+++ b/crack-core/src/commands/music/remove.rs
@@ -4,6 +4,7 @@ use crate::{
     handlers::track_end::update_queue_messages,
     messaging::message::CrackedMessage,
     messaging::messages::REMOVED_QUEUE,
+    music::{remove_at, PlaybackOwner},
     utils::send_reply,
     utils::{get_track_handle_metadata, send_embed_response_poise},
     Context, Error,
@@ -46,6 +47,10 @@ pub async fn remove_internal(
         None => remove_index,
     };
 
+    // Ordinary music commands mutate as `Free`; a guild a game owns refuses
+    // here, which is the same refusal GP_BLOCKED_COMMANDS gives earlier and
+    // more kindly. This one cannot be forgotten.
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let handler = call.lock().await;
     let queue = handler.queue().current_queue();
 
@@ -69,14 +74,11 @@ pub async fn remove_internal(
 
     let track = queue.get(remove_index).unwrap();
 
-    handler.queue().modify_queue(|v| {
-        // This is what songbird does internally when it stops the queue
-        // so it should be the right thing to do here.
-        v.drain(remove_index..=remove_until).for_each(|x| {
-            let _ = x.stop();
-            drop(x);
-        });
-    });
+    // Removing repeatedly at `remove_index` shifts each later track down into
+    // it, so this reaches the same tracks as the old `v.drain(a..=b)` did.
+    for _ in remove_index..=remove_until {
+        remove_at(&guard, &handler, remove_index);
+    }
 
     // refetch the queue after modification
     let queue = handler.queue().current_queue();

--- a/crack-core/src/commands/music/remove.rs
+++ b/crack-core/src/commands/music/remove.rs
@@ -79,6 +79,9 @@ pub async fn remove_internal(
     for _ in remove_index..=remove_until {
         remove_at(&guard, &handler, remove_index);
     }
+    // The guard is held only for the mutation, not across the Discord round
+    // trips below (the reply, then `update_queue_messages`) -- see lease.rs.
+    drop(guard);
 
     // refetch the queue after modification
     let queue = handler.queue().current_queue();

--- a/crack-core/src/commands/music/remove.rs
+++ b/crack-core/src/commands/music/remove.rs
@@ -1,5 +1,6 @@
 use self::serenity::builder::CreateEmbed;
 use crate::{
+    commands::cmd_check_music,
     errors::{verify, CrackedError},
     handlers::track_end::update_queue_messages,
     messaging::message::CrackedMessage,
@@ -15,7 +16,13 @@ use std::cmp::min;
 
 /// Remove track(s) from the queue.
 #[cfg(not(tarpaulin_include))]
-#[poise::command(category = "Music", prefix_command, slash_command, guild_only)]
+#[poise::command(
+    category = "Music",
+    check = "cmd_check_music",
+    prefix_command,
+    slash_command,
+    guild_only
+)]
 pub async fn remove(
     ctx: Context<'_>,
     #[description = "Index in the queue to remove (Or number of tracks to remove if no second argument."]

--- a/crack-core/src/commands/music/resume.rs
+++ b/crack-core/src/commands/music/resume.rs
@@ -1,13 +1,21 @@
 use crate::{
+    commands::cmd_check_music,
     errors::{verify, CrackedError},
     messaging::message::CrackedMessage,
+    music::{queue::resume_queue, PlaybackOwner},
     utils::send_reply,
     {Context, Error},
 };
 
 /// Resume the current track.
 #[cfg(not(tarpaulin_include))]
-#[poise::command(category = "Music", slash_command, prefix_command, guild_only)]
+#[poise::command(
+    category = "Music",
+    check = "cmd_check_music",
+    slash_command,
+    prefix_command,
+    guild_only
+)]
 pub async fn resume(ctx: Context<'_>) -> Result<(), Error> {
     resume_internal(ctx).await
 }
@@ -18,11 +26,24 @@ pub async fn resume_internal(ctx: Context<'_>) -> Result<(), Error> {
     let songbird = ctx.data().songbird.clone();
     let call = songbird.get(guild_id).ok_or(CrackedError::NotConnected)?;
 
-    let handler = call.lock().await;
-    let queue = handler.queue();
+    // Ordinary music commands mutate as `Free`; a guild a game owns refuses
+    // here, which is the same refusal GP_BLOCKED_COMMANDS gives earlier and
+    // more kindly. This one cannot be forgotten.
+    //
+    // 🔴 `/resume` reached `queue.resume()` on a running `/gp` round until this
+    // line existed: it was on neither the blocklist nor the funnel. The
+    // blocklist entry added alongside is the friendlier of the two refusals;
+    // this is the one that cannot be forgotten.
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
+    {
+        let handler = call.lock().await;
 
-    verify(!queue.is_empty(), CrackedError::NothingPlaying)?;
-    verify(queue.resume(), CrackedError::FailedResume)?;
+        verify(!handler.queue().is_empty(), CrackedError::NothingPlaying)?;
+        verify(resume_queue(&guard, &handler), CrackedError::FailedResume)?;
+    }
+    // Resuming does not fire `End`, but the guard still goes before the Discord
+    // round trip -- exclusion is held for milliseconds, never for a send.
+    drop(guard);
 
     send_reply(&ctx, CrackedMessage::Resume, true).await?;
 

--- a/crack-core/src/commands/music/shuffle.rs
+++ b/crack-core/src/commands/music/shuffle.rs
@@ -1,9 +1,13 @@
 use crate::{
-    commands::cmd_check_music, errors::verify, handlers::track_end::update_queue_messages,
-    messaging::message::CrackedMessage, poise_ext::ContextExt, utils::send_reply, Context,
-    CrackedError, Error,
+    commands::cmd_check_music,
+    errors::verify,
+    handlers::track_end::update_queue_messages,
+    messaging::message::CrackedMessage,
+    music::{move_track, shuffle_behind_current, PlaybackOwner},
+    poise_ext::ContextExt,
+    utils::send_reply,
+    Context, CrackedError, Error,
 };
-use rand::RngExt;
 
 /// Move a song in the queue to a different position.
 #[cfg(not(tarpaulin_include))]
@@ -28,6 +32,10 @@ pub async fn movesong_internal(ctx: Context<'_>, at: usize, to: usize) -> Result
     let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
     let call = ctx.get_call().await?;
 
+    // Ordinary music commands mutate as `Free`; a guild a game owns refuses
+    // here, which is the same refusal GP_BLOCKED_COMMANDS gives earlier and
+    // more kindly. This one cannot be forgotten.
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let handler = call.lock().await;
     let len = handler.queue().current_queue().len();
     verify(
@@ -39,11 +47,7 @@ pub async fn movesong_internal(ctx: Context<'_>, at: usize, to: usize) -> Result
         CrackedError::Other("Index for `to` out of bounds"),
     )?;
 
-    handler.queue().modify_queue(|queue| {
-        // We verified before that this index is good, so this is safe.
-        let song = queue.remove(at).expect("Index out of bounds");
-        queue.insert(to, song);
-    });
+    move_track(&guard, &handler, at, to);
 
     // refetch the queue after modification
     let queue = handler.queue().current_queue();
@@ -67,11 +71,12 @@ pub async fn shuffle(ctx: Context<'_>) -> Result<(), Error> {
     let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
     let call = ctx.get_call().await?;
 
+    // Ordinary music commands mutate as `Free`; a guild a game owns refuses
+    // here, which is the same refusal GP_BLOCKED_COMMANDS gives earlier and
+    // more kindly. This one cannot be forgotten.
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let handler = call.lock().await;
-    handler.queue().modify_queue(|queue| {
-        // skip the first track on queue because it's being played
-        fisher_yates(queue.make_contiguous()[1..].as_mut(), &mut rand::rng())
-    });
+    shuffle_behind_current(&guard, &handler);
 
     // refetch the queue after modification
     let queue = handler.queue().current_queue();
@@ -80,27 +85,4 @@ pub async fn shuffle(ctx: Context<'_>) -> Result<(), Error> {
     send_reply(&ctx, CrackedMessage::Shuffle, true).await?;
     update_queue_messages(&ctx.serenity_context().http, ctx.data(), &queue, guild_id).await;
     Ok(())
-}
-
-fn fisher_yates<T, R>(values: &mut [T], mut rng: R)
-where
-    R: rand::Rng + Sized,
-{
-    let mut index = values.len();
-    while index >= 2 {
-        index -= 1;
-        values.swap(index, rng.random_range(0..(index + 1)));
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_fisher_yates() {
-        let mut values = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-        fisher_yates(&mut values, &mut rand::rng());
-        assert_ne!(values, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    }
 }

--- a/crack-core/src/commands/music/shuffle.rs
+++ b/crack-core/src/commands/music/shuffle.rs
@@ -48,6 +48,9 @@ pub async fn movesong_internal(ctx: Context<'_>, at: usize, to: usize) -> Result
     )?;
 
     move_track(&guard, &handler, at, to);
+    // The guard is held only for the mutation, not across the Discord round
+    // trips below (`send_reply`, `update_queue_messages`) -- see lease.rs.
+    drop(guard);
 
     // refetch the queue after modification
     let queue = handler.queue().current_queue();
@@ -77,6 +80,9 @@ pub async fn shuffle(ctx: Context<'_>) -> Result<(), Error> {
     let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let handler = call.lock().await;
     shuffle_behind_current(&guard, &handler);
+    // The guard is held only for the mutation, not across the Discord round
+    // trips below (`send_reply`, `update_queue_messages`) -- see lease.rs.
+    drop(guard);
 
     // refetch the queue after modification
     let queue = handler.queue().current_queue();

--- a/crack-core/src/commands/music/skip.rs
+++ b/crack-core/src/commands/music/skip.rs
@@ -4,6 +4,7 @@ use crate::{
     commands::get_call_or_join_author,
     errors::{verify, CrackedError},
     messaging::message::CrackedMessage,
+    music::{drain_after_current, PlaybackOwner, QueueGuard},
     poise_ext::PoiseContextExt,
     utils::get_track_handle_metadata,
     Context, Error,
@@ -29,6 +30,10 @@ pub async fn skip(
     let (call, guild_id) = ctx.get_call_guild_id().await?;
     let to_skip = num_tracks.unwrap_or(1) as usize;
 
+    // Ordinary music commands mutate as `Free`; a guild a game owns refuses
+    // here, which is the same refusal GP_BLOCKED_COMMANDS gives earlier and
+    // more kindly. This one cannot be forgotten.
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let handler = call.lock().await;
     let queue = handler.queue();
 
@@ -36,11 +41,9 @@ pub async fn skip(
 
     let tracks_to_skip = min(to_skip, queue.len());
 
-    handler.queue().modify_queue(|v| {
-        v.drain(1..tracks_to_skip);
-    });
+    drain_after_current(&guard, &handler, tracks_to_skip.saturating_sub(1));
 
-    force_skip_top_track(&handler).await?;
+    force_skip_top_track(&guard, &handler).await?;
     let msg = create_skip_response(ctx, &handler, tracks_to_skip).await?;
     ctx.data().add_msg_to_cache(guild_id, msg).await;
     Ok(())
@@ -91,13 +94,17 @@ pub async fn downvote(ctx: Context<'_>) -> Result<(), Error> {
 
     let call = get_call_or_join_author(ctx).await?;
 
+    // Ordinary music commands mutate as `Free`; a guild a game owns refuses
+    // here, which is the same refusal GP_BLOCKED_COMMANDS gives earlier and
+    // more kindly. This one cannot be forgotten.
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let handler = call.lock().await;
     let queue = handler.queue();
     let metadata = get_track_handle_metadata(&queue.current().unwrap()).await?;
 
     let source_url = &metadata.source_url.ok_or("ASDF").unwrap();
     let res1 = ctx.data().downvote_track(guild_id, source_url).await?;
-    let res2 = force_skip_top_track(&handler).await?;
+    let res2 = force_skip_top_track(&guard, &handler).await?;
 
     tracing::warn!("downvoted track: {:#?}", res1);
     tracing::warn!("refetched queue: {:#?}", res2);
@@ -106,10 +113,16 @@ pub async fn downvote(ctx: Context<'_>) -> Result<(), Error> {
 }
 
 /// Do the actual skipping of the top track.
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
 #[cfg(not(tarpaulin_include))]
 pub async fn force_skip_top_track(
+    guard: &QueueGuard,
     handler: &MutexGuard<'_, Call>,
 ) -> Result<Vec<TrackHandle>, CrackedError> {
+    let _ = guard;
     // this is an odd sequence of commands to ensure the queue is properly updated
     // apparently, skipping/stopping a track takes a while to remove it from the queue
     // also, manually removing tracks doesn't trigger the next track to play

--- a/crack-core/src/commands/music/skip.rs
+++ b/crack-core/src/commands/music/skip.rs
@@ -44,6 +44,9 @@ pub async fn skip(
     drain_after_current(&guard, &handler, tracks_to_skip.saturating_sub(1));
 
     force_skip_top_track(&guard, &handler).await?;
+    // The guard is held only for the mutations above, not across the Discord
+    // round trip in `create_skip_response` -- see lease.rs.
+    drop(guard);
     let msg = create_skip_response(ctx, &handler, tracks_to_skip).await?;
     ctx.data().add_msg_to_cache(guild_id, msg).await;
     Ok(())

--- a/crack-core/src/commands/music/skip.rs
+++ b/crack-core/src/commands/music/skip.rs
@@ -97,16 +97,21 @@ pub async fn downvote(ctx: Context<'_>) -> Result<(), Error> {
 
     let call = get_call_or_join_author(ctx).await?;
 
+    // The downvote is a database round trip and the guard must not span one, so
+    // it happens first, outside. Reading the metadata needs the call lock but
+    // not exclusion -- it mutates nothing.
+    let metadata = {
+        let handler = call.lock().await;
+        get_track_handle_metadata(&handler.queue().current().unwrap()).await?
+    };
+    let source_url = &metadata.source_url.ok_or("ASDF").unwrap();
+    let res1 = ctx.data().downvote_track(guild_id, source_url).await?;
+
     // Ordinary music commands mutate as `Free`; a guild a game owns refuses
     // here, which is the same refusal GP_BLOCKED_COMMANDS gives earlier and
     // more kindly. This one cannot be forgotten.
     let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let handler = call.lock().await;
-    let queue = handler.queue();
-    let metadata = get_track_handle_metadata(&queue.current().unwrap()).await?;
-
-    let source_url = &metadata.source_url.ok_or("ASDF").unwrap();
-    let res1 = ctx.data().downvote_track(guild_id, source_url).await?;
     let res2 = force_skip_top_track(&guard, &handler).await?;
     // Released the moment the last mutation is done, the same as `skip` above.
     // `force_skip_top_track` fires `TrackEvent::End`, and since Task 6 the

--- a/crack-core/src/commands/music/skip.rs
+++ b/crack-core/src/commands/music/skip.rs
@@ -97,21 +97,23 @@ pub async fn downvote(ctx: Context<'_>) -> Result<(), Error> {
 
     let call = get_call_or_join_author(ctx).await?;
 
-    // The downvote is a database round trip and the guard must not span one, so
-    // it happens first, outside. Reading the metadata needs the call lock but
-    // not exclusion -- it mutates nothing.
-    let metadata = {
-        let handler = call.lock().await;
-        get_track_handle_metadata(&handler.queue().current().unwrap()).await?
-    };
-    let source_url = &metadata.source_url.ok_or("ASDF").unwrap();
-    let res1 = ctx.data().downvote_track(guild_id, source_url).await?;
-
     // Ordinary music commands mutate as `Free`; a guild a game owns refuses
     // here, which is the same refusal GP_BLOCKED_COMMANDS gives earlier and
     // more kindly. This one cannot be forgotten.
+    //
+    // 🪤 The database write below sits *under* the guard, against the usual
+    // rule. It was hoisted above the lock once and that bought two holes: a
+    // refused lock left an orphan downvote row with no skip to go with it, and
+    // the `current()` read moved outside exclusion, so the track downvoted was
+    // not provably the track skipped. Closing either needs the write to sit
+    // between the read and the skip, which is to say inside. One `UPDATE` is
+    // the lesser evil now that every other hold on this guard is milliseconds.
     let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let handler = call.lock().await;
+    let metadata = get_track_handle_metadata(&handler.queue().current().unwrap()).await?;
+
+    let source_url = &metadata.source_url.ok_or("ASDF").unwrap();
+    let res1 = ctx.data().downvote_track(guild_id, source_url).await?;
     let res2 = force_skip_top_track(&guard, &handler).await?;
     // Released the moment the last mutation is done, the same as `skip` above.
     // `force_skip_top_track` fires `TrackEvent::End`, and since Task 6 the

--- a/crack-core/src/commands/music/skip.rs
+++ b/crack-core/src/commands/music/skip.rs
@@ -108,6 +108,11 @@ pub async fn downvote(ctx: Context<'_>) -> Result<(), Error> {
     let source_url = &metadata.source_url.ok_or("ASDF").unwrap();
     let res1 = ctx.data().downvote_track(guild_id, source_url).await?;
     let res2 = force_skip_top_track(&guard, &handler).await?;
+    // Released the moment the last mutation is done, the same as `skip` above.
+    // `force_skip_top_track` fires `TrackEvent::End`, and since Task 6 the
+    // global track-end handler awaits `lock_queue` for autopause -- holding on
+    // past here would park songbird's event task for the formatting below.
+    drop(guard);
 
     tracing::warn!("downvoted track: {:#?}", res1);
     tracing::warn!("refetched queue: {:#?}", res2);

--- a/crack-core/src/commands/music/skip.rs
+++ b/crack-core/src/commands/music/skip.rs
@@ -108,6 +108,18 @@ pub async fn downvote(ctx: Context<'_>) -> Result<(), Error> {
     // not provably the track skipped. Closing either needs the write to sit
     // between the read and the skip, which is to say inside. One `UPDATE` is
     // the lesser evil now that every other hold on this guard is milliseconds.
+    //
+    // That trade also holds `handler` (the songbird `Call` mutex) across the
+    // `downvote_track` DB round trip below, not just the guard -- `handler` is
+    // locked before the write and not dropped until after the skip. A re-lock
+    // around just the write was considered and rejected: `TrackQueue` advances
+    // to the next track from its own `End` handler under the queue's internal
+    // lock, not under `Call`, so releasing `handler` for the UPDATE would not
+    // buy back the "the track downvoted is the track skipped" property this
+    // comment is about -- a concurrent skip could still land between the
+    // re-lock and the read. And nothing is blocked behind the UPDATE today
+    // regardless: `downvote` is unregistered (see `blocklist_matches_registry`
+    // in gp.rs), so this hold has no observable cost yet.
     let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let handler = call.lock().await;
     let metadata = get_track_handle_metadata(&handler.queue().current().unwrap()).await?;

--- a/crack-core/src/commands/music/stop.rs
+++ b/crack-core/src/commands/music/stop.rs
@@ -5,6 +5,7 @@ use crate::{
     errors::{verify, CrackedError},
     guild::operations::GuildSettingsOperations,
     messaging::message::CrackedMessage,
+    music::{queue::stop_queue, PlaybackOwner},
     poise_ext::ContextExt,
     utils::send_reply,
     Context, Error,
@@ -30,15 +31,22 @@ pub async fn stop_internal(ctx: Context<'_>) -> Result<Vec<TrackHandle>, Error> 
     let (call, guild_id) = ctx.get_call_guild_id().await?;
     let _ = ctx.data().set_autoplay(guild_id, false).await;
 
+    // Ordinary music commands mutate as `Free`; a guild a game owns refuses
+    // here, which is the same refusal GP_BLOCKED_COMMANDS gives earlier and
+    // more kindly. This one cannot be forgotten.
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let handler = call.lock().await;
-    let queue = handler.queue();
     // Do we want to return an error here or just pritn and return/?
-    verify(!queue.is_empty(), CrackedError::NothingPlaying)?;
-    queue.stop();
+    verify(!handler.queue().is_empty(), CrackedError::NothingPlaying)?;
+    stop_queue(&guard, &handler);
 
     // refetch the queue after modification
     let queue = handler.queue().current_queue();
     drop(handler);
+    // `stop_queue` fires `TrackEvent::End`, and the global track-end handler
+    // awaits `lock_queue` for autopause -- so the guard goes before the reply
+    // below, not after it. See `stop_queue`.
+    drop(guard);
 
     send_reply(&ctx, CrackedMessage::Stop, true).await?;
     Ok(queue)

--- a/crack-core/src/commands/music/voteskip.rs
+++ b/crack-core/src/commands/music/voteskip.rs
@@ -6,6 +6,7 @@ use crate::{
     connection::get_voice_channel_for_user,
     errors::{verify, CrackedError},
     messaging::message::CrackedMessage,
+    music::PlaybackOwner,
     poise_ext::{ContextExt, PoiseContextExt},
     Context, Error,
 };
@@ -51,6 +52,10 @@ async fn voteskip_internal(ctx: Context<'_>) -> Result<(), Error> {
     let manager = ctx.data().songbird.clone();
     let call = manager.get(guild_id).unwrap();
 
+    // Ordinary music commands mutate as `Free`; a guild a game owns refuses
+    // here, which is the same refusal GP_BLOCKED_COMMANDS gives earlier and
+    // more kindly. This one cannot be forgotten.
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let handler = call.lock().await;
     let queue = handler.queue();
 
@@ -87,7 +92,7 @@ async fn voteskip_internal(ctx: Context<'_>) -> Result<(), Error> {
         //         user_id: user_id.0 as i64,
         //     },
         // );
-        force_skip_top_track(&handler).await?;
+        force_skip_top_track(&guard, &handler).await?;
         create_skip_response(ctx, &handler, 1).await
     } else {
         ctx.send_reply_embed(CrackedMessage::VoteSkip {

--- a/crack-core/src/commands/music/voteskip.rs
+++ b/crack-core/src/commands/music/voteskip.rs
@@ -93,8 +93,15 @@ async fn voteskip_internal(ctx: Context<'_>) -> Result<(), Error> {
         //     },
         // );
         force_skip_top_track(&guard, &handler).await?;
+        // The guard is held only for the mutation above, not across the
+        // Discord round trip in `create_skip_response` -- see lease.rs.
+        drop(guard);
         create_skip_response(ctx, &handler, 1).await
     } else {
+        // Never mutates the queue on this path, so the guard is dropped
+        // before the Discord round trip below rather than held idle across
+        // it -- see lease.rs.
+        drop(guard);
         ctx.send_reply_embed(CrackedMessage::VoteSkip {
             mention: ctx.get_user_id().mention(),
             missing: skip_threshold - cache.current_skip_votes.len(),

--- a/crack-core/src/config.rs
+++ b/crack-core/src/config.rs
@@ -54,6 +54,35 @@ async fn on_error(error: poise::FrameworkError<'_, Data, Error>) {
             //     .with_label_values(&[&ctx.command().qualified_name])
             //     .inc();
         },
+        // #467. Without this arm a failed *check* falls through to poise's
+        // builtin, which only logs -- so every `GP_BLOCKED_COMMANDS` refusal
+        // reached the user as Discord's "The application did not respond".
+        // The check refusal is meant to be the friendlier of the two a blocked
+        // command can hit, arriving before the command body rather than out of
+        // it, but that is only true if it is actually delivered.
+        poise::FrameworkError::CommandCheckFailed { error, ctx, .. } => {
+            let reply = match error {
+                Some(error) => Some(CrackedError::Poise(error)),
+                // A check that returned `Ok(false)` rather than `Err` carries
+                // nothing to report, so the refusal is named generically.
+                // `cmd_check_music` does that for a permission refusal -- and,
+                // deliberately silently, for a bot author: `ignore_bots` is off
+                // for the smoke tests, and answering a bot every time it trips a
+                // check is how a reply loop starts.
+                None if ctx.author().bot() => None,
+                None => Some(CrackedError::UnauthorizedUser),
+            };
+            match reply {
+                Some(err) => {
+                    let params = SendMessageParams::new(CrackedMessage::CrackedError(err));
+                    check_reply(ctx.send_message(params).await.map_err(Into::into));
+                },
+                None => tracing::trace!(
+                    "check on {} refused a bot author, saying nothing",
+                    ctx.command().qualified_name
+                ),
+            }
+        },
         error => {
             if let Err(e) = poise::builtins::on_error(error).await {
                 tracing::error!("Error while handling error: {}", e)

--- a/crack-core/src/handlers/track_end.rs
+++ b/crack-core/src/handlers/track_end.rs
@@ -7,6 +7,8 @@ use crate::{
         messages::{AUTOPLAY_DISABLED_ERROR, AUTOPLAY_DISABLED_SPOTIFY, SPOTIFY_AUTH_FAILED},
     },
     music::query::NewQueryType,
+    music::queue::{enqueue_input_back, pause_queue},
+    music::PlaybackOwner,
     sources::spotify::{Spotify, SPOTIFY},
     utils::{
         calculate_num_pages, forget_queue_message, set_track_handle_metadata,
@@ -135,7 +137,24 @@ impl EventHandler for TrackEndHandler {
 
         if autopause {
             tracing::trace!("Pausing");
-            self.call.lock().await.queue().pause().ok();
+            // Autopause has no command and no user behind it, but it mutates
+            // the queue, so it takes the guard like every other mutation.
+            // `Free` is correct: the early return above has already left for
+            // any guild a game owns, so by the time control reaches this line
+            // nothing holds the lease. Passing `Game` here would be refused for
+            // every ordinary guild -- which is to say, always.
+            match self
+                .data
+                .lock_queue(self.guild_id, PlaybackOwner::Free)
+                .await
+            {
+                Ok(guard) => {
+                    let handler = self.call.lock().await;
+                    pause_queue(&guard, &handler);
+                },
+                // A nicety with nobody to answer to: log it and carry on.
+                Err(e) => tracing::trace!("autopause skipped in {}: {e}", self.guild_id),
+            }
         } else {
             tracing::trace!("Not pausing");
         }
@@ -206,7 +225,7 @@ impl EventHandler for TrackEndHandler {
         };
 
         let call = self.call.clone();
-        match queue_query(query, call).await {
+        match queue_query(&self.data, self.guild_id, query, call).await {
             Ok(_) => (),
             Err(e) => {
                 self.data.set_autoplay(self.guild_id, false).await;
@@ -227,7 +246,19 @@ impl EventHandler for TrackEndHandler {
 
 use songbird::input::Input as SongbirdInput;
 /// Queues a query and returns the track handle.
+///
+/// Resolves first, *then* acquires the [`QueueGuard`], the same shape as
+/// [`queue_track_back`](crate::music::queue::queue_track_back): resolution is
+/// the slow leg (8-15s cold) and `lease.rs` forbids holding exclusion across
+/// one, so the guard cannot be supplied by the caller.
+///
+/// [`PlaybackOwner::Free`] is what it locks as. Its only caller is the autoplay
+/// tail of [`TrackEndHandler::act`], which has already returned early for any
+/// guild a game owns, so nothing holds the lease by then -- and locking as
+/// `Game` would be refused for every ordinary guild.
 pub async fn queue_query(
+    data: &Data,
+    guild_id: GuildId,
     query: QueryType,
     call: Arc<Mutex<Call>>,
 ) -> Result<TrackHandle, CrackedError> {
@@ -242,7 +273,12 @@ pub async fn queue_query(
     let (source, metadata_vec): (SongbirdInput, Vec<NewAuxMetadata>) = qt
         .get_track_source_and_metadata(Some(client.clone()))
         .await?;
-    let mut track = call.as_ref().lock().await.enqueue_input(source).await;
+    let mut track = {
+        let guard = data.lock_queue(guild_id, PlaybackOwner::Free).await?;
+        enqueue_input_back(&guard, &call, source).await
+        // The guard drops with this block. `add_metadata_to_track` below writes
+        // the track's own typemap, not the queue, so it needs no exclusion.
+    };
     if let Some(metadata) = metadata_vec.first() {
         add_metadata_to_track(&mut track, metadata.clone().into()).await?;
     }

--- a/crack-core/src/handlers/track_end.rs
+++ b/crack-core/src/handlers/track_end.rs
@@ -7,7 +7,7 @@ use crate::{
         messages::{AUTOPLAY_DISABLED_ERROR, AUTOPLAY_DISABLED_SPOTIFY, SPOTIFY_AUTH_FAILED},
     },
     music::query::NewQueryType,
-    music::queue::{enqueue_input_back, pause_queue},
+    music::queue::{enqueue_input_back, pause_queue, preload_from_metadata},
     music::PlaybackOwner,
     sources::spotify::{Spotify, SPOTIFY},
     utils::{
@@ -150,7 +150,9 @@ impl EventHandler for TrackEndHandler {
             {
                 Ok(guard) => {
                     let handler = self.call.lock().await;
-                    pause_queue(&guard, &handler);
+                    // Nobody asked for this pause, so a failure has nobody to
+                    // report it to.
+                    pause_queue(&guard, &handler).ok();
                 },
                 // A nicety with nobody to answer to: log it and carry on.
                 Err(e) => tracing::trace!("autopause skipped in {}: {e}", self.guild_id),
@@ -273,9 +275,13 @@ pub async fn queue_query(
     let (source, metadata_vec): (SongbirdInput, Vec<NewAuxMetadata>) = qt
         .get_track_source_and_metadata(Some(client.clone()))
         .await?;
+    // Supplied rather than derived: `enqueue_input` would read it back off the
+    // input, which for a lazy source means spawning yt-dlp under the guard.
+    // Resolution above already produced the duration.
+    let preload = preload_from_metadata(metadata_vec.first().map(|meta| &meta.0));
     let mut track = {
         let guard = data.lock_queue(guild_id, PlaybackOwner::Free).await?;
-        enqueue_input_back(&guard, &call, source).await
+        enqueue_input_back(&guard, &call, source, preload).await
         // The guard drops with this block. `add_metadata_to_track` below writes
         // the track's own typemap, not the queue, so it needs no exclusion.
     };

--- a/crack-core/src/lib.rs
+++ b/crack-core/src/lib.rs
@@ -376,6 +376,12 @@ pub struct DataInner {
     pub authorized_users: HashSet<u64>,
     // Why not Arc here?
     pub join_vc_tokens: dashmap::DashMap<serenity::GuildId, Arc<tokio::sync::Mutex<()>>>,
+    /// Who owns playback per guild. Written ONLY by `claim_playback` /
+    /// `release_playback`, which are called from inside the methods that move
+    /// `gp_games` -- see `music/lease.rs`. Do not write it anywhere else.
+    pub playback_owners: dashmap::DashMap<serenity::GuildId, crate::music::lease::PlaybackOwner>,
+    /// Per-guild queue-mutation mutex. Held for milliseconds; see `lock_queue`.
+    pub queue_locks: dashmap::DashMap<serenity::GuildId, Arc<tokio::sync::Mutex<()>>>,
     pub phone_data: PhoneCodeData,
     pub event_log_async: EventLogAsync,
     // Why Option instead of Arc here? Certainly it's an indirection to allow for an uninitialized state
@@ -593,6 +599,8 @@ impl Default for DataInner {
             phone_data: PhoneCodeData::default(),
             bot_settings: Default::default(),
             join_vc_tokens: Default::default(),
+            playback_owners: Default::default(),
+            queue_locks: Default::default(),
             authorized_users: Default::default(),
             guild_settings_map: Arc::new(RwLock::new(HashMap::new())),
             guild_cache_map: Arc::new(Mutex::new(HashMap::new())),

--- a/crack-core/src/music/lease.rs
+++ b/crack-core/src/music/lease.rs
@@ -1,0 +1,277 @@
+//! Per-guild playback ownership and queue exclusion.
+//!
+//! Two concepts, deliberately not merged, because their lifetimes differ by
+//! three orders of magnitude:
+//!
+//! * **Ownership** ([`PlaybackOwner`]) -- long-lived and declarative. Who owns
+//!   playback in this guild. Claimed by `/gp start`, released at game end,
+//!   checked cheaply, and **fails fast**.
+//! * **Exclusion** ([`QueueGuard`]) -- short-lived and operational. A per-guild
+//!   mutex serialising queue mutation, held for milliseconds.
+//!
+//! # 🔑 Ownership is written in exactly five places
+//!
+//! [`Data::claim_playback`] and [`Data::release_playback`] are called from
+//! *inside* the methods that move `gp_games`, never alongside them. An explicit
+//! lease is a second source of truth, and a lease that outlives its game wedges
+//! `/play` forever with no game left to end. Co-locating the two writes makes
+//! divergence structurally impossible rather than merely unlikely. If you find
+//! yourself calling `claim_playback` from a new place, you are adding the bug
+//! this design exists to prevent.
+//!
+//! # 🪤 `QueueGuard` is NOT shaped like `JoinVCToken`
+//!
+//! #434 describes it as "in the shape of `JoinVCToken`", and the *intent* is the
+//! same -- an unforgeable proof carried in the type system -- but the mechanism
+//! differs and assuming otherwise will produce a bug:
+//!
+//! | | `JoinVCToken` | `QueueGuard` |
+//! |---|---|---|
+//! | `acquire` | not `async`, takes no lock | `async`, holds the lock on return |
+//! | who locks | the consumer (`join_vc`) | the constructor |
+//! | what it proves | you went through the right door | you hold exclusion *now* |
+//!
+//! # Lock ordering
+//!
+//! The lease sits alongside `join_vc_tokens`, not replacing it, so there are two
+//! per-guild locks. **Playback lease first, join token second, never the
+//! reverse.**
+
+use crate::errors::CrackedError;
+use crate::Data;
+use dashmap::mapref::entry::Entry;
+use poise::serenity_prelude::GuildId;
+use std::sync::Arc;
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+/// Who owns playback in a guild.
+///
+/// An enum rather than a bool because a third owner is foreseeable; adding one
+/// now would be speculative.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PlaybackOwner {
+    /// Nobody owns playback; ordinary music commands may mutate the queue.
+    #[default]
+    Free,
+    /// A `/gp` game owns playback for the duration of the game.
+    Game,
+}
+
+/// Proof that the holder may mutate this guild's queue, and that nobody else is
+/// doing so concurrently.
+///
+/// Obtained only from [`Data::lock_queue`]. The exclusion is released when this
+/// is dropped, so do not hold one across a slow operation -- in particular never
+/// across track resolution, which takes 8-15s cold.
+#[derive(Debug)]
+pub struct QueueGuard {
+    guild_id: GuildId,
+    /// Dropping this releases the per-guild mutex. Never read.
+    _exclusion: OwnedMutexGuard<()>,
+}
+
+impl QueueGuard {
+    /// The guild this guard permits mutation in.
+    #[must_use]
+    pub fn guild_id(&self) -> GuildId {
+        self.guild_id
+    }
+}
+
+impl Data {
+    /// Who owns playback in this guild. A guild with no claim is [`PlaybackOwner::Free`].
+    #[must_use]
+    pub fn playback_owner(&self, guild_id: GuildId) -> PlaybackOwner {
+        self.playback_owners
+            .get(&guild_id)
+            .map(|owner| *owner)
+            .unwrap_or_default()
+    }
+
+    /// Take ownership of playback in a guild.
+    ///
+    /// # Errors
+    ///
+    /// [`CrackedError::GameInProgress`] if a *different* owner already holds it.
+    /// Re-claiming as the current owner succeeds: the callers claim from inside
+    /// an `Entry::Vacant` branch on `gp_games`, so a collision should be
+    /// unreachable, and failing here would turn a harmless double-claim into a
+    /// refused `/gp start`.
+    pub fn claim_playback(
+        &self,
+        guild_id: GuildId,
+        owner: PlaybackOwner,
+    ) -> Result<(), CrackedError> {
+        match self.playback_owners.entry(guild_id) {
+            Entry::Vacant(slot) => {
+                slot.insert(owner);
+                Ok(())
+            },
+            Entry::Occupied(held) if *held.get() == owner => Ok(()),
+            Entry::Occupied(_) => Err(CrackedError::GameInProgress),
+        }
+    }
+
+    /// Give up ownership of playback in a guild.
+    ///
+    /// Infallible and idempotent. Releasing a guild that owns nothing is a
+    /// no-op, not an error: the game-end paths are event-driven and each can
+    /// arrive first.
+    pub fn release_playback(&self, guild_id: GuildId) {
+        self.playback_owners.remove(&guild_id);
+    }
+
+    /// Acquire exclusive permission to mutate this guild's queue.
+    ///
+    /// Game-versus-command fails fast; command-versus-command waits, and the
+    /// wait is short because resolution happens outside the guard.
+    ///
+    /// # Errors
+    ///
+    /// [`CrackedError::GameInProgress`] -- immediately, without touching the
+    /// mutex -- when a game owns playback and `as_` is not that owner.
+    pub async fn lock_queue(
+        &self,
+        guild_id: GuildId,
+        as_: PlaybackOwner,
+    ) -> Result<QueueGuard, CrackedError> {
+        // Ownership is checked BEFORE the mutex, deliberately. A caller refused
+        // on ownership must not first wait out whoever holds the mutex.
+        let owner = self.playback_owner(guild_id);
+        if owner != PlaybackOwner::Free && owner != as_ {
+            return Err(CrackedError::GameInProgress);
+        }
+
+        // 🪤 The `.clone()` matters: a dashmap reference held across the await
+        // below deadlocks the shard. Cloning the Arc lets the entry ref drop at
+        // the end of this statement. Same shape as `JoinVCToken::acquire`.
+        let lock = self
+            .queue_locks
+            .entry(guild_id)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone();
+
+        Ok(QueueGuard {
+            guild_id,
+            _exclusion: lock.lock_owned().await,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{Data, DataInner};
+    use std::sync::Arc;
+
+    const G: GuildId = GuildId::new(1);
+    const H: GuildId = GuildId::new(2);
+
+    fn data() -> Data {
+        Data(Arc::new(DataInner::default()))
+    }
+
+    #[test]
+    fn a_guild_with_no_claim_is_free() {
+        assert_eq!(data().playback_owner(G), PlaybackOwner::Free);
+    }
+
+    #[test]
+    fn claim_then_release_round_trips() {
+        let d = data();
+        d.claim_playback(G, PlaybackOwner::Game)
+            .expect("free guild accepts a claim");
+        assert_eq!(d.playback_owner(G), PlaybackOwner::Game);
+        d.release_playback(G);
+        assert_eq!(d.playback_owner(G), PlaybackOwner::Free);
+    }
+
+    #[test]
+    fn releasing_a_guild_that_owns_nothing_is_a_no_op() {
+        // The game-end paths are event-driven and can each arrive first, so a
+        // double release is normal, not an error.
+        let d = data();
+        d.release_playback(G);
+        d.release_playback(G);
+        assert_eq!(d.playback_owner(G), PlaybackOwner::Free);
+    }
+
+    #[test]
+    fn re_claiming_as_the_same_owner_succeeds() {
+        // Defensive idempotency: `gp_start` only claims from an Entry::Vacant
+        // branch, so this should be unreachable -- but failing here would turn a
+        // harmless double-claim into a refused /gp start.
+        let d = data();
+        d.claim_playback(G, PlaybackOwner::Game).unwrap();
+        d.claim_playback(G, PlaybackOwner::Game)
+            .expect("same owner may re-claim");
+    }
+
+    #[test]
+    fn a_claim_is_per_guild() {
+        let d = data();
+        d.claim_playback(G, PlaybackOwner::Game).unwrap();
+        assert_eq!(d.playback_owner(H), PlaybackOwner::Free);
+    }
+
+    #[tokio::test]
+    async fn a_free_guild_hands_out_a_guard() {
+        let d = data();
+        let guard = d
+            .lock_queue(G, PlaybackOwner::Free)
+            .await
+            .expect("free guild locks");
+        assert_eq!(guard.guild_id(), G);
+    }
+
+    #[tokio::test]
+    async fn a_game_owned_guild_refuses_a_non_owner_immediately() {
+        let d = data();
+        d.claim_playback(G, PlaybackOwner::Game).unwrap();
+        let err = d.lock_queue(G, PlaybackOwner::Free).await.unwrap_err();
+        assert!(matches!(err, CrackedError::GameInProgress));
+    }
+
+    #[tokio::test]
+    async fn the_owner_can_still_lock_its_own_queue() {
+        // /gp mutates its own queue at four sites; the lease must not lock the
+        // owner out of the thing it owns.
+        let d = data();
+        d.claim_playback(G, PlaybackOwner::Game).unwrap();
+        d.lock_queue(G, PlaybackOwner::Game)
+            .await
+            .expect("the owner may lock");
+    }
+
+    #[tokio::test]
+    async fn the_refusal_does_not_wait_for_the_mutex() {
+        // Fail-fast is the whole point: nobody waits out a half-hour game. If the
+        // ownership check happened after the mutex, this would block forever.
+        let d = data();
+        d.claim_playback(G, PlaybackOwner::Game).unwrap();
+        let _held = d.lock_queue(G, PlaybackOwner::Game).await.unwrap();
+        let refused = tokio::time::timeout(
+            std::time::Duration::from_millis(200),
+            d.lock_queue(G, PlaybackOwner::Free),
+        )
+        .await
+        .expect("must refuse without waiting on the mutex");
+        assert!(matches!(refused, Err(CrackedError::GameInProgress)));
+    }
+
+    #[tokio::test]
+    async fn two_lockers_of_a_free_guild_serialise() {
+        let d = data();
+        let first = d.lock_queue(G, PlaybackOwner::Free).await.unwrap();
+        let blocked = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            d.lock_queue(G, PlaybackOwner::Free),
+        )
+        .await;
+        assert!(blocked.is_err(), "the second locker must wait");
+        drop(first);
+        d.lock_queue(G, PlaybackOwner::Free)
+            .await
+            .expect("the lock is released on drop");
+    }
+}

--- a/crack-core/src/music/lease.rs
+++ b/crack-core/src/music/lease.rs
@@ -34,8 +34,45 @@
 //! # Lock ordering
 //!
 //! The lease sits alongside `join_vc_tokens`, not replacing it, so there are two
-//! per-guild locks. **Playback lease first, join token second, never the
-//! reverse.**
+//! per-guild locks: the exclusion mutex behind [`Data::lock_queue`] (via
+//! `queue_locks`) and the one behind `JoinVCToken::acquire`
+//! (`crate::poise_ext`, backed by `Data::join_vc_tokens`). **Playback lease
+//! first, join token second, never the reverse.** A task that holds one must
+//! not go on to take the other in the wrong order: two per-guild locks taken
+//! in opposite orders by two concurrent tasks is a textbook AB-BA deadlock,
+//! and because songbird dispatches track events inline (see
+//! `src/events/store.rs:89` and `:130`), a task parked on either lock also
+//! blocks that event store's dispatch loop for the guild -- the deadlock does
+//! not stay contained to the two commands that caused it.
+//!
+//! Three independent reviews traced every call site that takes the queue
+//! lock -- the 16 pre-existing `lock_queue` sites plus the six added
+//! alongside this lease -- and found the order uniform everywhere: lease
+//! (ownership check, then `queue_locks`) before any voice-join step, never
+//! after. Every site also drops its [`QueueGuard`] before doing Discord HTTP,
+//! so a guard is never held across the kind of slow `.await` that would let
+//! the ordering matter in practice today.
+//!
+//! 🪤 That last point is why this rule is written down rather than asserted.
+//! `JoinVCToken::acquire` (`crate::poise_ext`) currently has no caller that
+//! also holds a [`QueueGuard`] -- `do_join`
+//! (`crate::commands::music_utils::do_join`) calls `songbird::Songbird::join`
+//! directly and never constructs a `JoinVCToken` at all, so the two locks are
+//! never actually taken together yet. A `debug_assert` in `acquire` was tried
+//! and rejected: the only cheap signal available is "is `queue_locks[guild_id]`
+//! contended right now", checked with `try_lock` from a task that does not
+//! hold it -- and `tokio::sync::Mutex` has no task-affinity introspection, so
+//! that can't distinguish *this task is mid-violation* from *a sibling
+//! command for the same guild is legitimately mid-mutation*, which is normal:
+//! exclusion is held for milliseconds, and two commands for one guild are
+//! free to interleave. A version sound enough to fire only on a real
+//! same-task violation would need task-local state set for the lifetime of a
+//! [`QueueGuard`] and checked in `acquire` -- real machinery for a path
+//! nothing exercises yet. Build it when `do_join` is wired through
+//! `JoinVCToken`, not before; until then, the regression test below is the
+//! cheap version of this guarantee -- it proves the sanctioned order
+//! (lease, then join token) completes without deadlocking, which is the one
+//! thing worth locking in now.
 
 use crate::errors::CrackedError;
 use crate::Data;
@@ -273,5 +310,18 @@ mod test {
         d.lock_queue(G, PlaybackOwner::Free)
             .await
             .expect("the lock is released on drop");
+    }
+
+    #[tokio::test]
+    async fn the_sanctioned_lock_order_completes() {
+        // Lease first, join token second. Two per-guild locks taken in
+        // opposite orders is a textbook deadlock; this proves the sanctioned
+        // order is not itself blocking. See the module doc's "Lock ordering"
+        // section for why this is a regression test rather than an assert.
+        let d = data();
+        let guard = d.lock_queue(G, PlaybackOwner::Free).await.unwrap();
+        let token = crate::poise_ext::JoinVCToken::acquire(&d, G);
+        drop(token);
+        drop(guard);
     }
 }

--- a/crack-core/src/music/lease.rs
+++ b/crack-core/src/music/lease.rs
@@ -53,26 +53,35 @@
 //! so a guard is never held across the kind of slow `.await` that would let
 //! the ordering matter in practice today.
 //!
-//! 🪤 That last point is why this rule is written down rather than asserted.
-//! `JoinVCToken::acquire` (`crate::poise_ext`) currently has no caller that
-//! also holds a [`QueueGuard`] -- `do_join`
+//! 🪤 That last point is why this rule is written down rather than asserted
+//! or tested. `JoinVCToken::acquire` (`crate::poise_ext`) currently has no
+//! caller that also holds a [`QueueGuard`] -- `do_join`
 //! (`crate::commands::music_utils::do_join`) calls `songbird::Songbird::join`
 //! directly and never constructs a `JoinVCToken` at all, so the two locks are
-//! never actually taken together yet. A `debug_assert` in `acquire` was tried
-//! and rejected: the only cheap signal available is "is `queue_locks[guild_id]`
-//! contended right now", checked with `try_lock` from a task that does not
-//! hold it -- and `tokio::sync::Mutex` has no task-affinity introspection, so
-//! that can't distinguish *this task is mid-violation* from *a sibling
-//! command for the same guild is legitimately mid-mutation*, which is normal:
-//! exclusion is held for milliseconds, and two commands for one guild are
-//! free to interleave. A version sound enough to fire only on a real
-//! same-task violation would need task-local state set for the lifetime of a
-//! [`QueueGuard`] and checked in `acquire` -- real machinery for a path
-//! nothing exercises yet. Build it when `do_join` is wired through
-//! `JoinVCToken`, not before; until then, the regression test below is the
-//! cheap version of this guarantee -- it proves the sanctioned order
-//! (lease, then join token) completes without deadlocking, which is the one
-//! thing worth locking in now.
+//! never actually taken together yet. It goes further than that: the only
+//! code that ever locks `join_vc_tokens` is the *consumer*,
+//! `SongbirdManagerExt::join_vc` (`poise_ext.rs`), and it too has zero call
+//! sites. `acquire` itself takes no lock at all -- it clones an `Arc` out of
+//! `join_vc_tokens` and returns, per the comparison table above -- so the
+//! whole join-token mechanism is unreachable from production code today, not
+//! merely decoupled from `QueueGuard`. A `debug_assert` in `acquire` was
+//! tried and rejected: the only cheap signal available is "is
+//! `queue_locks[guild_id]` contended right now", checked with `try_lock` from
+//! a task that does not hold it -- and `tokio::sync::Mutex` has no
+//! task-affinity introspection, so that can't distinguish *this task is
+//! mid-violation* from *a sibling command for the same guild is legitimately
+//! mid-mutation*, which is normal: exclusion is held for milliseconds, and
+//! two commands for one guild are free to interleave. For the same reason no
+//! regression test is shipped either: with the second lock never actually
+//! taken, any test that calls `lock_queue` then `acquire` in one task
+//! exercises zero contention between the two locks and cannot fail
+//! regardless of the order it uses -- it would pass as long as the code
+//! compiles, which is not a guarantee worth having a test for. A sound
+//! version of either -- assert or test -- would need task-local state set
+//! for the lifetime of a [`QueueGuard`] and checked in `join_vc`, real
+//! machinery for a path nothing exercises yet. Build it, and add the test,
+//! the day `JoinVCToken`/`join_vc` gains a real production caller; until
+//! then this paragraph is the only enforcement the rule has.
 
 use crate::errors::CrackedError;
 use crate::Data;
@@ -310,18 +319,5 @@ mod test {
         d.lock_queue(G, PlaybackOwner::Free)
             .await
             .expect("the lock is released on drop");
-    }
-
-    #[tokio::test]
-    async fn the_sanctioned_lock_order_completes() {
-        // Lease first, join token second. Two per-guild locks taken in
-        // opposite orders is a textbook deadlock; this proves the sanctioned
-        // order is not itself blocking. See the module doc's "Lock ordering"
-        // section for why this is a regression test rather than an assert.
-        let d = data();
-        let guard = d.lock_queue(G, PlaybackOwner::Free).await.unwrap();
-        let token = crate::poise_ext::JoinVCToken::acquire(&d, G);
-        drop(token);
-        drop(guard);
     }
 }

--- a/crack-core/src/music/mod.rs
+++ b/crack-core/src/music/mod.rs
@@ -1,7 +1,9 @@
 pub mod context;
+pub mod lease;
 pub(crate) mod query;
 pub(crate) mod queue;
 
 pub use context::QueryContext;
+pub use lease::{PlaybackOwner, QueueGuard};
 pub(crate) use query::*;
 pub(crate) use queue::*;

--- a/crack-core/src/music/query.rs
+++ b/crack-core/src/music/query.rs
@@ -2,6 +2,7 @@ use super::queue::{queue_track_back, queue_track_front};
 use super::{queue_keyword_list_back, queue_query_list_offset, queue_resolved_list_back};
 use crate::guild::operations::GuildSettingsOperations;
 use crate::messaging::interface::create_search_response;
+use crate::music::PlaybackOwner;
 use crate::sources::rusty_ytdl::NewSearchSource;
 use crate::sources::youtube::search_query_to_source_and_metadata_rusty;
 use crate::utils::MUSIC_SEARCH_SUFFIX;
@@ -418,7 +419,7 @@ impl NewQueryType {
                 queue_track_front(ctx, &call, qt).await?;
             },
             QueryType::PlaylistLink(url) => {
-                let _guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
+                let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
                 let playlist: Playlist = rusty_ytdl::search::Playlist::get(
                     url.clone(),
                     Some(&rusty_ytdl::search::PlaylistSearchOptions {
@@ -427,11 +428,25 @@ impl NewQueryType {
                     }),
                 )
                 .await?;
-                queue_query_list_offset(ctx, call, Queries::from(playlist).to_vec(), 1, search_msg)
-                    .await?;
+                // Ordinary music commands mutate as `Free`; a guild a game
+                // owns refuses here, which is the same refusal
+                // GP_BLOCKED_COMMANDS gives earlier and more kindly.
+                let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
+                queue_query_list_offset(
+                    &guard,
+                    ctx,
+                    call,
+                    Queries::from(playlist).to_vec(),
+                    1,
+                    search_msg,
+                )
+                .await?;
             },
             QueryType::KeywordList(keywords_list) => {
+                let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
+                let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
                 queue_query_list_offset(
+                    &guard,
                     ctx,
                     call,
                     Queries::from(keywords_list.clone()).to_vec(),
@@ -445,7 +460,10 @@ impl NewQueryType {
                 //     .iter()
                 //     .map(|x| x.build_query())
                 //     .collect::<Vec<String>>();
+                let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
+                let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
                 queue_query_list_offset(
+                    &guard,
                     ctx,
                     call,
                     Queries::from(tracks.clone()).to_vec(),

--- a/crack-core/src/music/query.rs
+++ b/crack-core/src/music/query.rs
@@ -2,7 +2,6 @@ use super::queue::{queue_track_back, queue_track_front};
 use super::{queue_keyword_list_back, queue_query_list_offset, queue_resolved_list_back};
 use crate::guild::operations::GuildSettingsOperations;
 use crate::messaging::interface::create_search_response;
-use crate::music::PlaybackOwner;
 use crate::sources::rusty_ytdl::NewSearchSource;
 use crate::sources::youtube::search_query_to_source_and_metadata_rusty;
 use crate::utils::MUSIC_SEARCH_SUFFIX;
@@ -419,7 +418,6 @@ impl NewQueryType {
                 queue_track_front(ctx, &call, qt).await?;
             },
             QueryType::PlaylistLink(url) => {
-                let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
                 let playlist: Playlist = rusty_ytdl::search::Playlist::get(
                     url.clone(),
                     Some(&rusty_ytdl::search::PlaylistSearchOptions {
@@ -428,25 +426,14 @@ impl NewQueryType {
                     }),
                 )
                 .await?;
-                // Ordinary music commands mutate as `Free`; a guild a game
-                // owns refuses here, which is the same refusal
-                // GP_BLOCKED_COMMANDS gives earlier and more kindly.
-                let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
-                queue_query_list_offset(
-                    &guard,
-                    ctx,
-                    call,
-                    Queries::from(playlist).to_vec(),
-                    1,
-                    search_msg,
-                )
-                .await?;
+                // queue_query_list_offset acquires its own guard internally,
+                // after it resolves -- no guard passed in here. See its doc
+                // comment.
+                queue_query_list_offset(ctx, call, Queries::from(playlist).to_vec(), 1, search_msg)
+                    .await?;
             },
             QueryType::KeywordList(keywords_list) => {
-                let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
-                let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
                 queue_query_list_offset(
-                    &guard,
                     ctx,
                     call,
                     Queries::from(keywords_list.clone()).to_vec(),
@@ -460,10 +447,7 @@ impl NewQueryType {
                 //     .iter()
                 //     .map(|x| x.build_query())
                 //     .collect::<Vec<String>>();
-                let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
-                let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
                 queue_query_list_offset(
-                    &guard,
                     ctx,
                     call,
                     Queries::from(tracks.clone()).to_vec(),

--- a/crack-core/src/music/queue.rs
+++ b/crack-core/src/music/queue.rs
@@ -729,15 +729,79 @@ pub fn remove_at(guard: &QueueGuard, handler: &Call, index: usize) {
     });
 }
 
-// `stop_queue` and `pause_queue` (guard-taking wrappers around
-// `call.lock().await.queue().stop()`/`.pause()`) are deliberately NOT defined
-// here. Their only intended callers are gp.rs and track_end.rs -- Task 6's
-// files, not this dispatch's -- so with no caller anywhere in this dispatch
-// they trip `dead_code` (this module is `pub(crate)`, so `pub` alone does not
-// exempt them), and "no new #[allow(dead_code)]" rules out silencing that.
-// Add them in queue.rs, with the same doc comments Task 4 specified, at the
-// point Task 6 gains a real call site for each -- that gives them a caller in
-// the same commit that defines them, same as every other helper here.
+/// Stop everything in the queue. Used by `/gp start`, `/gp end` and the abort
+/// path.
+///
+/// Takes the already-locked `handler` rather than the `Arc<Mutex<Call>>`, like
+/// the other synchronous helpers above: two of its three callers read
+/// `queue().is_empty()` under the same lock to report what they cleared, and a
+/// helper that re-locked internally would deadlock them.
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
+///
+/// # 🪤 This fires `TrackEvent::End`
+///
+/// `stop()` queues the `End` rather than firing it inline, and songbird's event
+/// task dispatches handlers inline. So a handler that awaits `lock_queue` parks
+/// that task until this caller's guard drops -- release it before anything slow
+/// (Discord HTTP, resolution, the database), never after.
+pub fn stop_queue(guard: &QueueGuard, handler: &Call) {
+    let _ = guard;
+    handler.queue().stop();
+}
+
+/// Pause the queue. Used by autopause in the global track-end handler.
+///
+/// Same `&Call` shape as [`stop_queue`], for symmetry at the two call sites.
+/// A pause that fails (nothing is playing) is swallowed: autopause is a nicety
+/// nobody asked for at this instant, and it has no user to answer to.
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
+pub fn pause_queue(guard: &QueueGuard, handler: &Call) {
+    let _ = guard;
+    handler.queue().pause().ok();
+}
+
+/// Enqueue an already-built [`Track`] at the back of the queue, returning its
+/// handle. Used by `/gp` to play a round's song.
+///
+/// Returns the [`TrackHandle`] rather than a queue snapshot because the caller
+/// arms per-track event handlers on it; [`queue_resolved_track_back`] is the
+/// snapshot-returning shape.
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
+pub async fn enqueue_track_back(
+    guard: &QueueGuard,
+    call: &Arc<Mutex<Call>>,
+    track: Track,
+) -> TrackHandle {
+    let _ = guard;
+    let mut handler = call.lock().await;
+    handler.enqueue(track).await
+}
+
+/// Enqueue an already-resolved songbird [`Input`](SongbirdInput) at the back of
+/// the queue, returning its handle. Used by autoplay in the global track-end
+/// handler.
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
+pub async fn enqueue_input_back(
+    guard: &QueueGuard,
+    call: &Arc<Mutex<Call>>,
+    source: SongbirdInput,
+) -> TrackHandle {
+    let _ = guard;
+    let mut handler = call.lock().await;
+    handler.enqueue_input(source).await
+}
 
 /// Shuffle `values` in place using the Fisher-Yates algorithm.
 fn fisher_yates<T, R>(values: &mut [T], mut rng: R)

--- a/crack-core/src/music/queue.rs
+++ b/crack-core/src/music/queue.rs
@@ -117,17 +117,6 @@ pub(crate) fn build_track(
 pub struct Inserted {
     /// The handles this call added, in the order they were added.
     pub handles: Vec<TrackHandle>,
-    /// Where the first of them landed in the queue.
-    ///
-    /// Not read by any caller in this crate yet -- no current call site builds
-    /// a "queued at position N" reply. Carried for the callers that will.
-    #[allow(dead_code)]
-    pub first_position: usize,
-    /// Queue length after this call. For "added N, now M in queue" replies.
-    ///
-    /// Not read by any caller in this crate yet, same as `first_position`.
-    #[allow(dead_code)]
-    pub queue_len: usize,
 }
 
 impl Inserted {
@@ -152,7 +141,6 @@ pub async fn enqueue_resolved_tracks_back(
     http_client: reqwest::Client,
 ) -> Result<Inserted, CrackedError> {
     let mut handler = call.lock().await;
-    let first_position = handler.queue().len();
     let mut handles = Vec::with_capacity(tracks.len());
     for resolved in &tracks {
         match build_track(resolved, &http_client) {
@@ -160,12 +148,7 @@ pub async fn enqueue_resolved_tracks_back(
             Err(e) => tracing::warn!("Failed to enqueue {}: {e}", resolved.get_url()),
         }
     }
-    let queue_len = handler.queue().len();
-    Ok(Inserted {
-        handles,
-        first_position,
-        queue_len,
-    })
+    Ok(Inserted { handles })
 }
 
 /// Data needed to queue a track.
@@ -790,20 +773,14 @@ mod insertion_tests {
         // cannot express that -- it carries only what this call added.
         let inserted = Inserted {
             handles: Vec::new(),
-            first_position: 3,
-            queue_len: 5,
         };
         assert_eq!(inserted.count(), 0);
-        assert_eq!(inserted.first_position, 3);
-        assert_eq!(inserted.queue_len, 5);
     }
 
     #[test]
     fn count_is_the_handles_this_call_added() {
         let inserted = Inserted {
             handles: Vec::new(),
-            first_position: 0,
-            queue_len: 0,
         };
         assert_eq!(inserted.count(), inserted.handles.len());
     }

--- a/crack-core/src/music/queue.rs
+++ b/crack-core/src/music/queue.rs
@@ -514,23 +514,29 @@ pub async fn queue_resolved_list_back(
     Ok(())
 }
 
-/// Enqueue already-resolved tracks and hold `guard` across the snapshot read
-/// right after, closing the window a concurrent command's insert could
-/// otherwise land in -- those used to be two separate acquisitions of just the
-/// call lock. See #333.
+/// Enqueue already-resolved tracks and return a snapshot of the queue taken
+/// right after, while `guard` is still held -- closing the window a
+/// concurrent command's insert could otherwise land in between the enqueue
+/// and the snapshot. See #333.
 ///
 /// Deliberately takes already-resolved tracks rather than doing the
 /// `resolve_track_many` itself: resolution is the slow leg, and a caller must
 /// do it before acquiring `guard`, not while holding it. [`queue_vec_query_type`]
 /// and [`queue_query_list_offset`]'s low-queue branch are the two callers, and
 /// each resolves on its own schedule before reaching here.
+///
+/// Deliberately does NOT call `update_queue_messages` itself: that is a
+/// Discord HTTP round trip, and `guard` -- borrowed here, owned by the caller
+/// -- must be dropped before it, not held across it (`lease.rs`: "held for
+/// milliseconds ... do not hold one across a slow operation"). Callers drop
+/// their guard, then redraw with the returned snapshot.
 #[cfg(not(tarpaulin_include))]
 async fn enqueue_resolved_and_snapshot(
     guard: &QueueGuard,
     ctx: CrackContext<'_>,
     call: &Arc<Mutex<Call>>,
     resolved: Vec<ResolvedTrack<'static>>,
-) -> Result<(), Error> {
+) -> Result<Vec<TrackHandle>, CrackedError> {
     let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
     debug_assert_eq!(
         guard.guild_id(),
@@ -539,19 +545,16 @@ async fn enqueue_resolved_and_snapshot(
     );
     enqueue_resolved_tracks_back(guard, call, resolved, http_utils::get_client_old().clone())
         .await?;
-    // update_queue_messages redraws the whole queue message, so it wants the
-    // whole queue -- read deliberately here rather than received from the
-    // enqueue, which now reports only what this call added. See #333.
-    let snapshot = call.lock().await.queue().current_queue();
-    update_queue_messages(&ctx, ctx.data(), &snapshot, guild_id).await;
-    Ok(())
+    // The whole queue, not what this call added -- `update_queue_messages`
+    // redraws the whole queue message. See #333.
+    Ok(call.lock().await.queue().current_queue())
 }
 
 /// Queue a list of keywords to be played with an offset.
 ///
-/// Resolves first, then acquires a [`QueueGuard`] and holds it across the
-/// enqueue and its snapshot -- never across the resolve above, which is the
-/// slow leg. See [`enqueue_resolved_and_snapshot`].
+/// Resolves first, then acquires a [`QueueGuard`] and holds it only across
+/// the enqueue and its snapshot -- never across the resolve above (the slow
+/// leg) or the Discord round trip below. See [`enqueue_resolved_and_snapshot`].
 #[cfg(not(tarpaulin_include))]
 pub async fn queue_vec_query_type(
     ctx: CrackContext<'_>,
@@ -575,25 +578,24 @@ pub async fn queue_vec_query_type(
         .collect::<Vec<_>>();
 
     let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
-    enqueue_resolved_and_snapshot(&guard, ctx, &call, resolved).await
+    let snapshot = enqueue_resolved_and_snapshot(&guard, ctx, &call, resolved).await?;
+    drop(guard);
+    update_queue_messages(&ctx, ctx.data(), &snapshot, guild_id).await;
+    Ok(())
 }
 
 use crate::http_utils;
 /// Queue a list of queries to be played with a given offset.
 /// N.B. The offset must be 0 < offset < queue.len() + 1
 ///
-/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
-/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
-/// error message rather than a corrupted `/gp` round.
-///
-/// 🪤 The `resolve_track_many` call below runs while `guard` is held, which
-/// wraps a second `/play` in this guild around this call's whole 8-15s
-/// resolution rather than just its enqueue. That is a known, deliberate gap:
-/// fixing it means restructuring this function's check-then-act shape, which
-/// is a separate, already-tracked piece of work. Do not fix it here.
+/// Resolves first (the slow leg -- worse than the usual 8-15s here, since a
+/// big playlist batches through `RESOLVE_CONCURRENCY` lookups at a time), then
+/// acquires a [`QueueGuard`] and reads *and* acts on the queue length under
+/// that one guard, so the length cannot go stale between the check and the
+/// insert -- it used to be read before resolving and acted on afterward,
+/// against whatever the queue had become in between.
 #[cfg(not(tarpaulin_include))]
 pub async fn queue_query_list_offset(
-    guard: &QueueGuard,
     ctx: CrackContext<'_>,
     call: Arc<Mutex<Call>>,
     queries: Vec<QueryType>,
@@ -601,51 +603,33 @@ pub async fn queue_query_list_offset(
     _search_msg: &mut Message,
 ) -> Result<(), Error> {
     let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
-    debug_assert_eq!(
-        guard.guild_id(),
-        guild_id,
-        "QueueGuard is for another guild"
-    );
+    let user_id = ctx.author().id;
 
-    // Can this starting section be simplified?
+    // Resolved concurrently; this was a serial round trip per track. Runs
+    // before the guard is taken -- see the doc comment above.
+    let tracks = ctx.data().ct_client.resolve_track_many(queries).await?;
+
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let queue_size = {
         let handler = call.lock().await;
         handler.queue().len()
     };
 
     if queue_size <= 1 {
-        // Reuses the guard already held here rather than going through
-        // `queue_vec_query_type`, which acquires its own -- a second
-        // `lock_queue` for this same guild from inside this call would
-        // deadlock on the per-guild mutex `QueueGuard` wraps, which is not
-        // re-entrant. This is the smallest change that avoids that; the
-        // check-then-act restructuring is the separate work referenced above.
-        let user_id = ctx.author().id;
-        let resolved = ctx
-            .data()
-            .ct_client
-            .resolve_track_many(queries)
-            .await?
+        let resolved = tracks
             .into_iter()
             .map(|t| t.with_user_id(user_id))
             .collect::<Vec<_>>();
-        return enqueue_resolved_and_snapshot(guard, ctx, &call, resolved).await;
+        let snapshot = enqueue_resolved_and_snapshot(&guard, ctx, &call, resolved).await?;
+        drop(guard);
+        update_queue_messages(&ctx, ctx.data(), &snapshot, guild_id).await;
+        return Ok(());
     }
 
     verify(
         offset > 0 && offset <= queue_size + 1,
         CrackedError::NotInRange("index", offset as isize, 1, queue_size as isize),
     )?;
-
-    // Resolved concurrently; this was a serial round trip per track.
-    let tracks = ctx.data().ct_client.resolve_track_many(queries).await?;
-    // enqueue_resolved_tracks(ctx.get_call(), tracks).await?;
-    // for query in queries {
-    //     let ready_track = ready_query(ctx, query).await?;
-    //     // FIXME:
-    //     //ctx.async_send_track_metadata_write_msg(&ready_track);
-    //     tracks.push(ready_track);
-    // }
 
     // One lock for the whole insert, and a lazy `Compose` per track rather than
     // an eager `YoutubeDl` metadata fetch.
@@ -669,6 +653,7 @@ pub async fn queue_query_list_offset(
         }
         handler.queue().current_queue()
     };
+    drop(guard);
 
     update_queue_messages(&ctx, ctx.data(), &cur_q, guild_id).await;
 

--- a/crack-core/src/music/queue.rs
+++ b/crack-core/src/music/queue.rs
@@ -58,30 +58,6 @@ pub async fn queue_resolved_track_back(
     Ok(new_q)
 }
 
-/// Takes a resolved track and queues it to the back of the queue.
-/// Old version.
-/// # Errors
-/// Returns a [`CrackedError`] if the track cannot be queued.
-#[allow(dead_code)]
-pub async fn queue_resolved_track_back_old(
-    call: &Arc<Mutex<Call>>,
-    track: ResolvedTrack<'static>,
-    http_client: reqwest::Client,
-) -> Result<Vec<TrackHandle>, CrackedError> {
-    let mut handler = call.lock().await;
-    let ytdl = YoutubeDl::new(http_client.clone(), track.get_url());
-
-    let mut track_handle = handler
-        .enqueue_input(Into::<SongbirdInput>::into(ytdl))
-        .await;
-    let new_q = handler.queue().current_queue();
-    drop(handler);
-    set_track_handle_metadata(&mut track_handle, track.metadata.unwrap()).await?;
-    set_track_handle_requesting_user(&mut track_handle, track.user_id).await?;
-
-    Ok(new_q)
-}
-
 /// Build the songbird [`Track`] for an already-resolved track.
 ///
 /// This performs no I/O: [`YoutubeDl`] is a lazy [`Compose`], so yt-dlp is not
@@ -1107,30 +1083,6 @@ mod test {
         let is_prefix = true;
         let res = get_msg(mode, query_or_url, is_prefix);
         assert_eq!(res, Some("asdf asdf asdf asd f".to_string()));
-    }
-}
-
-#[cfg(test)]
-mod insertion_tests {
-    use super::*;
-
-    #[test]
-    fn inserted_describes_only_this_call() {
-        // #333: the bug was returning the whole queue after enqueueing, so two
-        // concurrent /play calls each reported both sets of songs. `Inserted`
-        // cannot express that -- it carries only what this call added.
-        let inserted = Inserted {
-            handles: Vec::new(),
-        };
-        assert_eq!(inserted.count(), 0);
-    }
-
-    #[test]
-    fn count_is_the_handles_this_call_added() {
-        let inserted = Inserted {
-            handles: Vec::new(),
-        };
-        assert_eq!(inserted.count(), inserted.handles.len());
     }
 }
 

--- a/crack-core/src/music/queue.rs
+++ b/crack-core/src/music/queue.rs
@@ -105,32 +105,67 @@ pub(crate) fn build_track(
     Ok(Track::new_with_data(ytdl.into(), track_data))
 }
 
+/// What one enqueue call put into the queue.
+///
+/// 🔑 Deliberately NOT the whole queue. `enqueue_resolved_tracks_back` used to
+/// return `handler.queue().current_queue()` *after* enqueueing, so two
+/// concurrent `/play` calls both read the post-both state and both replies
+/// listed both sets of songs -- #333, reported as "one of the songs got queued
+/// twice". A reply built from what *this* call inserted cannot be corrupted by
+/// a concurrent one.
+#[derive(Debug, Clone)]
+pub struct Inserted {
+    /// The handles this call added, in the order they were added.
+    pub handles: Vec<TrackHandle>,
+    /// Where the first of them landed in the queue.
+    ///
+    /// Not read by any caller in this crate yet -- no current call site builds
+    /// a "queued at position N" reply. Carried for the callers that will.
+    #[allow(dead_code)]
+    pub first_position: usize,
+    /// Queue length after this call. For "added N, now M in queue" replies.
+    ///
+    /// Not read by any caller in this crate yet, same as `first_position`.
+    #[allow(dead_code)]
+    pub queue_len: usize,
+}
+
+impl Inserted {
+    /// How many tracks this call added.
+    #[must_use]
+    pub fn count(&self) -> usize {
+        self.handles.len()
+    }
+}
+
 /// Queue a batch of resolved tracks to the back of the queue.
 ///
 /// Takes the call lock once for the whole batch instead of once per track,
 /// which matters when a playlist adds tens of tracks at a time.
+///
+/// Returns only what THIS call inserted -- see [`Inserted`]. Callers that also
+/// want a whole-queue snapshot (to redraw a queue message, say) take it
+/// explicitly and separately; see #333.
 pub async fn enqueue_resolved_tracks_back(
     call: &Arc<Mutex<Call>>,
     tracks: Vec<ResolvedTrack<'static>>,
     http_client: reqwest::Client,
-) -> Result<Vec<TrackHandle>, CrackedError> {
-    if tracks.is_empty() {
-        let handler = call.lock().await;
-        return Ok(handler.queue().current_queue());
-    }
-
+) -> Result<Inserted, CrackedError> {
     let mut handler = call.lock().await;
+    let first_position = handler.queue().len();
+    let mut handles = Vec::with_capacity(tracks.len());
     for resolved in &tracks {
         match build_track(resolved, &http_client) {
-            Ok(track) => {
-                let _ = handler.enqueue(track).await;
-            },
-            Err(e) => {
-                tracing::warn!("Failed to enqueue {}: {e}", resolved.get_url());
-            },
+            Ok(track) => handles.push(handler.enqueue(track).await),
+            Err(e) => tracing::warn!("Failed to enqueue {}: {e}", resolved.get_url()),
         }
     }
-    Ok(handler.queue().current_queue())
+    let queue_len = handler.queue().len();
+    Ok(Inserted {
+        handles,
+        first_position,
+        queue_len,
+    })
 }
 
 /// Data needed to queue a track.
@@ -389,8 +424,12 @@ pub async fn queue_resolved_list_back(
     }
 
     let rest = tracks.split_off(1);
-    let queue = enqueue_resolved_tracks_back(&call, tracks, client.clone()).await?;
-    update_queue_messages(&ctx, ctx.data(), &queue, guild_id).await;
+    enqueue_resolved_tracks_back(&call, tracks, client.clone()).await?;
+    // update_queue_messages redraws the whole queue message, so it wants the
+    // whole queue -- read deliberately here rather than received from the
+    // enqueue, which now reports only what this call added. See #333.
+    let snapshot = call.lock().await.queue().current_queue();
+    update_queue_messages(&ctx, ctx.data(), &snapshot, guild_id).await;
 
     if rest.is_empty() {
         return Ok(());
@@ -401,9 +440,10 @@ pub async fn queue_resolved_list_back(
     let mut last_edit = std::time::Instant::now();
 
     for chunk in rest.chunks(QUEUE_BATCH_SIZE) {
-        let queue = enqueue_resolved_tracks_back(&call, chunk.to_vec(), client.clone()).await?;
-        queued += chunk.len();
-        update_queue_messages(&ctx, ctx.data(), &queue, guild_id).await;
+        let inserted = enqueue_resolved_tracks_back(&call, chunk.to_vec(), client.clone()).await?;
+        queued += inserted.count();
+        let snapshot = call.lock().await.queue().current_queue();
+        update_queue_messages(&ctx, ctx.data(), &snapshot, guild_id).await;
 
         let is_last = queued >= total;
         if is_last || last_edit.elapsed() >= PROGRESS_EDIT_INTERVAL {
@@ -450,9 +490,12 @@ pub async fn queue_vec_query_type(
         .map(|t| t.with_user_id(user_id))
         .collect::<Vec<_>>();
 
-    let queue =
-        enqueue_resolved_tracks_back(&call, resolved, http_utils::get_client_old().clone()).await?;
-    update_queue_messages(&ctx, ctx.data(), &queue, guild_id).await;
+    enqueue_resolved_tracks_back(&call, resolved, http_utils::get_client_old().clone()).await?;
+    // update_queue_messages redraws the whole queue message, so it wants the
+    // whole queue -- read deliberately here rather than received from the
+    // enqueue, which now reports only what this call added. See #333.
+    let snapshot = call.lock().await.queue().current_queue();
+    update_queue_messages(&ctx, ctx.data(), &snapshot, guild_id).await;
     Ok(())
 }
 
@@ -733,5 +776,35 @@ mod test {
         let is_prefix = true;
         let res = get_msg(mode, query_or_url, is_prefix);
         assert_eq!(res, Some("asdf asdf asdf asd f".to_string()));
+    }
+}
+
+#[cfg(test)]
+mod insertion_tests {
+    use super::*;
+
+    #[test]
+    fn inserted_describes_only_this_call() {
+        // #333: the bug was returning the whole queue after enqueueing, so two
+        // concurrent /play calls each reported both sets of songs. `Inserted`
+        // cannot express that -- it carries only what this call added.
+        let inserted = Inserted {
+            handles: Vec::new(),
+            first_position: 3,
+            queue_len: 5,
+        };
+        assert_eq!(inserted.count(), 0);
+        assert_eq!(inserted.first_position, 3);
+        assert_eq!(inserted.queue_len, 5);
+    }
+
+    #[test]
+    fn count_is_the_handles_this_call_added() {
+        let inserted = Inserted {
+            handles: Vec::new(),
+            first_position: 0,
+            queue_len: 0,
+        };
+        assert_eq!(inserted.count(), inserted.handles.len());
     }
 }

--- a/crack-core/src/music/queue.rs
+++ b/crack-core/src/music/queue.rs
@@ -2,12 +2,13 @@ use crate::{
     errors::{verify, CrackedError},
     handlers::track_end::update_queue_messages,
     http_utils::CacheHttpExt,
-    music::NewQueryType,
+    music::{NewQueryType, PlaybackOwner, QueueGuard},
     utils::{set_track_handle_metadata, set_track_handle_requesting_user, TrackData},
     Context as CrackContext, Error,
 };
 use crack_testing::ResolvedTrack;
 use crack_types::{Mode, NewAuxMetadata, QueryType};
+use rand::RngExt;
 use serenity::{
     all::{CreateEmbed, EditMessage, Message, UserId},
     small_fixed_array::FixedString,
@@ -23,15 +24,21 @@ use tokio::sync::{Mutex, RwLock};
 
 /// Takes a resolved track and queues it to the back of the queue.
 /// Returns a snapshot of th new queue as a [`Vec<TrackHandle>`].
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
 /// # Errors
 /// Returns a [`CrackedError`] if the track cannot be queued.
 /// Can fail during the search itself, or when adding the metadata to the track,
 /// or when adding the track to the internal queue.
 pub async fn queue_resolved_track_back(
+    guard: &QueueGuard,
     call: &Arc<Mutex<Call>>,
     track_resolved: ResolvedTrack<'static>,
     http_client: reqwest::Client,
 ) -> Result<Vec<TrackHandle>, CrackedError> {
+    let _ = guard;
     // Through `build_track`, not a second copy of it. This function used to
     // construct its own `RustyYoutubeSearch` inline, which is why fixing the
     // source in `build_track` fixed `/gp` and left `/play` still silent.
@@ -135,11 +142,17 @@ impl Inserted {
 /// Returns only what THIS call inserted -- see [`Inserted`]. Callers that also
 /// want a whole-queue snapshot (to redraw a queue message, say) take it
 /// explicitly and separately; see #333.
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
 pub async fn enqueue_resolved_tracks_back(
+    guard: &QueueGuard,
     call: &Arc<Mutex<Call>>,
     tracks: Vec<ResolvedTrack<'static>>,
     http_client: reqwest::Client,
 ) -> Result<Inserted, CrackedError> {
+    let _ = guard;
     let mut handler = call.lock().await;
     let mut handles = Vec::with_capacity(tracks.len());
     for resolved in &tracks {
@@ -190,10 +203,16 @@ pub async fn ready_query(
 }
 
 /// Pushes a track to the front of the queue, after readying it.
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
 pub async fn queue_track_ready_front(
+    guard: &QueueGuard,
     call: &Arc<Mutex<Call>>,
     ready_track: TrackReadyData,
 ) -> Result<Vec<TrackHandle>, CrackedError> {
+    let _ = guard;
     let mut handler = call.lock().await;
     let mut track_handle = handler.enqueue_input(ready_track.source).await;
     let new_q = handler.queue().current_queue();
@@ -215,10 +234,16 @@ pub async fn queue_track_ready_front(
 }
 
 /// Pushes a track to the back of the queue, after readying it.
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
 pub async fn _queue_track_ready_back(
+    guard: &QueueGuard,
     call: &Arc<Mutex<Call>>,
     ready_track: TrackReadyData,
 ) -> Result<Vec<TrackHandle>, CrackedError> {
+    let _ = guard;
     let mut handler = call.lock().await;
 
     let TrackReadyData {
@@ -241,20 +266,38 @@ pub async fn _queue_track_ready_back(
 }
 
 /// Pushes a track to the front of the queue.
+///
+/// Not itself in the guard-parameter group ([`queue_track_ready_front`] is):
+/// `ready_query` is the slow leg (it can hit the network), so the guard is
+/// acquired here internally, after readying completes, and held only for the
+/// enqueue that follows. A guard taken by the caller before this call would
+/// wrap the whole readying step, which is exactly the "second /play waits out
+/// the first one's resolution" shape the funnel exists to avoid.
 pub async fn queue_track_front(
     ctx: CrackContext<'_>,
     call: &Arc<Mutex<Call>>,
     query_type: &QueryType,
 ) -> Result<Vec<TrackHandle>, CrackedError> {
+    let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
     let ready_track = ready_query(ctx, query_type.clone()).await?;
     // FIXME:
     //ctx.async_send_track_metadata_write_msg(&ready_track);
-    let q = queue_track_ready_front(call, ready_track).await?;
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
+    let q = queue_track_ready_front(&guard, call, ready_track).await?;
     Ok(q)
 }
 
 use crack_types::TrackResolveError;
 /// Pushes a track to the front of the queue.
+///
+/// Not itself in the guard-parameter group ([`queue_resolved_track_back`] and
+/// [`_queue_track_ready_back`] are): this function resolves the query
+/// internally, and resolution is the slow leg (8-15s cold via `ct_client`, or
+/// the `ready_query` fallback). The guard is acquired here, after resolution
+/// completes on whichever branch was taken, and held only for the enqueue.
+/// Requiring an externally-supplied guard instead would make the caller hold
+/// playback exclusion for the whole resolution, which is the "second /play
+/// waits out the first one's resolve" shape the funnel exists to avoid.
 #[tracing::instrument(skip(ctx, call))]
 pub async fn queue_track_back(
     ctx: CrackContext<'_>,
@@ -262,6 +305,7 @@ pub async fn queue_track_back(
     query_type: &QueryType,
 ) -> Result<Vec<TrackHandle>, CrackedError> {
     let user_id = ctx.author().id;
+    let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
 
     let begin = std::time::Instant::now();
     let resolved = match ctx.data().ct_client.resolve_track(query_type.clone()).await {
@@ -270,7 +314,8 @@ pub async fn queue_track_back(
             match e1.into() {
                 Some(_e) => {
                     let ready_track = ready_query(ctx, query_type.clone()).await?;
-                    return _queue_track_ready_back(call, ready_track).await;
+                    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
+                    return _queue_track_ready_back(&guard, call, ready_track).await;
                 },
                 None => {
                     return Err(CrackedError::TrackResolveError(
@@ -285,8 +330,10 @@ pub async fn queue_track_back(
     //ctx.async_send_track_metadata_write_msg(&ready_track);
     let after_send = std::time::Instant::now();
     //let queue = queue_track_ready_back(call, ready_track).await;
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let queue =
-        queue_resolved_track_back(call, resolved, http_utils::get_client_old().clone()).await;
+        queue_resolved_track_back(&guard, call, resolved, http_utils::get_client_old().clone())
+            .await;
     let after_queue = std::time::Instant::now();
     tracing::warn!(
         r#"
@@ -304,10 +351,16 @@ pub async fn queue_track_back(
 }
 
 /// Append a list of tracks to the end of the queue.
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
 pub async fn _append_queue(
+    guard: &QueueGuard,
     call: Arc<Mutex<Call>>,
     mut tracks: VecDeque<Queued>,
 ) -> Result<Vec<TrackHandle>, Error> {
+    let _ = guard;
     let handler = call.lock().await;
     handler.queue().modify_queue(|queue| {
         queue.append(&mut tracks);
@@ -407,11 +460,16 @@ pub async fn queue_resolved_list_back(
     }
 
     let rest = tracks.split_off(1);
-    enqueue_resolved_tracks_back(&call, tracks, client.clone()).await?;
-    // update_queue_messages redraws the whole queue message, so it wants the
-    // whole queue -- read deliberately here rather than received from the
-    // enqueue, which now reports only what this call added. See #333.
+    // Hold the guard across the enqueue AND the snapshot read right after it,
+    // closing the window a concurrent command's insert could otherwise land
+    // in -- the enqueue and the snapshot used to be two separate acquisitions
+    // of just the call lock. Neither `build_track` nor the enqueue itself does
+    // I/O (tracks here are already resolved), so this is never held across a
+    // slow operation. See #333.
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
+    enqueue_resolved_tracks_back(&guard, &call, tracks, client.clone()).await?;
     let snapshot = call.lock().await.queue().current_queue();
+    drop(guard);
     update_queue_messages(&ctx, ctx.data(), &snapshot, guild_id).await;
 
     if rest.is_empty() {
@@ -423,9 +481,15 @@ pub async fn queue_resolved_list_back(
     let mut last_edit = std::time::Instant::now();
 
     for chunk in rest.chunks(QUEUE_BATCH_SIZE) {
-        let inserted = enqueue_resolved_tracks_back(&call, chunk.to_vec(), client.clone()).await?;
+        // Same reasoning as the first batch above: guard held across the
+        // enqueue and its snapshot, dropped before the (network) progress
+        // message edit below. See #333.
+        let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
+        let inserted =
+            enqueue_resolved_tracks_back(&guard, &call, chunk.to_vec(), client.clone()).await?;
         queued += inserted.count();
         let snapshot = call.lock().await.queue().current_queue();
+        drop(guard);
         update_queue_messages(&ctx, ctx.data(), &snapshot, guild_id).await;
 
         let is_last = queued >= total;
@@ -450,7 +514,44 @@ pub async fn queue_resolved_list_back(
     Ok(())
 }
 
+/// Enqueue already-resolved tracks and hold `guard` across the snapshot read
+/// right after, closing the window a concurrent command's insert could
+/// otherwise land in -- those used to be two separate acquisitions of just the
+/// call lock. See #333.
+///
+/// Deliberately takes already-resolved tracks rather than doing the
+/// `resolve_track_many` itself: resolution is the slow leg, and a caller must
+/// do it before acquiring `guard`, not while holding it. [`queue_vec_query_type`]
+/// and [`queue_query_list_offset`]'s low-queue branch are the two callers, and
+/// each resolves on its own schedule before reaching here.
+#[cfg(not(tarpaulin_include))]
+async fn enqueue_resolved_and_snapshot(
+    guard: &QueueGuard,
+    ctx: CrackContext<'_>,
+    call: &Arc<Mutex<Call>>,
+    resolved: Vec<ResolvedTrack<'static>>,
+) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
+    debug_assert_eq!(
+        guard.guild_id(),
+        guild_id,
+        "QueueGuard is for another guild"
+    );
+    enqueue_resolved_tracks_back(guard, call, resolved, http_utils::get_client_old().clone())
+        .await?;
+    // update_queue_messages redraws the whole queue message, so it wants the
+    // whole queue -- read deliberately here rather than received from the
+    // enqueue, which now reports only what this call added. See #333.
+    let snapshot = call.lock().await.queue().current_queue();
+    update_queue_messages(&ctx, ctx.data(), &snapshot, guild_id).await;
+    Ok(())
+}
+
 /// Queue a list of keywords to be played with an offset.
+///
+/// Resolves first, then acquires a [`QueueGuard`] and holds it across the
+/// enqueue and its snapshot -- never across the resolve above, which is the
+/// slow leg. See [`enqueue_resolved_and_snapshot`].
 #[cfg(not(tarpaulin_include))]
 pub async fn queue_vec_query_type(
     ctx: CrackContext<'_>,
@@ -473,20 +574,26 @@ pub async fn queue_vec_query_type(
         .map(|t| t.with_user_id(user_id))
         .collect::<Vec<_>>();
 
-    enqueue_resolved_tracks_back(&call, resolved, http_utils::get_client_old().clone()).await?;
-    // update_queue_messages redraws the whole queue message, so it wants the
-    // whole queue -- read deliberately here rather than received from the
-    // enqueue, which now reports only what this call added. See #333.
-    let snapshot = call.lock().await.queue().current_queue();
-    update_queue_messages(&ctx, ctx.data(), &snapshot, guild_id).await;
-    Ok(())
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
+    enqueue_resolved_and_snapshot(&guard, ctx, &call, resolved).await
 }
 
 use crate::http_utils;
 /// Queue a list of queries to be played with a given offset.
 /// N.B. The offset must be 0 < offset < queue.len() + 1
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
+///
+/// 🪤 The `resolve_track_many` call below runs while `guard` is held, which
+/// wraps a second `/play` in this guild around this call's whole 8-15s
+/// resolution rather than just its enqueue. That is a known, deliberate gap:
+/// fixing it means restructuring this function's check-then-act shape, which
+/// is a separate, already-tracked piece of work. Do not fix it here.
 #[cfg(not(tarpaulin_include))]
 pub async fn queue_query_list_offset(
+    guard: &QueueGuard,
     ctx: CrackContext<'_>,
     call: Arc<Mutex<Call>>,
     queries: Vec<QueryType>,
@@ -494,6 +601,11 @@ pub async fn queue_query_list_offset(
     _search_msg: &mut Message,
 ) -> Result<(), Error> {
     let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
+    debug_assert_eq!(
+        guard.guild_id(),
+        guild_id,
+        "QueueGuard is for another guild"
+    );
 
     // Can this starting section be simplified?
     let queue_size = {
@@ -502,7 +614,22 @@ pub async fn queue_query_list_offset(
     };
 
     if queue_size <= 1 {
-        return queue_vec_query_type(ctx, call, queries, Mode::End).await;
+        // Reuses the guard already held here rather than going through
+        // `queue_vec_query_type`, which acquires its own -- a second
+        // `lock_queue` for this same guild from inside this call would
+        // deadlock on the per-guild mutex `QueueGuard` wraps, which is not
+        // re-entrant. This is the smallest change that avoids that; the
+        // check-then-act restructuring is the separate work referenced above.
+        let user_id = ctx.author().id;
+        let resolved = ctx
+            .data()
+            .ct_client
+            .resolve_track_many(queries)
+            .await?
+            .into_iter()
+            .map(|t| t.with_user_id(user_id))
+            .collect::<Vec<_>>();
+        return enqueue_resolved_and_snapshot(guard, ctx, &call, resolved).await;
     }
 
     verify(
@@ -546,6 +673,97 @@ pub async fn queue_query_list_offset(
     update_queue_messages(&ctx, ctx.data(), &cur_q, guild_id).await;
 
     Ok(())
+}
+
+/// Drop everything from `from` onward, stopping each track. Used by `/clear`.
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
+pub fn clear_from(guard: &QueueGuard, handler: &Call, from: usize) {
+    let _ = guard;
+    handler.queue().modify_queue(|v| {
+        v.drain(from..).for_each(|x| {
+            let _ = x.stop();
+            drop(x);
+        });
+    });
+}
+
+/// Drop `count` tracks after the currently-playing one. Used by `/skip`.
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
+pub fn drain_after_current(guard: &QueueGuard, handler: &Call, count: usize) {
+    let _ = guard;
+    handler.queue().modify_queue(|v| {
+        let end = (1 + count).min(v.len());
+        v.drain(1..end);
+    });
+}
+
+/// Reorder the queue behind the currently-playing track. Used by `/shuffle`.
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
+pub fn shuffle_behind_current(guard: &QueueGuard, handler: &Call) {
+    let _ = guard;
+    handler.queue().modify_queue(|queue| {
+        // skip the first track on queue because it's being played
+        fisher_yates(queue.make_contiguous()[1..].as_mut(), &mut rand::rng())
+    });
+}
+
+/// Move a track from one queue index to another. Used by `/movesong`.
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
+pub fn move_track(guard: &QueueGuard, handler: &Call, at: usize, to: usize) {
+    let _ = guard;
+    handler.queue().modify_queue(|queue| {
+        // The caller verifies both indices are in range before calling.
+        let song = queue.remove(at).expect("index out of bounds");
+        queue.insert(to, song);
+    });
+}
+
+/// Remove one track by queue index. Used by `/remove`.
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
+pub fn remove_at(guard: &QueueGuard, handler: &Call, index: usize) {
+    let _ = guard;
+    handler.queue().modify_queue(|v| {
+        if let Some(track) = v.remove(index) {
+            let _ = track.stop();
+        }
+    });
+}
+
+// `stop_queue` and `pause_queue` (guard-taking wrappers around
+// `call.lock().await.queue().stop()`/`.pause()`) are deliberately NOT defined
+// here. Their only intended callers are gp.rs and track_end.rs -- Task 6's
+// files, not this dispatch's -- so with no caller anywhere in this dispatch
+// they trip `dead_code` (this module is `pub(crate)`, so `pub` alone does not
+// exempt them), and "no new #[allow(dead_code)]" rules out silencing that.
+// Add them in queue.rs, with the same doc comments Task 4 specified, at the
+// point Task 6 gains a real call site for each -- that gives them a caller in
+// the same commit that defines them, same as every other helper here.
+
+/// Shuffle `values` in place using the Fisher-Yates algorithm.
+fn fisher_yates<T, R>(values: &mut [T], mut rng: R)
+where
+    R: rand::Rng + Sized,
+{
+    let mut index = values.len();
+    while index >= 2 {
+        index -= 1;
+        values.swap(index, rng.random_range(0..(index + 1)));
+    }
 }
 
 /// Get the play mode and the message from the parameters to the play command.
@@ -650,6 +868,13 @@ mod test {
     use crack_types::to_fixed;
 
     use super::*;
+
+    #[test]
+    fn test_fisher_yates() {
+        let mut values = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        fisher_yates(&mut values, &mut rand::rng());
+        assert_ne!(values, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
 
     #[test]
     fn test_get_mode() {

--- a/crack-core/src/music/queue.rs
+++ b/crack-core/src/music/queue.rs
@@ -14,11 +14,12 @@ use serenity::{
     small_fixed_array::FixedString,
 };
 use songbird::{
-    input::{Input as SongbirdInput, YoutubeDl},
-    tracks::{Queued, Track, TrackHandle},
+    input::{AuxMetadata, Input as SongbirdInput, YoutubeDl},
+    tracks::{Queued, Track, TrackHandle, TrackResult},
     Call,
 };
 use std::str::FromStr;
+use std::time::Duration;
 use std::{collections::VecDeque, sync::Arc};
 use tokio::sync::{Mutex, RwLock};
 
@@ -44,7 +45,8 @@ pub async fn queue_resolved_track_back(
     // source in `build_track` fixed `/gp` and left `/play` still silent.
     let track = build_track(&track_resolved, &http_client)?;
     let mut handler = call.lock().await;
-    let _track_handle = handler.enqueue(track).await;
+    // `enqueue_with_preload`, not `enqueue`: see [`preload_time`].
+    let _track_handle = handler.enqueue_with_preload(track, preload_time(&track_resolved));
     // .enqueue_input(Into::<SongbirdInput>::into(track))
     let new_q = handler.queue().current_queue();
     drop(handler);
@@ -112,6 +114,42 @@ pub(crate) fn build_track(
     Ok(Track::new_with_data(ytdl.into(), track_data))
 }
 
+/// When to start loading the *next* track, given what we already know about this
+/// one.
+///
+/// # 🪤 This exists to keep yt-dlp out of the guard
+///
+/// `Call::enqueue` (songbird `driver/mod.rs:301`) calls
+/// `TrackQueue::get_preload_time`, which does
+/// `Input::Lazy(rec).aux_metadata().await` purely to read the duration.
+/// [`build_track`] hands songbird a `YoutubeDl` with `metadata: None`, so that
+/// `aux_metadata` falls through to `query(1)` and **spawns yt-dlp** -- 1-3s, per
+/// track, inside the enqueue, inside the [`QueueGuard`]. A 20-track playlist
+/// paid it twenty times and made a second `/play` in the same guild wait out
+/// every one of them.
+///
+/// songbird's `YoutubeDl::metadata` is private with no setter on the pinned rev
+/// (`3fe7289`), so it cannot be primed; `enqueue_with_preload` is the way out.
+/// This computes exactly what `get_preload_time` would have -- duration minus
+/// five seconds -- from the [`ResolvedTrack`] metadata resolution already
+/// produced, so preload is preserved rather than disabled.
+///
+/// `None` (no metadata, or metadata with no duration) disables preload for that
+/// track: it is readied when the previous one ends instead of five seconds
+/// early. That is a small gap, not a failure, and it is what songbird itself
+/// falls back to when the query yields no duration.
+pub(crate) fn preload_time(resolved: &ResolvedTrack<'_>) -> Option<Duration> {
+    preload_from_metadata(resolved.metadata.as_ref())
+}
+
+/// [`preload_time`] for the paths that hold [`AuxMetadata`] rather than a
+/// [`ResolvedTrack`]. The five seconds is songbird's own figure, from
+/// `TrackQueue::get_preload_time`.
+pub(crate) fn preload_from_metadata(meta: Option<&AuxMetadata>) -> Option<Duration> {
+    meta.and_then(|meta| meta.duration)
+        .map(|d| d.saturating_sub(Duration::from_secs(5)))
+}
+
 /// What one enqueue call put into the queue.
 ///
 /// 🔑 Deliberately NOT the whole queue. `enqueue_resolved_tracks_back` used to
@@ -157,7 +195,10 @@ pub async fn enqueue_resolved_tracks_back(
     let mut handles = Vec::with_capacity(tracks.len());
     for resolved in &tracks {
         match build_track(resolved, &http_client) {
-            Ok(track) => handles.push(handler.enqueue(track).await),
+            // `enqueue_with_preload`, not `enqueue`: see [`preload_time`]. This
+            // is the loop that made it matter -- a 20-track playlist ran yt-dlp
+            // twenty times here, under the guard, before this.
+            Ok(track) => handles.push(handler.enqueue_with_preload(track, preload_time(resolved))),
             Err(e) => tracing::warn!("Failed to enqueue {}: {e}", resolved.get_url()),
         }
     }
@@ -213,8 +254,11 @@ pub async fn queue_track_ready_front(
     ready_track: TrackReadyData,
 ) -> Result<Vec<TrackHandle>, CrackedError> {
     let _ = guard;
+    // `enqueue_with_preload`, not `enqueue_input`: see [`preload_time`]. The
+    // readied metadata is right here, so songbird never has to go and ask.
+    let preload = preload_from_metadata(Some(&ready_track.metadata.0));
     let mut handler = call.lock().await;
-    let mut track_handle = handler.enqueue_input(ready_track.source).await;
+    let mut track_handle = handler.enqueue_with_preload(ready_track.source.into(), preload);
     let new_q = handler.queue().current_queue();
     // Zeroth index: Currently playing track
     // First index: Current next track
@@ -253,12 +297,15 @@ pub async fn _queue_track_ready_back(
         ..
     } = ready_track;
 
+    // Computed before `metadata` is moved into the track data below.
+    let preload = preload_from_metadata(Some(&metadata.0));
     let track_data = TrackData::new()
         .with_user_id(user_id.unwrap())
         .with_metadata(metadata.into());
     let track = Track::new_with_data(source, track_data);
 
-    let _track_handle = handler.enqueue(track).await;
+    // `enqueue_with_preload`, not `enqueue`: see [`preload_time`].
+    let _track_handle = handler.enqueue_with_preload(track, preload);
     let new_q = handler.queue().current_queue();
     drop(handler);
 
@@ -631,8 +678,10 @@ pub async fn queue_query_list_offset(
         CrackedError::NotInRange("index", offset as isize, 1, queue_size as isize),
     )?;
 
-    // One lock for the whole insert, and a lazy `Compose` per track rather than
-    // an eager `YoutubeDl` metadata fetch.
+    // One lock for the whole insert. The `Compose` per track is lazy, but
+    // `enqueue` is not: it reads the duration back off the input to schedule
+    // preload, which runs yt-dlp. `enqueue_with_preload` is what actually keeps
+    // this loop lazy -- see [`preload_time`].
     let client = http_utils::get_client_old().clone();
     let cur_q = {
         let mut handler = call.lock().await;
@@ -644,7 +693,7 @@ pub async fn queue_query_list_offset(
                     continue;
                 },
             };
-            let _ = handler.enqueue(track).await;
+            let _ = handler.enqueue_with_preload(track, preload_time(&resolved));
             handler.queue().modify_queue(|q| {
                 if let Some(back) = q.pop_back() {
                     q.insert((idx + offset).min(q.len()), back);
@@ -752,18 +801,33 @@ pub fn stop_queue(guard: &QueueGuard, handler: &Call) {
     handler.queue().stop();
 }
 
-/// Pause the queue. Used by autopause in the global track-end handler.
+/// Pause the queue. Used by `/pause` and by autopause in the global track-end
+/// handler.
 ///
-/// Same `&Call` shape as [`stop_queue`], for symmetry at the two call sites.
-/// A pause that fails (nothing is playing) is swallowed: autopause is a nicety
-/// nobody asked for at this instant, and it has no user to answer to.
+/// Same `&Call` shape as [`stop_queue`]. The failure is handed back rather than
+/// swallowed, because the two callers want opposite things with it: `/pause`
+/// has a user to tell, autopause does not.
 ///
 /// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
 /// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
 /// error message rather than a corrupted `/gp` round.
-pub fn pause_queue(guard: &QueueGuard, handler: &Call) {
+pub fn pause_queue(guard: &QueueGuard, handler: &Call) -> TrackResult<()> {
     let _ = guard;
-    handler.queue().pause().ok();
+    handler.queue().pause()
+}
+
+/// Resume the queue. Used by `/resume`.
+///
+/// Same `&Call` shape as [`stop_queue`].
+///
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. 🔴 That is not belt-and-braces here: `/resume` was in neither
+/// `GP_BLOCKED_COMMANDS` nor the funnel, so it was the one queue mutation a
+/// user could still land on a running `/gp` round. The guard is what closes it;
+/// the blocklist entry added alongside only makes the refusal arrive earlier.
+pub fn resume_queue(guard: &QueueGuard, handler: &Call) -> TrackResult<()> {
+    let _ = guard;
+    handler.queue().resume()
 }
 
 /// Enqueue an already-built [`Track`] at the back of the queue, returning its
@@ -773,6 +837,10 @@ pub fn pause_queue(guard: &QueueGuard, handler: &Call) {
 /// arms per-track event handlers on it; [`queue_resolved_track_back`] is the
 /// snapshot-returning shape.
 ///
+/// `preload` is passed explicitly rather than letting songbird derive it,
+/// because deriving it spawns yt-dlp inside the guard -- see [`preload_time`],
+/// which is how the caller should compute this.
+///
 /// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
 /// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
 /// error message rather than a corrupted `/gp` round.
@@ -780,15 +848,20 @@ pub async fn enqueue_track_back(
     guard: &QueueGuard,
     call: &Arc<Mutex<Call>>,
     track: Track,
+    preload: Option<Duration>,
 ) -> TrackHandle {
     let _ = guard;
     let mut handler = call.lock().await;
-    handler.enqueue(track).await
+    handler.enqueue_with_preload(track, preload)
 }
 
 /// Enqueue an already-resolved songbird [`Input`](SongbirdInput) at the back of
 /// the queue, returning its handle. Used by autoplay in the global track-end
 /// handler.
+///
+/// `preload` is passed explicitly for the same reason as
+/// [`enqueue_track_back`]: `enqueue_input` would derive it by spawning yt-dlp
+/// under the guard. The caller has the resolved metadata and can supply it.
 ///
 /// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
 /// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
@@ -797,10 +870,11 @@ pub async fn enqueue_input_back(
     guard: &QueueGuard,
     call: &Arc<Mutex<Call>>,
     source: SongbirdInput,
+    preload: Option<Duration>,
 ) -> TrackHandle {
     let _ = guard;
     let mut handler = call.lock().await;
-    handler.enqueue_input(source).await
+    handler.enqueue_with_preload(source.into(), preload)
 }
 
 /// Shuffle `values` in place using the Fisher-Yates algorithm.

--- a/crack-core/src/music/queue.rs
+++ b/crack-core/src/music/queue.rs
@@ -1133,3 +1133,134 @@ mod insertion_tests {
         assert_eq!(inserted.count(), inserted.handles.len());
     }
 }
+
+#[cfg(test)]
+mod queue_query_list_offset_ordering_tests {
+    //! Regression test for the Critical fixed in 6f2d8b4:
+    //! `queue_query_list_offset` used to take its `QueueGuard` as an external
+    //! parameter, so callers held it across the function's own
+    //! `resolve_track_many` -- up to ~13 sequential resolve batches for a
+    //! 100-track playlist, meaning every other music command in the guild
+    //! could block for over a minute. The fix moved guard acquisition inside
+    //! the function, *after* resolution, and made the queue length get read
+    //! (and acted on) under that same guard instead of being read before
+    //! resolving and acted on against a stale number afterward.
+    //!
+    //! Neither half of that fix has a behavioural test available offline: it
+    //! needs a live songbird `Call`, a real voice connection, and a genuinely
+    //! slow (8-15s+) resolve to observe the blocking, none of which are
+    //! reachable without the network -- which tests in this repo may not
+    //! touch. So this test reads the function's own source text and asserts
+    //! the ordering of four markers instead. It is a deliberately unusual
+    //! shape for a test; keep it that way rather than deleting it unless a
+    //! real behavioural test becomes possible.
+
+    /// The whole file, included as a string so the test can scan the
+    /// function's own source. If `queue_query_list_offset` is ever renamed,
+    /// moved to another file, or restructured past what the markers below
+    /// can find, every `.expect`/panic here fails loudly with a message that
+    /// says so -- on purpose. A test that silently stops checking and keeps
+    /// passing is worse than no test at all (see ct#448, #449, #471); this
+    /// one refuses to pass vacuously.
+    const SRC: &str = include_str!("queue.rs");
+
+    const FN_SIGNATURE: &str = "pub async fn queue_query_list_offset(";
+    const RESOLVE_MARKER: &str = "resolve_track_many(queries)";
+    const LOCK_MARKER: &str = "lock_queue(guild_id, PlaybackOwner::Free)";
+    const LEN_MARKER: &str = "handler.queue().len()";
+    const DROP_MARKER: &str = "drop(guard)";
+
+    /// Slices out `queue_query_list_offset`'s own body, from its signature to
+    /// the first column-0 `}` that follows it. Every top-level item in this
+    /// file is rustfmt'd with its closing brace alone on an unindented line;
+    /// every brace inside the function body (blocks, closures, `if`, loops)
+    /// is indented. That makes `"\n}\n"` a reliable end-of-function marker
+    /// without a full brace-matching parser.
+    fn function_body() -> &'static str {
+        let sig_idx = SRC.find(FN_SIGNATURE).unwrap_or_else(|| {
+            panic!(
+                "queue_query_list_offset's signature (`{FN_SIGNATURE}`) is no \
+                 longer found in queue.rs -- the function was renamed, moved, \
+                 or restructured. This test guards a Critical fixed in \
+                 6f2d8b4: resolve_track_many must run before the QueueGuard \
+                 is acquired, and the queue length must be read and acted on \
+                 under that one guard, not read, dropped, and acted on \
+                 stale. Update the markers in this test to match the new \
+                 shape rather than deleting it."
+            )
+        });
+        let end_rel = SRC[sig_idx..].find("\n}\n").unwrap_or_else(|| {
+            panic!(
+                "could not find the end of queue_query_list_offset (no \
+                 unindented closing brace found after its signature) -- the \
+                 function's shape changed enough that this test's \
+                 end-of-body heuristic no longer applies. Update it rather \
+                 than deleting the test; see the module doc comment for why \
+                 it exists."
+            )
+        });
+        &SRC[sig_idx..sig_idx + end_rel + 2]
+    }
+
+    fn find_marker(body: &str, marker: &str, what: &str) -> usize {
+        body.find(marker).unwrap_or_else(|| {
+            panic!(
+                "expected to find `{marker}` ({what}) inside \
+                 queue_query_list_offset, but it's gone. This test guards the \
+                 Critical fixed in 6f2d8b4 -- see the module doc comment. If \
+                 the code was legitimately restructured, update this marker \
+                 to match rather than deleting the assertion."
+            )
+        })
+    }
+
+    #[test]
+    fn resolves_before_locking_and_reads_length_under_the_guard() {
+        let body = function_body();
+
+        let resolve_idx = find_marker(body, RESOLVE_MARKER, "the resolve_track_many call");
+        let lock_idx = find_marker(body, LOCK_MARKER, "the lock_queue call");
+        let len_idx = find_marker(body, LEN_MARKER, "the queue-length read");
+        let drop_idx = find_marker(body, DROP_MARKER, "the first guard drop");
+
+        // Invariant 1: resolution (the slow, network-bound leg) happens
+        // entirely before the guard is acquired. If this regresses, a
+        // second `/play` in the guild waits out someone else's resolve --
+        // up to ~13 sequential batches, over a minute, for a big playlist.
+        assert!(
+            resolve_idx < lock_idx,
+            "resolve_track_many must be called before lock_queue in \
+             queue_query_list_offset (found resolve at byte {resolve_idx}, \
+             lock at byte {lock_idx}). Holding the QueueGuard across \
+             resolution blocks every other music command in the guild for \
+             as long as the resolve takes (8-15s+, worse for playlists) -- \
+             this was a shipped Critical, fixed in 6f2d8b4. Do not reorder \
+             these calls; if resolution genuinely needs to move, the guard \
+             must not be held across it."
+        );
+
+        // Invariant 2: the queue length is read after the guard is
+        // acquired, and before the guard is ever dropped -- i.e. under the
+        // one guard that also performs the insert, not read, dropped, and
+        // acted on stale. If this regresses, the length used to decide
+        // "insert at offset" vs. "just append" can be stale against a
+        // concurrent mutation that happened while the guard was released.
+        assert!(
+            lock_idx < len_idx,
+            "the queue-length read (`{LEN_MARKER}`) must come after \
+             lock_queue in queue_query_list_offset (found lock at byte \
+             {lock_idx}, length read at byte {len_idx}) -- the length must \
+             be read under the guard, not before it is acquired."
+        );
+        assert!(
+            len_idx < drop_idx,
+            "the queue-length read (`{LEN_MARKER}`) must come before the \
+             guard is ever dropped (found length read at byte {len_idx}, \
+             first `drop(guard)` at byte {drop_idx}) in \
+             queue_query_list_offset. If the guard is dropped before the \
+             length is read and acted on, the check-then-act race this \
+             guard exists to close (fixed in 6f2d8b4) is back: the length \
+             can go stale between the check and the insert."
+        );
+    }
+}

--- a/crack-gpt/Cargo.toml
+++ b/crack-gpt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-gpt"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-osint/Cargo.toml
+++ b/crack-osint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-osint"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-sleevenote/Cargo.toml
+++ b/crack-sleevenote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-sleevenote"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-testing/Cargo.toml
+++ b/crack-testing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "crack-testing"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/crack-types/Cargo.toml
+++ b/crack-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-types"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-voting/Cargo.toml
+++ b/crack-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-voting"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/docs/superpowers/plans/2026-09-10-playback-ownership-lease.md
+++ b/docs/superpowers/plans/2026-09-10-playback-ownership-lease.md
@@ -1,0 +1,1304 @@
+# Playback Ownership Lease Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make queue mutation in a guild impossible without holding a token that
+proves nobody else owns playback, closing #434 and #333 together.
+
+**Architecture:** Two per-guild concepts on `Data`, deliberately separate because
+their lifetimes differ by three orders of magnitude. *Ownership* (`PlaybackOwner`)
+is long-lived and declarative, written only inside the five methods that already
+move `gp_games` so the two cannot diverge. *Exclusion* (`QueueGuard`) is a
+short-lived RAII guard over a per-guild mutex. Every queue mutation moves behind a
+`music/queue.rs` helper that takes `&QueueGuard`, so a command physically cannot
+mutate the queue without passing the ownership check.
+
+**Tech Stack:** Rust, tokio (`Mutex`, `OwnedMutexGuard`), dashmap, songbird
+(`Call`, `TrackQueue`, `TrackHandle`), poise/serenity.
+
+**Spec:** `docs/superpowers/specs/2026-09-10-playback-ownership-lease-design.md`
+
+## Global Constraints
+
+- **Resolution stays outside the lease.** `resolve_track_many` shells out to
+  `yt-dlp` and takes 8–15s cold. Resolve first, then take the guard for the
+  enqueue and the reply. A guard held across resolution is a defect.
+- **Lock order: playback lease first, join token second, never the reverse.**
+  Carry a `debug_assert`, not only a comment.
+- **Never hold a `dashmap` reference across an `.await`.** It deadlocks. Clone
+  the `Arc` out and let the entry ref drop before awaiting — the pattern
+  `JoinVCToken::acquire` (`crack-core/src/poise_ext.rs:586-594`) already uses.
+- **The lease is process-local.** It is never written to Postgres.
+- **No test may reach live YouTube.** Use `#[ignore = "hits live YouTube"]` if a
+  test genuinely needs the network. See `docs/testing.md`.
+- **`GP_BLOCKED_COMMANDS` is not removed.** It stays as the early, friendly
+  refusal.
+- Commit trailer on every commit:
+  `Co-Authored-By: Claude & Lothrop (cycle.five@proton.me)`
+
+### ⚠️ Raise lease refusals from command bodies, not from poise checks
+
+`CrackedError::GameInProgress` reaches a user only when it is returned from a
+command **body**. Returned from a poise **check** it becomes
+`FrameworkError::CommandCheckFailed`, which `on_error`
+(`crack-core/src/config.rs:32`) has **no arm for** — it falls through to poise's
+builtin, which logs and never replies, and Discord times the interaction out
+after three seconds with "The application did not respond". That is **#467**,
+open and unfixed.
+
+Every `lock_queue` call in this plan is inside a command body or an event
+handler, so none of them hit this. **Do not move one into a check** to make it
+fire earlier: it would become invisible. `GP_BLOCKED_COMMANDS` already runs in
+`cmd_check_music` and has the same problem — that is #467's job, not this
+plan's.
+
+### ⚠️ Re-derive the site lists before you start
+
+`GP_BLOCKED_COMMANDS` grew 11 → 19 in the four days between the issue and the
+spec. The tables below were accurate at `0d5f4d0`. Run these first and reconcile:
+
+```bash
+grep -rn "\.enqueue(\|modify_queue\|\.dequeue(\|queue()\.\(skip\|stop\|pause\|resume\)()" \
+     --include='*.rs' crack-core/src
+grep -rn "gp_games\.\(insert\|remove\|entry\)" --include='*.rs' crack-core/src
+```
+
+If a site exists that is not in this plan, add it to the task that owns its file
+and say so in the task report.
+
+---
+
+## File Structure
+
+| file | responsibility |
+|---|---|
+| **Create** `crack-core/src/music/lease.rs` | `PlaybackOwner`, `QueueGuard`, and the `Data` impl block for claim/release/lock. New file rather than `lib.rs` (already 600+ lines of `Data`) or `gp.rs` (5,651 lines, and #461 proposes splitting it). |
+| **Modify** `crack-core/src/music/mod.rs` | declare and re-export `lease` |
+| **Modify** `crack-core/src/lib.rs` | two new `DataInner` fields + their `Default` |
+| **Modify** `crack-core/src/commands/music/gp.rs` | 5 ownership sites, 4 mutation sites |
+| **Modify** `crack-core/src/commands/music/gp_persist.rs` | route the raw `gp_games.remove()` through a method |
+| **Modify** `crack-core/src/music/queue.rs` | helpers take `&QueueGuard`; `Inserted` return; fix check-then-act |
+| **Modify** `crack-core/src/commands/music/{skip,shuffle,remove,clear}.rs` | call helpers instead of `handler.queue()` |
+| **Modify** `crack-core/src/handlers/track_end.rs` | event-handler carve-out |
+| **Modify** `crack-core/src/commands/music/doplay.rs` | reply from the insertion result |
+
+---
+
+### Task 1: The lease primitives
+
+**Files:**
+- Create: `crack-core/src/music/lease.rs`
+- Modify: `crack-core/src/music/mod.rs`
+- Modify: `crack-core/src/lib.rs` (`DataInner` fields + `Default`)
+- Test: inline `#[cfg(test)] mod test` in `crack-core/src/music/lease.rs`
+
+**Interfaces:**
+- Consumes: `CrackedError::GameInProgress` (`crack-core/src/errors.rs:109`),
+  `Data`/`DataInner` (`crack-core/src/lib.rs:367`).
+- Produces:
+  ```rust
+  pub enum PlaybackOwner { Free, Game }          // Copy, Eq, Default = Free
+  pub struct QueueGuard;                          // opaque; .guild_id() -> GuildId
+  impl Data {
+      pub fn playback_owner(&self, guild_id: GuildId) -> PlaybackOwner;
+      pub fn claim_playback(&self, guild_id: GuildId, owner: PlaybackOwner) -> Result<(), CrackedError>;
+      pub fn release_playback(&self, guild_id: GuildId);
+      pub async fn lock_queue(&self, guild_id: GuildId, as_: PlaybackOwner) -> Result<QueueGuard, CrackedError>;
+  }
+  ```
+
+- [ ] **Step 1: Add the two `DataInner` fields**
+
+In `crack-core/src/lib.rs`, immediately after the `join_vc_tokens` field
+(currently line 378) so the two per-guild locks sit together:
+
+```rust
+    /// Who owns playback per guild. Written ONLY by `claim_playback` /
+    /// `release_playback`, which are called from inside the methods that move
+    /// `gp_games` -- see `music/lease.rs`. Do not write it anywhere else.
+    pub playback_owners: dashmap::DashMap<serenity::GuildId, crate::music::lease::PlaybackOwner>,
+    /// Per-guild queue-mutation mutex. Held for milliseconds; see `lock_queue`.
+    pub queue_locks: dashmap::DashMap<serenity::GuildId, Arc<tokio::sync::Mutex<()>>>,
+```
+
+And in the `Default for DataInner` impl, beside `join_vc_tokens: Default::default(),`
+(currently line 595):
+
+```rust
+            playback_owners: Default::default(),
+            queue_locks: Default::default(),
+```
+
+- [ ] **Step 2: Declare the module**
+
+In `crack-core/src/music/mod.rs`, after `pub(crate) mod queue;`:
+
+```rust
+pub mod lease;
+
+pub use lease::{PlaybackOwner, QueueGuard};
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+Create `crack-core/src/music/lease.rs` containing ONLY this test module for now
+(the code comes in Step 5), plus `use` lines so it compiles once the types exist:
+
+```rust
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{Data, DataInner};
+    use std::sync::Arc;
+
+    const G: GuildId = GuildId::new(1);
+    const H: GuildId = GuildId::new(2);
+
+    fn data() -> Data {
+        Data(Arc::new(DataInner::default()))
+    }
+
+    #[test]
+    fn a_guild_with_no_claim_is_free() {
+        assert_eq!(data().playback_owner(G), PlaybackOwner::Free);
+    }
+
+    #[test]
+    fn claim_then_release_round_trips() {
+        let d = data();
+        d.claim_playback(G, PlaybackOwner::Game).expect("free guild accepts a claim");
+        assert_eq!(d.playback_owner(G), PlaybackOwner::Game);
+        d.release_playback(G);
+        assert_eq!(d.playback_owner(G), PlaybackOwner::Free);
+    }
+
+    #[test]
+    fn releasing_a_guild_that_owns_nothing_is_a_no_op() {
+        // The game-end paths are event-driven and can each arrive first, so a
+        // double release is normal, not an error.
+        let d = data();
+        d.release_playback(G);
+        d.release_playback(G);
+        assert_eq!(d.playback_owner(G), PlaybackOwner::Free);
+    }
+
+    #[test]
+    fn re_claiming_as_the_same_owner_succeeds() {
+        // Defensive idempotency: `gp_start` only claims from an Entry::Vacant
+        // branch, so this should be unreachable -- but failing here would turn a
+        // harmless double-claim into a refused /gp start.
+        let d = data();
+        d.claim_playback(G, PlaybackOwner::Game).unwrap();
+        d.claim_playback(G, PlaybackOwner::Game).expect("same owner may re-claim");
+    }
+
+    #[test]
+    fn a_claim_is_per_guild() {
+        let d = data();
+        d.claim_playback(G, PlaybackOwner::Game).unwrap();
+        assert_eq!(d.playback_owner(H), PlaybackOwner::Free);
+    }
+
+    #[tokio::test]
+    async fn a_free_guild_hands_out_a_guard() {
+        let d = data();
+        let guard = d.lock_queue(G, PlaybackOwner::Free).await.expect("free guild locks");
+        assert_eq!(guard.guild_id(), G);
+    }
+
+    #[tokio::test]
+    async fn a_game_owned_guild_refuses_a_non_owner_immediately() {
+        let d = data();
+        d.claim_playback(G, PlaybackOwner::Game).unwrap();
+        let err = d.lock_queue(G, PlaybackOwner::Free).await.unwrap_err();
+        assert!(matches!(err, CrackedError::GameInProgress));
+    }
+
+    #[tokio::test]
+    async fn the_owner_can_still_lock_its_own_queue() {
+        // /gp mutates its own queue at four sites; the lease must not lock the
+        // owner out of the thing it owns.
+        let d = data();
+        d.claim_playback(G, PlaybackOwner::Game).unwrap();
+        d.lock_queue(G, PlaybackOwner::Game).await.expect("the owner may lock");
+    }
+
+    #[tokio::test]
+    async fn the_refusal_does_not_wait_for_the_mutex() {
+        // Fail-fast is the whole point: nobody waits out a half-hour game. If the
+        // ownership check happened after the mutex, this would block forever.
+        let d = data();
+        d.claim_playback(G, PlaybackOwner::Game).unwrap();
+        let _held = d.lock_queue(G, PlaybackOwner::Game).await.unwrap();
+        let refused = tokio::time::timeout(
+            std::time::Duration::from_millis(200),
+            d.lock_queue(G, PlaybackOwner::Free),
+        )
+        .await
+        .expect("must refuse without waiting on the mutex");
+        assert!(matches!(refused, Err(CrackedError::GameInProgress)));
+    }
+
+    #[tokio::test]
+    async fn two_lockers_of_a_free_guild_serialise() {
+        let d = data();
+        let first = d.lock_queue(G, PlaybackOwner::Free).await.unwrap();
+        let blocked = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            d.lock_queue(G, PlaybackOwner::Free),
+        )
+        .await;
+        assert!(blocked.is_err(), "the second locker must wait");
+        drop(first);
+        d.lock_queue(G, PlaybackOwner::Free)
+            .await
+            .expect("the lock is released on drop");
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they fail**
+
+Run: `cargo test -p crack-core --lib music::lease`
+Expected: FAIL to compile — `PlaybackOwner`, `QueueGuard`, `playback_owner`,
+`claim_playback`, `release_playback`, `lock_queue` are not defined.
+
+- [ ] **Step 5: Write the implementation**
+
+Prepend to `crack-core/src/music/lease.rs`, above the test module:
+
+```rust
+//! Per-guild playback ownership and queue exclusion.
+//!
+//! Two concepts, deliberately not merged, because their lifetimes differ by
+//! three orders of magnitude:
+//!
+//! * **Ownership** ([`PlaybackOwner`]) -- long-lived and declarative. Who owns
+//!   playback in this guild. Claimed by `/gp start`, released at game end,
+//!   checked cheaply, and **fails fast**.
+//! * **Exclusion** ([`QueueGuard`]) -- short-lived and operational. A per-guild
+//!   mutex serialising queue mutation, held for milliseconds.
+//!
+//! # 🔑 Ownership is written in exactly five places
+//!
+//! [`Data::claim_playback`] and [`Data::release_playback`] are called from
+//! *inside* the methods that move `gp_games`, never alongside them. An explicit
+//! lease is a second source of truth, and a lease that outlives its game wedges
+//! `/play` forever with no game left to end. Co-locating the two writes makes
+//! divergence structurally impossible rather than merely unlikely. If you find
+//! yourself calling `claim_playback` from a new place, you are adding the bug
+//! this design exists to prevent.
+//!
+//! # 🪤 `QueueGuard` is NOT shaped like `JoinVCToken`
+//!
+//! #434 describes it as "in the shape of `JoinVCToken`", and the *intent* is the
+//! same -- an unforgeable proof carried in the type system -- but the mechanism
+//! differs and assuming otherwise will produce a bug:
+//!
+//! | | `JoinVCToken` | `QueueGuard` |
+//! |---|---|---|
+//! | `acquire` | not `async`, takes no lock | `async`, holds the lock on return |
+//! | who locks | the consumer (`join_vc`) | the constructor |
+//! | what it proves | you went through the right door | you hold exclusion *now* |
+//!
+//! # Lock ordering
+//!
+//! The lease sits alongside `join_vc_tokens`, not replacing it, so there are two
+//! per-guild locks. **Playback lease first, join token second, never the
+//! reverse.**
+
+use crate::errors::CrackedError;
+use crate::Data;
+use dashmap::mapref::entry::Entry;
+use poise::serenity_prelude::GuildId;
+use std::sync::Arc;
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+/// Who owns playback in a guild.
+///
+/// An enum rather than a bool because a third owner is foreseeable; adding one
+/// now would be speculative.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PlaybackOwner {
+    /// Nobody owns playback; ordinary music commands may mutate the queue.
+    #[default]
+    Free,
+    /// A `/gp` game owns playback for the duration of the game.
+    Game,
+}
+
+/// Proof that the holder may mutate this guild's queue, and that nobody else is
+/// doing so concurrently.
+///
+/// Obtained only from [`Data::lock_queue`]. The exclusion is released when this
+/// is dropped, so do not hold one across a slow operation -- in particular never
+/// across track resolution, which takes 8-15s cold.
+#[derive(Debug)]
+pub struct QueueGuard {
+    guild_id: GuildId,
+    /// Dropping this releases the per-guild mutex. Never read.
+    _exclusion: OwnedMutexGuard<()>,
+}
+
+impl QueueGuard {
+    /// The guild this guard permits mutation in.
+    #[must_use]
+    pub fn guild_id(&self) -> GuildId {
+        self.guild_id
+    }
+}
+
+impl Data {
+    /// Who owns playback in this guild. A guild with no claim is [`PlaybackOwner::Free`].
+    #[must_use]
+    pub fn playback_owner(&self, guild_id: GuildId) -> PlaybackOwner {
+        self.playback_owners
+            .get(&guild_id)
+            .map(|owner| *owner)
+            .unwrap_or_default()
+    }
+
+    /// Take ownership of playback in a guild.
+    ///
+    /// # Errors
+    ///
+    /// [`CrackedError::GameInProgress`] if a *different* owner already holds it.
+    /// Re-claiming as the current owner succeeds: the callers claim from inside
+    /// an `Entry::Vacant` branch on `gp_games`, so a collision should be
+    /// unreachable, and failing here would turn a harmless double-claim into a
+    /// refused `/gp start`.
+    pub fn claim_playback(
+        &self,
+        guild_id: GuildId,
+        owner: PlaybackOwner,
+    ) -> Result<(), CrackedError> {
+        match self.playback_owners.entry(guild_id) {
+            Entry::Vacant(slot) => {
+                slot.insert(owner);
+                Ok(())
+            },
+            Entry::Occupied(held) if *held.get() == owner => Ok(()),
+            Entry::Occupied(_) => Err(CrackedError::GameInProgress),
+        }
+    }
+
+    /// Give up ownership of playback in a guild.
+    ///
+    /// Infallible and idempotent. Releasing a guild that owns nothing is a
+    /// no-op, not an error: the game-end paths are event-driven and each can
+    /// arrive first.
+    pub fn release_playback(&self, guild_id: GuildId) {
+        self.playback_owners.remove(&guild_id);
+    }
+
+    /// Acquire exclusive permission to mutate this guild's queue.
+    ///
+    /// Game-versus-command fails fast; command-versus-command waits, and the
+    /// wait is short because resolution happens outside the guard.
+    ///
+    /// # Errors
+    ///
+    /// [`CrackedError::GameInProgress`] -- immediately, without touching the
+    /// mutex -- when a game owns playback and `as_` is not that owner.
+    pub async fn lock_queue(
+        &self,
+        guild_id: GuildId,
+        as_: PlaybackOwner,
+    ) -> Result<QueueGuard, CrackedError> {
+        // Ownership is checked BEFORE the mutex, deliberately. A caller refused
+        // on ownership must not first wait out whoever holds the mutex.
+        let owner = self.playback_owner(guild_id);
+        if owner != PlaybackOwner::Free && owner != as_ {
+            return Err(CrackedError::GameInProgress);
+        }
+
+        // 🪤 The `.clone()` matters: a dashmap reference held across the await
+        // below deadlocks the shard. Cloning the Arc lets the entry ref drop at
+        // the end of this statement. Same shape as `JoinVCToken::acquire`.
+        let lock = self
+            .queue_locks
+            .entry(guild_id)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone();
+
+        Ok(QueueGuard {
+            guild_id,
+            _exclusion: lock.lock_owned().await,
+        })
+    }
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cargo test -p crack-core --lib music::lease`
+Expected: PASS, 10 tests.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+cargo fmt --all
+cargo clippy -p crack-core --all-targets
+git add crack-core/src/music/lease.rs crack-core/src/music/mod.rs crack-core/src/lib.rs
+git commit -m "$(cat <<'EOF'
+feat(playback): a per-guild ownership lease and queue-exclusion guard
+
+Ownership is long-lived and fails fast; exclusion is a short RAII guard over a
+per-guild mutex. Ownership is checked BEFORE the mutex so a refused caller does
+not first wait out whoever holds it.
+
+Nothing calls these yet; the call sites arrive over the following commits.
+
+Co-Authored-By: Claude & Lothrop (cycle.five@proton.me)
+EOF
+)"
+```
+
+---
+
+### Task 2: Co-locate claim/release with the five `gp_games` sites
+
+This is the load-bearing task. After it, the lease and the games map cannot
+disagree.
+
+**Files:**
+- Modify: `crack-core/src/commands/music/gp.rs` (`gp_start` ~:1003,
+  `gp_remove_if_parked` ~:1582, `gp_remove` ~:1596, `gp_restore` ~:1611)
+- Modify: `crack-core/src/commands/music/gp_persist.rs` (~:619)
+- Test: inline in `crack-core/src/commands/music/gp.rs` test module
+
+**Interfaces:**
+- Consumes: `Data::claim_playback`, `Data::release_playback`,
+  `Data::playback_owner`, `PlaybackOwner` from Task 1.
+- Produces: the invariant *"`gp_games.contains_key(g)` ⟺ `playback_owner(g) == Game`"*,
+  which every later task may rely on.
+
+- [ ] **Step 1: Write the failing invariant test**
+
+Add to the existing `#[cfg(test)] mod test` in `crack-core/src/commands/music/gp.rs`.
+
+**Three fixtures are needed. Reuse the module's own if they exist under other
+names; otherwise write them:**
+
+- `recording() -> (Data, mpsc::UnboundedReceiver<GpPersist>)` — a `Data` whose
+  persistence writes land in a channel rather than Postgres. This one **already
+  exists** in `crack-core/src/commands/music/gp_persist.rs`'s test module; copy
+  it or lift it into a shared test helper.
+- `a_game(guild_id: GuildId) -> GpGame` — a minimal game, enough for
+  `gp_restore` to accept. Build it the way the existing `gp.rs` tests build one.
+- `start_a_game(data: &Data, guild_id: GuildId)` — calls `data.gp_start(..)` with
+  minimal arguments and asserts it succeeded, so the tests below read as
+  lifecycle rather than setup.
+
+`G` and `A` are the module's existing `GuildId`/`UserId` constants
+(`GuildId::new(1)`, `UserId::new(100)` in the `gp_persist.rs` tests).
+
+```rust
+    /// The lease and the games map must agree after EVERY game-lifecycle method.
+    /// This is the regression guard for the drift the co-location design exists
+    /// to prevent: a lease that outlives its game wedges /play forever, with no
+    /// game left to end.
+    fn assert_lease_agrees(data: &Data, guild_id: GuildId) {
+        let has_game = data.gp_games.contains_key(&guild_id);
+        let owned = data.playback_owner(guild_id) == PlaybackOwner::Game;
+        assert_eq!(
+            has_game, owned,
+            "gp_games says {has_game} but the lease says {owned} for {guild_id}"
+        );
+    }
+
+    #[test]
+    fn gp_start_claims_playback() {
+        let (data, _rx) = recording();
+        assert_lease_agrees(&data, G);
+        start_a_game(&data, G);
+        assert_eq!(data.playback_owner(G), PlaybackOwner::Game);
+        assert_lease_agrees(&data, G);
+    }
+
+    #[test]
+    fn gp_remove_releases_playback() {
+        let (data, _rx) = recording();
+        start_a_game(&data, G);
+        data.gp_remove(G);
+        assert_eq!(data.playback_owner(G), PlaybackOwner::Free);
+        assert_lease_agrees(&data, G);
+    }
+
+    #[test]
+    fn gp_remove_if_parked_releases_only_when_it_removes() {
+        let (data, _rx) = recording();
+        start_a_game(&data, G);
+
+        // Not parked: nothing is removed, so nothing is released.
+        assert!(!data.gp_remove_if_parked(G));
+        assert_eq!(data.playback_owner(G), PlaybackOwner::Game);
+        assert_lease_agrees(&data, G);
+
+        data.gp_park_for_end(G, A, true).expect("park");
+        assert!(data.gp_remove_if_parked(G));
+        assert_eq!(data.playback_owner(G), PlaybackOwner::Free);
+        assert_lease_agrees(&data, G);
+    }
+
+    #[test]
+    fn gp_restore_claims_playback() {
+        let (data, _rx) = recording();
+        let game = a_game(G);
+        assert!(data.gp_restore(G, game));
+        assert_eq!(data.playback_owner(G), PlaybackOwner::Game);
+        assert_lease_agrees(&data, G);
+    }
+
+    #[test]
+    fn a_refused_restore_does_not_claim() {
+        // `gp_restore` returns false when /gp start got there first. The lease
+        // is already held by that game; the refused restore must not touch it.
+        let (data, _rx) = recording();
+        start_a_game(&data, G);
+        assert!(!data.gp_restore(G, a_game(G)));
+        assert_lease_agrees(&data, G);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p crack-core --lib gp::test -- lease`
+Expected: FAIL — `playback_owner` returns `Free` after `gp_start`.
+
+- [ ] **Step 3: Claim inside the two insert paths**
+
+In `gp.rs`, `Data::gp_start` — the `Entry::Vacant` branch around line 1003. Claim
+**inside** the branch that inserts, so a refused start claims nothing:
+
+```rust
+        let dashmap::mapref::entry::Entry::Vacant(slot) = self.gp_games.entry(guild_id) else {
+            return Err(CrackedError::GameInProgress);
+        };
+        // 🔑 Claimed here, inside the branch that inserts, so the lease and the
+        // map move together. See music/lease.rs on why this must not be called
+        // from anywhere else.
+        self.claim_playback(guild_id, PlaybackOwner::Game)?;
+        slot.insert(game);
+```
+
+In `Data::gp_restore` around line 1611, in the `Vacant` arm only:
+
+```rust
+        match self.gp_games.entry(guild_id) {
+            dashmap::mapref::entry::Entry::Vacant(slot) => {
+                // Reclaimed before anything is restored into the guild -- the
+                // arbitration #431 needed, so a resumed game and a restored
+                // queue cannot both take the voice channel.
+                if self.claim_playback(guild_id, PlaybackOwner::Game).is_err() {
+                    return false;
+                }
+                slot.insert(game);
+                true
+            },
+```
+
+- [ ] **Step 4: Release inside the two remove paths**
+
+In `Data::gp_remove_if_parked` (~:1582), inside the `if let Some(..)`:
+
+```rust
+            if let Some((_, game)) = self.gp_games.remove(&guild_id) {
+                self.release_playback(guild_id);
+                self.gp_mark_finished(&game, GpOutcome::Ended);
+            }
+```
+
+In `Data::gp_remove` (~:1596), immediately after the successful remove:
+
+```rust
+        let (_, game) = self.gp_games.remove(&guild_id)?;
+        self.release_playback(guild_id);
+```
+
+- [ ] **Step 5: Route the raw remove through the method**
+
+`gp_persist.rs` around line 619 currently calls `data.gp_games.remove(&guild_id)`
+directly on the rejoin-failure path, bypassing `Data::gp_remove` — a defect in
+its own right, and with the lease it would strand ownership. Replace:
+
+```rust
+            data.gp_games.remove(&guild_id);
+```
+
+with:
+
+```rust
+            // Through the method, not the map: `gp_remove` is the one place a
+            // game ends, and it is what releases the playback lease. A raw
+            // remove here would leave the guild owned by a game that no longer
+            // exists, and /play refused forever.
+            data.gp_remove(guild_id);
+```
+
+`gp_remove` also writes a `GpOutcome`; the surrounding code then calls the
+`gp_mark_finished` *free function* with `GpOutcome::Lost`. Keep that call — the
+free function is the authoritative database write for this path — and note in a
+comment that `gp_remove`'s own bookkeeping is superseded here.
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `cargo test -p crack-core --lib gp`
+Expected: PASS, including the five new lease tests and every pre-existing `gp` test.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+cargo fmt --all
+cargo clippy -p crack-core --all-targets
+git add crack-core/src/commands/music/gp.rs crack-core/src/commands/music/gp_persist.rs
+git commit -m "$(cat <<'EOF'
+feat(gp): claim and release the playback lease where the games map moves
+
+Claim/release live INSIDE gp_start, gp_restore, gp_remove and
+gp_remove_if_parked rather than alongside them, so the lease and gp_games cannot
+diverge. An invariant test asserts they agree after every one.
+
+Also routes the rejoin-failure path in gp_resume_guild through Data::gp_remove
+instead of removing from the map directly. That was already a defect -- it
+bypassed the one place a game ends -- and with a lease it would strand ownership
+and refuse /play forever.
+
+Co-Authored-By: Claude & Lothrop (cycle.five@proton.me)
+EOF
+)"
+```
+
+---
+
+### Task 3: Phase C — report from the insertion result
+
+Closes #333 and shrinks the critical section the later tasks have to hold.
+
+**Files:**
+- Modify: `crack-core/src/music/queue.rs` (`enqueue_resolved_tracks_back` :112-134)
+- Modify: `crack-core/src/commands/music/doplay.rs` (reply construction)
+- Test: inline in `crack-core/src/music/queue.rs`
+
+**Interfaces:**
+- Consumes: nothing from Tasks 1-2.
+- Produces:
+  ```rust
+  pub struct Inserted {
+      pub handles: Vec<TrackHandle>,  // what THIS call added, in order
+      pub first_position: usize,      // where the first landed
+      pub queue_len: usize,           // queue length after this call
+  }
+  pub async fn enqueue_resolved_tracks_back(
+      call: &Arc<Mutex<Call>>, tracks: Vec<ResolvedTrack<'static>>, http_client: reqwest::Client,
+  ) -> Result<Inserted, CrackedError>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `crack-core/src/music/queue.rs`:
+
+```rust
+#[cfg(test)]
+mod insertion_tests {
+    use super::*;
+
+    #[test]
+    fn inserted_describes_only_this_call() {
+        // #333: the bug was returning the whole queue after enqueueing, so two
+        // concurrent /play calls each reported both sets of songs. `Inserted`
+        // cannot express that -- it carries only what this call added.
+        let inserted = Inserted {
+            handles: Vec::new(),
+            first_position: 3,
+            queue_len: 5,
+        };
+        assert_eq!(inserted.count(), 0);
+        assert_eq!(inserted.first_position, 3);
+        assert_eq!(inserted.queue_len, 5);
+    }
+
+    #[test]
+    fn count_is_the_handles_this_call_added() {
+        let inserted = Inserted { handles: Vec::new(), first_position: 0, queue_len: 0 };
+        assert_eq!(inserted.count(), inserted.handles.len());
+    }
+}
+```
+
+> A test that enqueues for real needs a songbird `Call`, which needs a voice
+> connection. Do not fake one. The behavioural guarantee here is structural — the
+> return type cannot express "the whole queue" — and that is what these assert.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p crack-core --lib music::queue::insertion_tests`
+Expected: FAIL to compile — `Inserted` is not defined.
+
+- [ ] **Step 3: Add `Inserted` and change the return**
+
+In `crack-core/src/music/queue.rs`:
+
+```rust
+/// What one enqueue call put into the queue.
+///
+/// 🔑 Deliberately NOT the whole queue. `enqueue_resolved_tracks_back` used to
+/// return `handler.queue().current_queue()` *after* enqueueing, so two
+/// concurrent `/play` calls both read the post-both state and both replies
+/// listed both sets of songs -- #333, reported as "one of the songs got queued
+/// twice". A reply built from what *this* call inserted cannot be corrupted by
+/// a concurrent one.
+#[derive(Debug, Clone)]
+pub struct Inserted {
+    /// The handles this call added, in the order they were added.
+    pub handles: Vec<TrackHandle>,
+    /// Where the first of them landed in the queue.
+    pub first_position: usize,
+    /// Queue length after this call. For "added N, now M in queue" replies.
+    pub queue_len: usize,
+}
+
+impl Inserted {
+    /// How many tracks this call added.
+    #[must_use]
+    pub fn count(&self) -> usize {
+        self.handles.len()
+    }
+}
+```
+
+Rewrite `enqueue_resolved_tracks_back` (currently :112-134):
+
+```rust
+pub async fn enqueue_resolved_tracks_back(
+    call: &Arc<Mutex<Call>>,
+    tracks: Vec<ResolvedTrack<'static>>,
+    http_client: reqwest::Client,
+) -> Result<Inserted, CrackedError> {
+    let mut handler = call.lock().await;
+    let first_position = handler.queue().len();
+    let mut handles = Vec::with_capacity(tracks.len());
+    for resolved in &tracks {
+        match build_track(resolved, &http_client) {
+            Ok(track) => handles.push(handler.enqueue(track).await),
+            Err(e) => tracing::warn!("Failed to enqueue {}: {e}", resolved.get_url()),
+        }
+    }
+    let queue_len = handler.queue().len();
+    Ok(Inserted { handles, first_position, queue_len })
+}
+```
+
+Note the empty-`tracks` early return is gone: the loop handles it, and the old
+early return called `current_queue()` — the very thing being removed.
+
+- [ ] **Step 4: Update the callers**
+
+Build with `cargo check -p crack-core` and fix each caller the compiler names.
+Callers that want a full queue snapshot for a message may still call
+`call.lock().await.queue().current_queue()` explicitly — the point is that they
+do so knowingly rather than receiving it from an enqueue.
+
+In `doplay.rs`, build the reply from the `Inserted` rather than a re-read.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cargo test -p crack-core --lib` and `cargo check -p crack-core --all-targets`
+Expected: PASS, no compile errors.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+cargo fmt --all
+cargo clippy -p crack-core --all-targets
+git add crack-core/src/music/queue.rs crack-core/src/commands/music/doplay.rs
+git commit -m "$(cat <<'EOF'
+fix(queue): report what this call inserted, not the queue afterwards (#333)
+
+enqueue_resolved_tracks_back returned handler.queue().current_queue() AFTER
+enqueueing, so two concurrent /play calls both read the post-both state and both
+replies listed both sets of songs -- the reported "one of the songs got queued
+twice".
+
+It now returns `Inserted`, which carries only the handles this call added. The
+type cannot express the old bug.
+
+This also shrinks the critical section the lease has to hold: a reply derived
+from the insertion result needs exclusion only over the enqueue, not over the
+enqueue and a re-read.
+
+Closes #333
+
+Co-Authored-By: Claude & Lothrop (cycle.five@proton.me)
+EOF
+)"
+```
+
+---
+
+### Task 4: The funnel — `queue.rs` helpers require a `&QueueGuard`
+
+**Files:**
+- Modify: `crack-core/src/music/queue.rs` (all 7 mutation sites)
+
+**Interfaces:**
+- Consumes: `QueueGuard` (Task 1), `Inserted` (Task 3).
+- Produces: every mutating helper in `music/queue.rs` takes `guard: &QueueGuard`
+  as its first parameter. Later tasks call these instead of `handler.queue()`.
+  Tasks 5 and 6 additionally need these **new** helpers, so define them here:
+
+  ```rust
+  /// Drop everything from `from` onward, stopping each track. Used by `/clear`.
+  pub fn clear_from(guard: &QueueGuard, handler: &Call, from: usize);
+
+  /// Drop `count` tracks after the currently-playing one. Used by `/skip`.
+  pub fn drain_after_current(guard: &QueueGuard, handler: &Call, count: usize);
+
+  /// Reorder the queue behind the currently-playing track. Used by `/shuffle`.
+  pub fn shuffle_behind_current(guard: &QueueGuard, handler: &Call);
+
+  /// Remove one track by queue index. Used by `/remove`.
+  pub fn remove_at(guard: &QueueGuard, handler: &Call, index: usize);
+
+  /// Stop the queue outright. Used by `/gp` when a game is discarded.
+  pub async fn stop_queue(guard: &QueueGuard, call: &Arc<Mutex<Call>>);
+
+  /// Pause the queue. Used by the track-end handler's autopause.
+  pub async fn pause_queue(guard: &QueueGuard, call: &Arc<Mutex<Call>>);
+  ```
+
+  Each takes the guard as its first parameter and ignores it — holding the
+  reference is the proof. Give each a `let _ = guard;` or name it `_guard` so
+  clippy does not flag it, and a doc line saying the caller must hold exclusion.
+
+- [ ] **Step 1: Add the guard parameter to every mutating helper**
+
+For each of `queue_resolved_track_back`, `queue_track_ready_front`,
+`_queue_track_ready_back`, `queue_track_front`, `queue_track_back`,
+`_append_queue`, `enqueue_resolved_tracks_back` and
+`queue_query_list_offset`, add a first parameter:
+
+```rust
+    guard: &QueueGuard,
+```
+
+and a doc line:
+
+```rust
+/// Requires a [`QueueGuard`]: the caller must hold playback exclusion for this
+/// guild. That is what makes forgetting a `GP_BLOCKED_COMMANDS` entry a worse
+/// error message rather than a corrupted `/gp` round.
+```
+
+Assert the guard is for the right guild wherever a `guild_id` is in scope:
+
+```rust
+    debug_assert_eq!(guard.guild_id(), guild_id, "QueueGuard is for another guild");
+```
+
+- [ ] **Step 2: Verify resolution stays outside**
+
+In `queue_track_back` and `queue_query_list_offset`, confirm
+`resolve_track`/`resolve_track_many` is called **before** the guard is used, and
+that no guard is held across it. If the current shape holds a lock across
+resolution, restructure so resolution completes first.
+
+This is a Global Constraint. A guard held across an 8–15s resolution makes a
+second `/play` wait 8–15s, which is barely an improvement on the bug.
+
+- [ ] **Step 3: Build**
+
+Run: `cargo check -p crack-core --all-targets`
+Expected: errors at every caller — that is the funnel working. Do not fix callers
+here; Tasks 5 and 6 own them.
+
+- [ ] **Step 4: Commit (compiles only after Task 6)**
+
+Because this task deliberately breaks callers, commit it together with Task 5 if
+your workflow requires each commit to build. Otherwise commit with
+`--no-verify` and note it in the task report.
+
+---
+
+### Task 5: Migrate the ordinary command call sites
+
+**Files:**
+- Modify: `crack-core/src/commands/music/skip.rs` (:39, :118, :119)
+- Modify: `crack-core/src/commands/music/shuffle.rs` (:42, :71)
+- Modify: `crack-core/src/commands/music/remove.rs` (:72)
+- Modify: `crack-core/src/commands/music/clear.rs` (:42)
+
+**Interfaces:**
+- Consumes: `Data::lock_queue`, `PlaybackOwner` (Task 1); the guard-taking
+  helpers (Task 4).
+- Produces: nothing new.
+
+- [ ] **Step 1: Apply this pattern at each site**
+
+These commands run for ordinary users, so they lock `as_ PlaybackOwner::Free` —
+which is exactly what a game refuses.
+
+Before (`clear.rs:42`):
+
+```rust
+    let handler = call.lock().await;
+    let queue = handler.queue().current_queue();
+    verify(queue.len() > 1, CrackedError::QueueEmpty)?;
+    handler.queue().modify_queue(|v| { /* ... */ });
+```
+
+After:
+
+```rust
+    // Ordinary music commands mutate as `Free`; a guild a game owns refuses
+    // here, which is the same refusal GP_BLOCKED_COMMANDS gives earlier and
+    // more kindly. This one cannot be forgotten.
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
+    let handler = call.lock().await;
+    let queue = handler.queue().current_queue();
+    verify(queue.len() > 1, CrackedError::QueueEmpty)?;
+    clear_from(&guard, &handler, 1);
+```
+
+Where a site does not have a natural helper yet, add one to `music/queue.rs`
+taking `&QueueGuard` and call it. Do not leave a bare `handler.queue()` mutation
+in a command file.
+
+- [ ] **Step 2: Build and test**
+
+Run: `cargo check -p crack-core --all-targets && cargo test -p crack-core --lib`
+Expected: PASS.
+
+- [ ] **Step 3: Lint and commit**
+
+```bash
+cargo fmt --all
+cargo clippy -p crack-core --all-targets
+git add crack-core/src/music/queue.rs crack-core/src/commands/music/{skip,shuffle,remove,clear}.rs
+git commit -m "$(cat <<'EOF'
+refactor(queue): route command queue mutation through guard-taking helpers
+
+Mutating helpers in music/queue.rs now take a &QueueGuard, and skip, shuffle,
+remove and clear acquire one instead of reaching for handler.queue() directly.
+
+A command can no longer mutate the queue without passing the ownership check, so
+forgetting a GP_BLOCKED_COMMANDS entry becomes a worse error message rather than
+a corrupted /gp round.
+
+Co-Authored-By: Claude & Lothrop (cycle.five@proton.me)
+EOF
+)"
+```
+
+---
+
+### Task 6: The two carve-outs — `/gp` itself and the event handler
+
+The sharp edge. A bug where `/gp` fails to take its own guard is **worse** than
+the bug being closed, because it is intermittent rather than deterministic.
+Review this task harder than Task 5.
+
+**Files:**
+- Modify: `crack-core/src/commands/music/gp.rs` (:2253, :2473, :3003, :3417)
+- Modify: `crack-core/src/handlers/track_end.rs` (:138)
+
+**Interfaces:**
+- Consumes: `Data::lock_queue`, `PlaybackOwner`, `QueueGuard` (Task 1); helpers
+  (Task 4).
+- Produces: nothing new.
+
+- [ ] **Step 1: `/gp` locks as the owner**
+
+All four `gp.rs` sites are the owner mutating its own queue, so they pass
+`PlaybackOwner::Game`. **No plumbing is needed** — `GpPlayback`
+(`gp.rs:2155-2160`) already carries `data: Arc<Data>`, `guild_id` and `call`.
+
+`gp_abort` (~:2253) becomes:
+
+```rust
+async fn gp_abort(pb: &GpPlayback, text_channel: GenericChannelId, reason: &str) {
+    if pb.data.gp_remove(pb.guild_id).is_none() {
+        return;
+    }
+    tracing::warn!("gp: {reason} in {}, game discarded", pb.guild_id);
+    // 🪤 ORDER MATTERS. `gp_remove` above released the lease, so this locks a
+    // guild that is now Free -- which is correct and is why `Free` is passed,
+    // not `Game`. Locking as `Game` here would refuse.
+    match pb.data.lock_queue(pb.guild_id, PlaybackOwner::Free).await {
+        Ok(guard) => stop_queue(&guard, &pb.call).await,
+        Err(e) => tracing::warn!("gp: could not lock the queue to abort in {}: {e}", pb.guild_id),
+    }
+```
+
+Apply the same reasoning at each of the other three: **lock as `Game` while the
+game still owns playback, as `Free` after it has been released.** State which in
+a comment at every site.
+
+- [ ] **Step 2: The event handler**
+
+`track_end.rs:138` pauses from an event handler with no command and no user.
+`TrackEndHandler` (`:36-42`) already carries `data`, `guild_id` and `call`, and
+`:130` already calls `self.data.gp_remove_if_parked(..)` three lines above.
+
+```rust
+        if autopause {
+            tracing::trace!("Pausing");
+            // Autopause is not a user action, but it mutates the queue, so it
+            // takes the guard like everything else. A game that owns playback
+            // refuses -- correctly: the game controls its own pausing, and the
+            // early return above has already handled the active-game case.
+            match self.data.lock_queue(self.guild_id, PlaybackOwner::Free).await {
+                Ok(guard) => pause_queue(&guard, &self.call).await,
+                Err(e) => tracing::trace!("autopause skipped in {}: {e}", self.guild_id),
+            }
+        }
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `cargo check -p crack-core --all-targets && cargo test -p crack-core --lib`
+Expected: PASS.
+
+- [ ] **Step 4: Confirm no bare mutation remains**
+
+Run:
+
+```bash
+grep -rn "\.enqueue(\|modify_queue\|\.dequeue(\|queue()\.\(skip\|stop\|pause\|resume\)()" \
+     --include='*.rs' crack-core/src | grep -v "music/queue.rs"
+```
+
+Expected: **no output**. Every hit outside `music/queue.rs` is a mutation that
+escaped the funnel. If one is genuinely legitimate, say why in the task report
+rather than silencing the grep.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cargo fmt --all
+cargo clippy -p crack-core --all-targets
+git add crack-core/src/commands/music/gp.rs crack-core/src/handlers/track_end.rs
+git commit -m "$(cat <<'EOF'
+refactor(gp): take the playback guard at the game's own mutation sites
+
+/gp mutates the queue at four sites and the track-end handler pauses at one.
+Both already carry Arc<Data>, guild_id and call, so no plumbing was needed.
+
+Each site states in a comment whether it locks as Game (the game still owns
+playback) or as Free (ownership already released) -- getting that backwards
+refuses rather than corrupts, but refuses silently, so it is written down.
+
+Co-Authored-By: Claude & Lothrop (cycle.five@proton.me)
+EOF
+)"
+```
+
+---
+
+### Task 7: Close the check-then-act in `queue_query_list_offset`
+
+**Files:**
+- Modify: `crack-core/src/music/queue.rs` (:463-511)
+- Test: inline in `crack-core/src/music/queue.rs`
+
+**Interfaces:**
+- Consumes: `QueueGuard` (Task 1), guard-taking helpers (Task 4).
+- Produces: nothing new.
+
+- [ ] **Step 1: Restructure**
+
+Currently the function reads `queue().len()`, drops the lock, validates `offset`
+against that number, then crosses `resolve_track_many` (8–15s cold) before
+acting. Resolve first, then take the guard, then read *and* act under it:
+
+```rust
+    // Resolution is slow (8-15s cold) and touches no shared state, so it happens
+    // BEFORE exclusion is taken -- a guard held across it would make a second
+    // /play wait it out. See the Global Constraints in the plan.
+    let tracks = ctx.data().ct_client.resolve_track_many(queries).await?;
+
+    // From here the queue length is read and acted on under one guard, so the
+    // number cannot go stale between the check and the insert.
+    let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
+    let mut handler = call.lock().await;
+    let queue_size = handler.queue().len();
+    if queue_size <= 1 {
+        drop(handler);
+        return queue_vec_query_type(&guard, ctx, call, queries, Mode::End).await;
+    }
+    verify(
+        offset > 0 && offset <= queue_size + 1,
+        CrackedError::NotInRange("index", offset as isize, 1, queue_size as isize),
+    )?;
+```
+
+⚠️ The early `queue_size <= 1` branch currently happens *before* resolution.
+Moving the length read after resolution means resolving even in that case. If
+that is unacceptable, keep a pre-resolution read as a fast path but **re-read and
+re-validate under the guard** — the pre-read must never be the number acted on.
+
+- [ ] **Step 2: Add the regression comment and test**
+
+```rust
+    #[test]
+    fn offset_validation_reads_under_the_same_guard_it_acts_under() {
+        // Documents the invariant this function got wrong: the queue length was
+        // read, the lock dropped, `resolve_track_many` awaited for 8-15s, and
+        // then the stale number acted on. Any refactor that reintroduces a read
+        // outside the guard reintroduces the race.
+        let src = include_str!("queue.rs");
+        let body = src
+            .split("pub async fn queue_query_list_offset")
+            .nth(1)
+            .expect("queue_query_list_offset must exist");
+        let body = &body[..body.find("\n}\n").expect("function end")];
+        let guard_at = body.find("lock_queue").expect("must take a QueueGuard");
+        let resolve_at = body.find("resolve_track_many").expect("must resolve");
+        assert!(
+            resolve_at < guard_at,
+            "resolution must happen BEFORE the guard is taken, never under it"
+        );
+    }
+```
+
+- [ ] **Step 3: Run to verify it passes**
+
+Run: `cargo test -p crack-core --lib music::queue`
+Expected: PASS.
+
+- [ ] **Step 4: Lint and commit**
+
+```bash
+cargo fmt --all
+cargo clippy -p crack-core --all-targets
+git add crack-core/src/music/queue.rs
+git commit -m "$(cat <<'EOF'
+fix(queue): validate the insert offset under the guard that acts on it
+
+queue_query_list_offset read queue().len(), dropped the lock, awaited
+resolve_track_many for 8-15s, then acted on the number it read before. The
+length is now read and acted on under one QueueGuard.
+
+Resolution deliberately stays outside the guard: it touches no shared state, and
+holding exclusion across it would make a second /play wait 8-15s.
+
+Co-Authored-By: Claude & Lothrop (cycle.five@proton.me)
+EOF
+)"
+```
+
+---
+
+### Task 8: Lock ordering, and write the rules down
+
+**Files:**
+- Modify: `crack-core/src/poise_ext.rs` (`JoinVCToken::acquire` ~:586)
+- Modify: `crack-core/src/music/lease.rs` (doc)
+- Test: inline in `crack-core/src/music/lease.rs`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[tokio::test]
+    async fn the_sanctioned_lock_order_completes() {
+        // Lease first, join token second. Two per-guild locks taken in opposite
+        // orders is a textbook deadlock; this asserts the sanctioned order is
+        // not itself blocking.
+        let d = data();
+        let guard = d.lock_queue(G, PlaybackOwner::Free).await.unwrap();
+        let token = crate::poise_ext::JoinVCToken::acquire(&d, G);
+        drop(token);
+        drop(guard);
+    }
+```
+
+- [ ] **Step 2: Add the ordering assert**
+
+In `poise_ext.rs`, in `JoinVCToken::acquire`:
+
+```rust
+    pub fn acquire(data: &Data, guild_id: serenity::GuildId) -> Self {
+        // 🪤 LOCK ORDER: playback lease first, join token second, NEVER the
+        // reverse. Two per-guild locks taken in opposite orders deadlock the
+        // shard for that guild. If you are taking a join token you must not
+        // subsequently take the playback lease.
+        debug_assert!(
+            !data.queue_locks.get(&guild_id).is_some_and(|l| l.try_lock().is_err())
+                || data.playback_owner(guild_id) != PlaybackOwner::Free,
+            "join token acquired while this task may be about to take the playback lease"
+        );
+```
+
+> If that predicate proves unworkable in practice — it is a heuristic, not a
+> proof — replace it with a plain comment plus the doc section, and say so in the
+> task report. Do **not** ship an assert that fires spuriously; a `debug_assert`
+> that cries wolf gets deleted, and the rule goes with it.
+
+- [ ] **Step 3: Document the rule where both locks are visible**
+
+Extend the `# Lock ordering` section of `music/lease.rs`'s module doc with the
+concrete rule, the deadlock it prevents, and a pointer to `join_vc_tokens`.
+
+- [ ] **Step 4: Run the whole suite**
+
+```bash
+cargo test --workspace
+cargo clippy --workspace --all-targets
+cargo fmt --all --check
+SQLX_OFFLINE=true cargo check -p crack-core
+```
+
+Expected: PASS. `SQLX_OFFLINE` is checked because CI's `Docker` job is skipped on
+pull requests and is the only place a bad offline build would otherwise surface.
+
+- [ ] **Step 5: Bump the version**
+
+This is a feature: minor bump, `0.8.0` → `0.9.0`, in **all nine** member
+`Cargo.toml` files. A partial bump compiles clean (#424b), so verify:
+
+```bash
+grep -H '^version = ' */Cargo.toml | sort
+grep -rn '"0\.8\.0"' --include='Cargo.toml' .   # expect no output
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt --all
+git add -A
+git commit -m "$(cat <<'EOF'
+docs(playback): write down the lease/join-token lock order, and bump to 0.9.0
+
+Two per-guild locks taken in opposite orders deadlock the guild's shard. The
+order is playback lease first, join token second, never the reverse -- now
+carried by a debug_assert and the lease module's docs rather than by memory.
+
+Co-Authored-By: Claude & Lothrop (cycle.five@proton.me)
+EOF
+)"
+```
+
+---
+
+## After the tasks
+
+Open the PR against `master` from `feat/playback-ownership-lease`. The body
+should explain the two concepts and why they are not merged, cite #434 and
+#333, and state plainly what is **not** covered: `leave`, `summon` and
+`summonchannel` never touch the queue, so the funnel closes the bug class for
+queue mutation (16 of 19 blocked commands) and leaves it intact for voice state
+(3 of 19).
+
+Then follow the repo cadence: CI green → review → merge → sync master → tag
+`-s v0.9.0` → push the tag. **Do not run `gh release create`** — cargo-dist's
+`Release` workflow creates the release from the tag, and running it by hand
+races the workflow and produces a release with no assets.
+
+⚠️ Before merging, re-check whether **#461** (splitting `gp.rs`, 5,651 lines,
+assigned to ChristianMorton) has started. This plan touches four sites in that
+file; a rebase across a split of that size is expensive, and it is cheaper to
+coordinate than to resolve.

--- a/docs/superpowers/specs/2026-09-10-playback-ownership-lease-design.md
+++ b/docs/superpowers/specs/2026-09-10-playback-ownership-lease-design.md
@@ -1,0 +1,283 @@
+# Playback ownership: a per-guild lease for queue mutation
+
+**Issue:** [#434](https://github.com/cycle-five/cracktunes/issues/434)
+**Also closes:** [#333](https://github.com/cycle-five/cracktunes/issues/333)
+**Date:** 2026-09-10
+**Scope decided with the issue author:** Phase A (the lease) and Phase C
+(report from the insertion result) land together, in one arc.
+
+## The question this answers
+
+**What owns playback in a guild right now, and what does that permit?**
+
+Today the only answer is `GP_BLOCKED_COMMANDS` (`gp.rs:149`) plus the
+`gp_is_active` check in `cmd_check_music` (`permissions.rs:18-24`). That is
+correct and properly per-guild, but it is one hardcoded name list serving one
+feature, and it is the only thing standing between a stray `/play` and a
+corrupted `/gp` round.
+
+## The two defects
+
+### #333 — concurrent `/play` reports the wrong queue
+
+`enqueue_resolved_tracks_back` (`music/queue.rs:112-134`) returns
+`handler.queue().current_queue()` **after** enqueueing:
+
+```rust
+let mut handler = call.lock().await;
+for resolved in &tracks { /* ... handler.enqueue(track).await ... */ }
+Ok(handler.queue().current_queue())   // :133 -- the whole queue, not ours
+```
+
+Two `/play` calls in flight both read the post-both state, so both replies list
+both sets of songs. That is the reported "one of the songs got queued twice".
+
+### `queue_query_list_offset` — check-then-act across a slow await
+
+`music/queue.rs:463-511`:
+
+```rust
+let queue_size = { call.lock().await.queue().len() };        // :473-476  read
+verify(offset > 0 && offset <= queue_size + 1, ..)?;         // :482-485  validate
+let tracks = ctx.data().ct_client.resolve_track_many(..).await?;  // :488  8-15s cold
+let mut handler = call.lock().await;                          // :501     act
+```
+
+The lock is dropped between reading `queue_size` and acting on it, across a
+boundary that takes eight to fifteen seconds cold. Not reported by anyone; real
+regardless.
+
+### The `/gp` guard is a "did we remember?" bug class
+
+`GP_BLOCKED_COMMANDS` grows with every new queue-mutating command. Miss one and
+it silently mutates the queue mid-round.
+
+**It has grown from eleven entries to nineteen in the four days since #434 was
+filed** — `voteskip`, `leave`, `seek`, `repeat`, `pause`, `summon`,
+`summonchannel` were added after. The issue's thesis demonstrating itself is the
+best argument for this work.
+
+## Architecture
+
+Two concepts, deliberately not merged, because their lifetimes differ by three
+orders of magnitude.
+
+### Ownership — long-lived, declarative, fails fast
+
+Who owns playback in this guild. Claimed by `/gp start`, released at game end.
+Checked cheaply.
+
+```rust
+pub enum PlaybackOwner { Free, Game }
+
+fn claim_playback(&self, guild_id: GuildId, owner: PlaybackOwner) -> CrackedResult<()>;
+fn release_playback(&self, guild_id: GuildId);
+```
+
+**Claim and release live inside the methods that already move `gp_games`.**
+This is the design's load-bearing decision. An explicit lease is a second
+source of truth, and a lease that outlives its game wedges `/play` forever with
+no game left to end. Co-locating the two writes makes divergence structurally
+impossible rather than merely unlikely.
+
+There are exactly five such sites:
+
+| site | role |
+|---|---|
+| `Data::gp_start` — `gp.rs:1003` | claim (`Entry::Vacant` insert) |
+| `Data::gp_restore` — `gp.rs:1611` | claim (the resume path #431 asked for) |
+| `Data::gp_remove` — `gp.rs:1596` | release |
+| `Data::gp_remove_if_parked` — `gp.rs:1582` | release |
+| `gp_persist.rs:619` | release — **a raw `gp_games.remove()` that bypasses the methods** |
+
+The fifth is a defect in its own right: the rejoin-failure path in
+`gp_resume_guild` removes from the map directly instead of going through
+`Data::gp_remove`. Route it through a method as part of this work, so there is
+exactly one way to end a game.
+
+`gp_is_active` stays as it is — `gp_games.contains_key(guild_id)` — and becomes
+the thing `claim_playback` is kept consistent *with*, not a competitor to it.
+
+### Exclusion — short-lived, operational
+
+A per-guild mutex serialising queue mutation, held for milliseconds.
+
+```rust
+async fn lock_queue(&self, guild_id: GuildId, as_: PlaybackOwner)
+    -> CrackedResult<QueueGuard>;
+```
+
+- A game owns playback and you are not the game → `Err(GameInProgress)`,
+  **immediately**. Nobody waits out a half-hour game.
+- Otherwise → await the mutex. Short, because resolution happens outside it.
+
+**`QueueGuard` is an RAII guard, not a capability token.** `JoinVCToken`
+(`poise_ext.rs:584-595`) is worth contrasting explicitly, because #434 describes
+`QueueGuard` as "in the shape of `JoinVCToken`" and the mechanism differs:
+
+| | `JoinVCToken` | `QueueGuard` |
+|---|---|---|
+| `acquire` | not `async`, takes no lock | `async`, holds the lock on return |
+| who locks | the consumer (`join_vc`, `poise_ext.rs:613`) | the constructor |
+| what it proves | you went through the right door | you hold exclusion *now* |
+
+Same intent — an unforgeable proof carried in the type system — different
+mechanism. Document the difference where `QueueGuard` is defined; a reader who
+assumes they are identical will write a bug.
+
+### The funnel — why the token has teeth
+
+If queue mutation *requires* a `&QueueGuard`, a command cannot mutate the queue
+without passing the ownership check. `GP_BLOCKED_COMMANDS` survives only as a UX
+nicety: failing early with a good message rather than deep in the call stack.
+Forgetting to list a command stops being a corrupted round and becomes a worse
+error message.
+
+Every mutation moves behind a helper in `music/queue.rs` taking `&QueueGuard`.
+There are **19 mutation sites** across 9 files. (Coincidentally also 19 — and
+unrelated to — the `GP_BLOCKED_COMMANDS` entries above. The two lists overlap
+only partly: `queue.rs` and `track_end.rs` mutate the queue without being
+commands at all.)
+
+| file | sites | disposition |
+|---|---|---|
+| `music/queue.rs` | 7 (`:40, :126, :187, :218, :294, :510, :511`) | become the helpers; take `&QueueGuard` |
+| `commands/music/gp.rs` | 4 (`:2253, :2473, :3003, :3417`) | the owner; acquire `as_ Game` |
+| `commands/music/skip.rs` | 3 (`:39, :118, :119`) | call helpers |
+| `commands/music/shuffle.rs` | 2 (`:42, :71`) | call helpers |
+| `commands/music/remove.rs` | 1 (`:72`) | call helper |
+| `commands/music/clear.rs` | 1 (`:42`) | call helper |
+| `handlers/track_end.rs` | 1 (`:138`) | event handler; see below |
+
+**No plumbing is required to reach `Data` at any of these.** Verified:
+
+- `TrackEndHandler` (`track_end.rs:36-42`) and `ModifyQueueHandler` (`:46-52`)
+  each already carry `guild_id`, `data: Arc<Data>`, `cache`, `http`, `call`.
+  `track_end.rs:130` already calls `self.data.gp_remove_if_parked(..)` three
+  lines above the `pause()` that needs guarding.
+- `GpPlayback` (`gp.rs:2155-2160`) carries `data: Arc<Data>`, `http`, `call`,
+  `guild_id`. `gp_abort` already calls `pb.data.gp_remove(..)` immediately before
+  its `queue().stop()`.
+- `gp.rs:3417` has `data` and `guild_id` in scope one line earlier
+  (`data.gp_park_for_end(..)`).
+- The seven `music/queue.rs` sites need no `Data`: they *take* `&QueueGuard`, and
+  the caller — which always has `ctx`/`data` — acquires it.
+
+### What the funnel does NOT cover
+
+The claim "forgetting to list a command becomes a worse error message" holds
+only for commands that reach the queue. **Three of the nineteen never do:**
+
+| command | what it actually touches |
+|---|---|
+| `leave` | `manager.remove(guild_id)` — songbird voice state (`leave.rs:38`) |
+| `summon` | joins a voice channel |
+| `summonchannel` | joins a voice channel |
+
+A `QueueGuard` cannot gate these; they change voice membership, which is
+`join_vc_tokens`' territory. They stay guarded by `GP_BLOCKED_COMMANDS` and the
+`cmd_check_music` check, and a future command of that shape can still be
+forgotten.
+
+So the honest claim is: **the funnel converts the bug class for queue mutation
+(16 of 19), and leaves it intact for voice-state changes (3 of 19).** Closing the
+remainder is what subsuming `JoinVCToken` into the lease would buy — listed under
+non-goals, and this is the argument for eventually doing it.
+
+### Phase C — report from the insertion result
+
+Have the enqueue path return the positions it inserted at, and build the reply
+from that rather than re-reading `current_queue()` afterwards. A reply describing
+what *this* call did cannot be corrupted by a concurrent one.
+
+This is not merely bundled: it **shrinks the critical section**. If the reply is
+derived from the insertion result, exclusion need only cover the enqueue. If the
+reply re-reads shared state, exclusion must span the enqueue *and* the read.
+
+It does not fix `queue_query_list_offset`'s check-then-act; that needs the lease.
+
+## Lock ordering
+
+The lease sits **alongside** `join_vc_tokens` (`lib.rs:378`), not replacing it,
+so this work does not touch functioning join code. That means two per-guild
+locks, which is a textbook deadlock if ever taken in opposite orders.
+
+**Order: playback lease first, join token second, never the reverse.** Carry a
+`debug_assert`, not only a comment.
+
+Subsuming `JoinVCToken` into the lease — one lock per guild, deadlock impossible
+by construction — is a deliberate follow-up once the lease has proven itself. Not
+part of this.
+
+## What stays outside the lease
+
+**Resolution.** `resolve_track_many` shells out to `yt-dlp` and takes eight to
+fifteen seconds cold. It touches no shared state, so it must not be inside the
+critical section — a lease held across it would make a second `/play` wait
+fifteen seconds, which is barely an improvement on the bug. **Resolve first, then
+take the guard for the enqueue and the reply.**
+
+**Persistence.** The lease is process-local and is not written to Postgres. A
+resume (`gp_restore`) reclaims it before restoring anything into the guild, which
+is the arbitration #431 needed: a resumed game and a restored queue cannot both
+take the voice channel, and `claim_playback` is where that is decided rather than
+in ad-hoc ordering.
+
+## Error handling
+
+- `lock_queue` refusing on ownership returns the existing
+  `CrackedError::GameInProgress`, so the message users see is unchanged.
+- ⚠️ That error currently reaches users only from a command *body*. Raised from a
+  poise **check** it becomes `FrameworkError::CommandCheckFailed`, which
+  `on_error` (`config.rs:32`) has no arm for — see **#467**. Any lease refusal
+  raised from a check inherits that silence. #467 should land first or alongside;
+  this design does not fix it.
+- `release_playback` is infallible and idempotent. Releasing a guild that owns
+  nothing is a no-op, not an error: the event-driven paths can each arrive first.
+
+## Testing
+
+- **Ownership/lease unit tests** on `Data` with no Discord: claim, double-claim
+  refused, release, release-when-free, and `lock_queue` refusing a non-owner
+  while a game owns playback.
+- **The invariant test that matters:** for each of the five game-lifecycle
+  methods, assert the lease and `gp_games` agree afterwards. That is the
+  regression guard for the drift this design is built to prevent.
+- **Phase C:** a test that two interleaved enqueues each report only their own
+  insertions — the #333 regression guard, expressible without a live voice
+  connection.
+- **Lock ordering:** a `debug_assert` plus a test that acquires in the sanctioned
+  order and completes.
+- No test may reach live YouTube. See `docs/testing.md` and ct#471.
+
+## Non-goals
+
+- Subsuming `JoinVCToken` into the lease.
+- Removing `GP_BLOCKED_COMMANDS`. It stays as the early, friendly refusal.
+- Persisting the lease.
+- Any owner other than `Free` and `Game`. `PlaybackOwner` is an enum so a third
+  can be added; adding one now would be speculative.
+
+## Risks
+
+**`gp.rs` collision.** This touches four sites in `gp.rs`, which is 5,651 lines
+and has an open refactor issue — **#461**, assigned to ChristianMorton. If #461
+starts moving, sequence around it; a rebase across a file split of that size is
+expensive.
+
+**The owner's own mutations are the sharp edge.** A bug where `/gp` fails to take
+its guard correctly is worse than the bug being closed, because it would be
+intermittent rather than deterministic. The four `gp.rs` sites deserve more review
+attention than the twelve command sites.
+
+**Scope.** 19 mutation sites, 5 ownership sites, a new guard type, and an
+event-handler carve-out. Mechanical, but not small.
+
+**The count moves under you.** `GP_BLOCKED_COMMANDS` went 11 → 19 in four days.
+Re-derive both lists at implementation time rather than trusting the tables here:
+
+```
+grep -rn "\.enqueue(\|modify_queue\|\.dequeue(\|queue()\.\(skip\|stop\|pause\|resume\)()" \
+     --include='*.rs' crack-core/src
+grep -rn "gp_games\.\(insert\|remove\|entry\)" --include='*.rs' crack-core/src
+```

--- a/docs/superpowers/specs/2026-09-10-playback-ownership-lease-design.md
+++ b/docs/superpowers/specs/2026-09-10-playback-ownership-lease-design.md
@@ -166,23 +166,28 @@ commands at all.)
 ### What the funnel does NOT cover
 
 The claim "forgetting to list a command becomes a worse error message" holds
-only for commands that reach the queue. **Three of the nineteen never do:**
+only for commands that reach the queue. **Five of the twenty never do:**
 
 | command | what it actually touches |
 |---|---|
 | `leave` | `manager.remove(guild_id)` — songbird voice state (`leave.rs:38`) |
 | `summon` | joins a voice channel |
 | `summonchannel` | joins a voice channel |
+| `seek` | seeks the current `TrackHandle` (`seek.rs`) — track state, not queue structure |
+| `repeat` | toggles looping on the current `TrackHandle` (`repeat.rs:36` reads only `handler.queue().current()`) — track state, not queue structure |
 
-A `QueueGuard` cannot gate these; they change voice membership, which is
-`join_vc_tokens`' territory. They stay guarded by `GP_BLOCKED_COMMANDS` and the
-`cmd_check_music` check, and a future command of that shape can still be
-forgotten.
+A `QueueGuard` cannot gate `leave`, `summon` or `summonchannel`; they change
+voice membership, which is `join_vc_tokens`' territory. `seek` and `repeat`
+mutate a single track in place rather than queue structure, so a guard would
+not add anything a `TrackHandle` doesn't already own. All five stay guarded by
+`GP_BLOCKED_COMMANDS` and the `cmd_check_music` check, and a future command of
+either shape can still be forgotten.
 
 So the honest claim is: **the funnel converts the bug class for queue mutation
-(16 of 19), and leaves it intact for voice-state changes (3 of 19).** Closing the
-remainder is what subsuming `JoinVCToken` into the lease would buy — listed under
-non-goals, and this is the argument for eventually doing it.
+(15 of 20), and leaves it intact for voice-state and track-state changes (5 of
+20).** Closing the voice-state remainder is what subsuming `JoinVCToken` into
+the lease would buy — listed under non-goals, and this is the argument for
+eventually doing it.
 
 ### Phase C — report from the insertion result
 


### PR DESCRIPTION
Closes #434 (Phases A and C), #333, #467.

Spec: `docs/superpowers/specs/2026-09-10-playback-ownership-lease-design.md`
Plan: `docs/superpowers/plans/2026-09-10-playback-ownership-lease.md`

## Design

Two mechanisms, deliberately separate, both per-guild:

**Ownership** (`PlaybackOwner`) is long-lived and fail-fast. `/gp` claims it for the duration of a game; anything else that would mutate the queue is refused with a real error rather than queued behind a lock. It lives in a `DashMap` beside `join_vc_tokens`.

**Exclusion** (`QueueGuard`) is a short per-guild `tokio::Mutex` handing out an RAII token, shaped after the existing `JoinVCToken`. Every queue-mutating helper in `music/queue.rs` now takes `&QueueGuard`, so the type system carries the proof that the caller holds exclusion — 19 mutation sites across 9 files funnel through those helpers.

Ownership is checked **before** the mutex, so a refused command never waits on a lock it was never going to be allowed to use.

**Phase C** (closes #333): `enqueue` now returns what it actually inserted (`Inserted { handles }`) instead of the caller re-reading the queue afterwards. The read-after-write on shared state was the root cause of the double-`/play` race.

**#467** fell out of this work: `FrameworkError::CommandCheckFailed` had no arm in `on_error` (`config.rs`), so every one of the `GP_BLOCKED_COMMANDS` refusals showed the user Discord's "The application did not respond" and nothing else. `FrameworkError::Command` *was* handled — that asymmetry is why errors from inside a command body reached users and a check's never did.

## The constraint that shaped everything

**Resolution must stay outside the lease.** `resolve_track_many` is 8–15s cold and can run 13+ batches on a playlist. Two review rounds caught the guard being held across it:

- `queue_query_list_offset` acquired the guard and then awaited resolution — restructured to resolve first, then acquire internally.
- `build_track` leaves `metadata: None`, so `Call::enqueue` → `aux_metadata()` spawned **yt-dlp per track** under the guard. Fixed with `enqueue_with_preload` + `preload_from_metadata` (duration − 5s, matched byte-for-byte to songbird's own `get_preload_time`).

⚠️ **That second fix is the riskiest change here for reviewers to weigh.** It changes when audio begins buffering for every track on every path. Tests can't hear a gap at a track transition; it was exercised by ear on the beta tenant instead.

## Also fixed in passing

- `/resume` was unguarded by **both** mechanisms. It is now on the blocklist — see the open question below.
- `/remove` had been on `GP_BLOCKED_COMMANDS` since #422 but had no `check`, so the entry was inert for four months. It now has one.
- `blocklist_matches_registry` asserts every blocklist entry names a real registered command, so a future inert entry fails the build.

## Open question for review

**`/resume` during a game.** The original author left a named test asserting `/resume` stays usable mid-game — a deliberate escape hatch. I blocked it, because it mutates the queue and the paused-during-game state is close to unreachable. That is my judgment against theirs, and they wrote a test specifically so it would not change by accident. **If a paused game is now unexitable except via `/gp end`, revert this part** — it is the cheapest thing on the branch to undo.

## On #461

This adds **272 net lines to `gp.rs`**, taking it from 5,651 to 5,923. @ChristianMorton filed #461 against that file at 4.5k lines, so this makes his case rather than answering it.

The claim/release calls are co-located with the five `gp_games` lifecycle sites on purpose — the spec argues ownership transitions have to sit next to the state changes they guard, or they drift. But they are a small, well-bounded surface (four call sites plus the blocklist), and they should move cleanly whenever the scoring/reveal/results split in #461 happens. Not blocking it.

## Verification

Full gate green on `97b0366`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets`, `SQLX_OFFLINE=true cargo check -p crack-core`, `cargo test --workspace`.

**One pre-existing failure, unrelated:** `crack-testing::tests::test_enqueue_query` fails on master too — the cause is a YouTube video id deleted upstream, already fixed in open PR #471. Verified by running it on unmodified master.

Built as a container on the staging host and run live on the **TuneTitan** beta tenant (13 guilds, real Discord traffic, with Postgres — the only tenant that can exercise the `gp_restore` path, since production runs without a database). No restarts, no hangs, reported good.

Version bumped 0.8.0 → 0.9.0 across all nine workspace members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8PrF3gizKqXCStjCuWL3d