### PR TITLE
v0.9.1: make it safe to give production a database

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,12 +40,31 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - 
+      -
         name: Build & Push Docker Image
         uses: docker/build-push-action@v5
         with:
           context: .
+          # 🪤 EXPLICIT. The Dockerfile's last stage is `migrate`, and an
+          # unspecified target builds the last stage -- which would publish the
+          # migration runner as the bot.
+          target: runner
           # push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      -
+        name: Extract Git Metadata (migrate image)
+        id: meta-migrate
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-migrate
+      -
+        name: Build & Push Migration Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: migrate
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta-migrate.outputs.tags }}
+          labels: ${{ steps.meta-migrate.outputs.labels }}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -64,6 +64,10 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          # 🪤 EXPLICIT. The Dockerfile's last stage is `migrate`, and an
+          # unspecified target builds the last stage -- which would publish the
+          # migration runner as the bot.
+          target: runner
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,14 +1012,14 @@ dependencies = [
 
 [[package]]
 name = "crack-bf"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "crack-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "crack-gpt"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-openai",
  "const_format",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "crack-osint"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "crack-types",
  "ipinfo",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "crack-sleevenote"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "crack-testing"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "crack-types"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "humantime",
  "poise",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "crack-voting"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "dbl-rs",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "cracktunes"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "config-file",
  "crack-core",

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,14 @@ RUN apk add --no-cache \
   cmake \
   git
 
+# 🔑 BEFORE `COPY . .`, deliberately. sqlx-cli takes minutes to build and never
+# changes with our source, so keeping it above the copy means the layer caches
+# across every source change and only rebuilds when this base image moves.
+#
+# Pinned to ~0.8 to match the sqlx 0.8.2 that writes the _sqlx_migrations
+# ledger; a mismatched CLI can disagree with the library about that table.
+RUN cargo install sqlx-cli --version '~0.8' --no-default-features --features rustls,postgres
+
 # Default directory
 WORKDIR /app
 
@@ -59,3 +67,15 @@ COPY --from=builder /app/target/dist/cracktunes /app/app
 COPY --from=builder /app/scripts/start.sh /app/start.sh
 
 CMD ["/app/start.sh"]
+
+# STAGE3: the migration runner, used as a one-shot before the bot starts.
+#
+# 🪤 This stage is LAST, which makes it the default build target. The bot image
+# must therefore be built with an explicit `--target runner`; the Docker
+# workflow does this. Building with no target gets you this image, which is
+# emphatically not the bot.
+FROM alpine:3.22 AS migrate
+COPY --from=builder /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
+COPY --from=builder /app/migrations /migrations
+# Needs DATABASE_URL in the environment and nothing else.
+ENTRYPOINT ["sqlx", "migrate", "run", "--source", "/migrations"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,4 +78,10 @@ FROM alpine:3.22 AS migrate
 COPY --from=builder /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
 COPY --from=builder /app/migrations /migrations
 # Needs DATABASE_URL in the environment and nothing else.
+#
+# No ca-certificates here. Harmless today -- compose points this at a
+# Postgres on the compose network with no sslmode, so rustls never needs a
+# root store -- but the first `sslmode=require` or managed Postgres target
+# will fail a TLS handshake from a one-shot container with no other context
+# to explain why.
 ENTRYPOINT ["sqlx", "migrate", "run", "--source", "/migrations"]

--- a/crack-bf/Cargo.toml
+++ b/crack-bf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-bf"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-cli/Cargo.toml
+++ b/crack-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "cracktunes"
-version = "0.9.0"
+version = "0.9.1"
 description = "Cracktunes is a hassle-free, highly performant, host-it-yourself, cracking smoking, discord-music-bot."
 publish = true
 edition = "2021"

--- a/crack-cli/src/main.rs
+++ b/crack-cli/src/main.rs
@@ -67,7 +67,10 @@ async fn main_async(event_log_async: EventLogAsync) -> Result<(), Error> {
 
     // init_metrics();
     let config = load_bot_config().expect("Error: Failed to load bot config");
-    tracing::warn!("Using config: {:?}", config);
+    // 🔑 `{}` not `{:?}`. BotConfig's hand-written Display redacts
+    // database_url through redact_url; the derived Debug does not, and this
+    // line is what put the Postgres password into `docker logs` (#473).
+    tracing::warn!("Using config: {}", config);
 
     let mut client = config::poise_framework(config, event_log_async).await?;
 
@@ -361,5 +364,29 @@ mod test {
     fn test_load_bot_config() {
         let result = load_bot_config();
         assert!(result.is_ok() || result.is_err());
+    }
+}
+
+#[cfg(test)]
+mod log_site_tests {
+    /// #473: the startup config log must use `Display` (`{}`), which redacts,
+    /// not the derived `Debug` (`{:?}`), which does not. A unit test cannot
+    /// observe a `tracing` macro's format string, so this reads the source.
+    #[test]
+    fn the_config_is_logged_with_display_not_debug() {
+        let src = include_str!("main.rs");
+        let line = src
+            .lines()
+            .find(|l| l.contains("Using config:"))
+            .expect("the startup config log line vanished; update this test");
+
+        assert!(
+            !line.contains("{:?}"),
+            "config is logged with derived Debug, which leaks the password (#473): {line}"
+        );
+        assert!(
+            line.contains("{}"),
+            "config log line no longer uses Display: {line}"
+        );
     }
 }

--- a/crack-core/Cargo.toml
+++ b/crack-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-core"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 edition = "2021"
 description = "Core module for the cracking smoking, discord-music-bot Cracktunes."

--- a/crack-core/src/config.rs
+++ b/crack-core/src/config.rs
@@ -413,8 +413,16 @@ pub async fn poise_framework(
 
         println!("Saving guilds...");
         if let Some(p) = pool {
+            let mut skipped = 0usize;
             for (k, v) in guilds {
-                //tracing::warn!("Saving Guild: {}", k);
+                // 🔑 Only write back settings that came FROM the database. A
+                // guild whose load failed is holding defaults, and writing
+                // those over its stored row destroys it -- permanently, and
+                // with no backup behind it. See guild::settings::Provenance.
+                if !v.is_persistable() {
+                    skipped += 1;
+                    continue;
+                }
                 match v.save(&p).await {
                     Ok(_) => {
                         saved_guilds.push(k);
@@ -423,6 +431,14 @@ pub async fn poise_framework(
                         tracing::error!("Error saving guild settings: {}", e);
                     },
                 }
+            }
+            if skipped > 0 {
+                // Loud on purpose: a large skip count means many guilds failed
+                // to load at boot, which is worth knowing about.
+                tracing::warn!(
+                    "Skipped {} guild(s) at shutdown whose settings never loaded from the database",
+                    skipped
+                );
             }
             p.close().await;
         }

--- a/crack-core/src/guild/operations.rs
+++ b/crack-core/src/guild/operations.rs
@@ -116,6 +116,10 @@ impl GuildSettingsOperations for Data {
     }
 
     /// Save the guild settings to the database.
+    ///
+    /// Writes back without checking `Provenance`; currently unused. Anything
+    /// wiring this up must check `is_persistable()` first or it will overwrite
+    /// stored settings with fallback defaults.
     async fn save_guild_settings(&self, guild_id: GuildId) -> Result<(), CrackedError> {
         let opt_settings = self.guild_settings_map.read().await;
         let settings = opt_settings.get(&guild_id);

--- a/crack-core/src/guild/settings.rs
+++ b/crack-core/src/guild/settings.rs
@@ -1096,6 +1096,10 @@ impl GuildSettings {
 }
 
 /// Save the guild settings to the database.
+///
+/// Writes back without checking `Provenance`; currently unused. Anything
+/// wiring this up must check `is_persistable()` first or it will overwrite
+/// stored settings with fallback defaults.
 pub async fn save_guild_settings(
     guild_settings_map: &HashMap<GuildId, GuildSettings>,
     pool: &PgPool,

--- a/crack-core/src/guild/settings.rs
+++ b/crack-core/src/guild/settings.rs
@@ -303,9 +303,34 @@ impl UserPermission {
 
 use super::permissions::GenericPermissionSettings;
 
+/// Where a guild's in-memory settings came from, and therefore whether writing
+/// them back to Postgres is safe.
+///
+/// 🔑 `Fallback` is the `Default` **deliberately**. The shutdown handler writes
+/// every in-memory guild back to the database, and `on_guild_create` falls back
+/// to `GuildSettings::new()` defaults when the load fails. Without this tag a
+/// transient read failure at boot becomes a permanent write at shutdown --
+/// defaults silently replacing a guild's stored settings, with no backup to
+/// restore from. Defaulting to `Fallback` means anything we did not explicitly
+/// load from Postgres is never written back.
+///
+/// 🪤 **Mutations must not reset this.** `set_volume` and friends use
+/// `and_modify` / `..self`, which leave the tag alone -- the behaviour we want.
+/// A future mutation site that *replaces* the map entry with a fresh
+/// `GuildSettings::new()` would silently re-arm the bug.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Provenance {
+    /// Defaults, built in memory. NOT safe to write back.
+    #[default]
+    Fallback,
+    /// Round-tripped through Postgres, so the row exists and a write updates
+    /// a row we actually read. Safe to write back.
+    Database,
+}
+
 // TODO
 //#[derive(Debug, Clone, Serialize, PartialEq)]
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct GuildSettings {
     pub guild_id: GuildId,
     pub guild_name: FixedString,
@@ -340,6 +365,39 @@ pub struct GuildSettings {
     pub log_settings: Option<LogSettings>,
     #[serde(default = "additional_prefixes_default")]
     pub additional_prefixes: Vec<String>,
+    /// Not a column and not on the wire -- see [`Provenance`].
+    #[serde(skip)]
+    pub provenance: Provenance,
+}
+
+/// 🔑 Hand-written to exclude `provenance`, which is bookkeeping about where a
+/// value came from rather than part of a guild's settings. Two guilds with
+/// identical settings are equal regardless of how they were loaded, and the
+/// existing equality tests should not care.
+impl PartialEq for GuildSettings {
+    fn eq(&self, other: &Self) -> bool {
+        self.guild_id == other.guild_id
+            && self.guild_name == other.guild_name
+            && self.prefix == other.prefix
+            && self.premium == other.premium
+            && self.command_settings == other.command_settings
+            && self.autopause == other.autopause
+            && self.autoplay == other.autoplay
+            && self.reply_with_embed == other.reply_with_embed
+            && self.allow_all_domains == other.allow_all_domains
+            && self.allowed_domains == other.allowed_domains
+            && self.banned_domains == other.banned_domains
+            && self.authorized_users == other.authorized_users
+            && self.authorized_groups == other.authorized_groups
+            && self.ignored_channels == other.ignored_channels
+            && self.old_volume == other.old_volume
+            && self.volume == other.volume
+            && self.self_deafen == other.self_deafen
+            && self.timeout == other.timeout
+            && self.welcome_settings == other.welcome_settings
+            && self.log_settings == other.log_settings
+            && self.additional_prefixes == other.additional_prefixes
+    }
 }
 
 /// Default value function for serialization that is false.
@@ -470,6 +528,7 @@ impl GuildSettings {
             welcome_settings: None,
             log_settings: None,
             additional_prefixes: Vec::new(),
+            provenance: Provenance::Fallback,
         }
     }
 
@@ -660,6 +719,19 @@ impl GuildSettings {
             volume,
             ..self
         }
+    }
+
+    /// Record where these settings came from. See [`Provenance`].
+    pub fn with_provenance(self, provenance: Provenance) -> Self {
+        Self { provenance, ..self }
+    }
+
+    /// Whether the shutdown handler may write these settings back to Postgres.
+    ///
+    /// Only settings that round-tripped through the database may be written:
+    /// writing a fallback default over a stored row destroys it.
+    pub fn is_persistable(&self) -> bool {
+        self.provenance == Provenance::Database
     }
 
     /// Set the volume level with mutating.
@@ -1064,6 +1136,7 @@ pub type GuildSettingsMapParam =
 
 #[cfg(test)]
 mod test {
+    use crate::guild::settings::{GuildSettings, Provenance};
     use serenity::all::GuildId;
 
     #[test]
@@ -1125,5 +1198,58 @@ mod test {
         assert!(!premium_default());
         assert!(!default_false());
         assert!(default_true());
+    }
+
+    #[test]
+    fn a_fresh_settings_value_is_fallback() {
+        // The safe direction: anything not explicitly loaded from Postgres
+        // must never be written back over a stored row.
+        let settings = GuildSettings::new(GuildId::new(123), None, None);
+        assert_eq!(settings.provenance, Provenance::Fallback);
+        assert!(!settings.is_persistable());
+    }
+
+    #[test]
+    fn the_default_provenance_is_the_safe_one() {
+        assert_eq!(Provenance::default(), Provenance::Fallback);
+    }
+
+    #[test]
+    fn with_provenance_marks_it_persistable() {
+        let settings =
+            GuildSettings::new(GuildId::new(123), None, None).with_provenance(Provenance::Database);
+        assert_eq!(settings.provenance, Provenance::Database);
+        assert!(settings.is_persistable());
+    }
+
+    #[test]
+    fn provenance_does_not_affect_equality() {
+        // GuildSettings derives PartialEq and is compared in existing tests.
+        // Provenance is bookkeeping, not part of a guild's settings.
+        let fallback = GuildSettings::new(GuildId::new(123), None, None);
+        let from_db = fallback.clone().with_provenance(Provenance::Database);
+        assert_eq!(fallback, from_db);
+    }
+
+    #[test]
+    fn provenance_is_not_serialized() {
+        // It is not a column and must not reach the wire.
+        let from_db =
+            GuildSettings::new(GuildId::new(123), None, None).with_provenance(Provenance::Database);
+        let json = serde_json::to_string(&from_db).expect("serialize");
+        assert!(
+            !json.contains("provenance"),
+            "provenance leaked into serialized output: {json}"
+        );
+    }
+
+    #[test]
+    fn a_builder_that_copies_self_preserves_provenance() {
+        // `with_volume` and friends use `..self`. A mutation must not silently
+        // downgrade a Database-loaded value back to Fallback.
+        let from_db = GuildSettings::new(GuildId::new(123), None, None)
+            .with_provenance(Provenance::Database)
+            .with_volume(0.8);
+        assert_eq!(from_db.provenance, Provenance::Database);
     }
 }

--- a/crack-core/src/handlers/serenity.rs
+++ b/crack-core/src/handlers/serenity.rs
@@ -3,7 +3,7 @@ use crate::{
     commands::music::gp::{handle_gp_component, GP_CUSTOM_ID_PREFIX},
     db::GuildEntity,
     errors::CrackedError,
-    guild::settings::{GuildSettings, DEFAULT_ACTIVITY},
+    guild::settings::{GuildSettings, Provenance, DEFAULT_ACTIVITY},
     handlers::voice_chat_stats::cam_status_loop,
     sources::spotify::{Spotify, SPOTIFY},
     BotConfig,
@@ -356,7 +356,13 @@ impl SerenityHandler {
             )
             .await
             {
-                Ok((_guild, settings)) => settings,
+                // 🔑 The ONLY place settings become persistable. get_or_create
+                // is an upsert returning the live row, so Ok means Postgres and
+                // memory agree the row exists -- including for a guild just
+                // joined. The Err and no-pool arms below deliberately keep the
+                // Fallback default, so a transient read failure cannot become a
+                // permanent write at shutdown.
+                Ok((_guild, settings)) => settings.with_provenance(Provenance::Database),
                 Err(err) => {
                     tracing::error!(
                         "Failed to load settings for guild {} from the database, \
@@ -804,4 +810,53 @@ pub async fn voice_state_diff_str(
         ));
     }
     Ok(result)
+}
+
+#[cfg(test)]
+mod provenance_wiring_tests {
+    /// `on_guild_create` is an async serenity event handler taking a live
+    /// `Context`; it cannot be called from a unit test. The property that
+    /// matters is which of its three arms marks settings persistable, so this
+    /// reads the source.
+    ///
+    /// If this test becomes annoying, the fix is to extract the arm selection
+    /// into a pure function and test that -- not to delete the test.
+    #[test]
+    fn only_the_database_arm_marks_settings_persistable() {
+        let src = include_str!("serenity.rs");
+
+        // Scan only the handler code above this test module. `include_str!`
+        // pulls in this test's own source too, and its filter predicate and
+        // assertion messages necessarily contain the string "with_provenance"
+        // -- left unscoped, the test would count itself and always fail.
+        let production_src = src
+            .split_once("#[cfg(test)]\nmod provenance_wiring_tests")
+            .map(|(before, _)| before)
+            .unwrap_or(src);
+
+        let marks: Vec<&str> = production_src
+            .lines()
+            .filter(|l| l.contains("with_provenance"))
+            .map(|l| l.trim())
+            .collect();
+
+        assert_eq!(
+            marks.len(),
+            1,
+            "expected exactly one with_provenance call in this file, found {}: {:#?}",
+            marks.len(),
+            marks
+        );
+        assert!(
+            marks[0].contains("Provenance::Database"),
+            "the only with_provenance call should mark Database: {}",
+            marks[0]
+        );
+        assert!(
+            marks[0].contains("Ok(("),
+            "with_provenance must be on the Ok arm of get_or_create, so a failed \
+             load keeps the Fallback default: {}",
+            marks[0]
+        );
+    }
 }

--- a/crack-core/src/lib.rs
+++ b/crack-core/src/lib.rs
@@ -859,3 +859,31 @@ msg_on_dc:     false
         assert!(new_data.guild_settings_map.read().await.is_empty());
     }
 }
+
+#[cfg(test)]
+mod redaction_tests {
+    use super::*;
+
+    /// The config is logged at startup. A password must not survive the trip
+    /// through `Display`. See #473.
+    #[test]
+    fn display_redacts_the_database_password() {
+        let config = BotConfig {
+            database_url: Some(
+                "postgres://cracktunes:sup3rs3cr3t@postgres:5432/cracktunes".to_string(),
+            ),
+            ..Default::default()
+        };
+
+        let rendered = format!("{}", config);
+
+        assert!(
+            !rendered.contains("sup3rs3cr3t"),
+            "Display leaked the password:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("<redacted>"),
+            "Display did not redact at all:\n{rendered}"
+        );
+    }
+}

--- a/crack-core/src/lib.rs
+++ b/crack-core/src/lib.rs
@@ -254,7 +254,7 @@ impl Display for BotConfig {
             self.guild_settings_map
         ));
         result.push_str(&format!(
-            "prefix: {}",
+            "prefix: {}\n",
             self.prefix
                 .as_ref()
                 .cloned()

--- a/crack-gpt/Cargo.toml
+++ b/crack-gpt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-gpt"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-osint/Cargo.toml
+++ b/crack-osint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-osint"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-sleevenote/Cargo.toml
+++ b/crack-sleevenote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-sleevenote"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-testing/Cargo.toml
+++ b/crack-testing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "crack-testing"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/crack-types/Cargo.toml
+++ b/crack-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-types"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-voting/Cargo.toml
+++ b/crack-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-voting"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/docs/superpowers/plans/2026-09-11-production-database.md
+++ b/docs/superpowers/plans/2026-09-11-production-database.md
@@ -1,0 +1,828 @@
+# Production Database Prerequisites Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `v0.9.1`, which makes it safe to give production a Postgres: stop logging the database password, and stop the shutdown handler overwriting settings that never loaded.
+
+**Architecture:** A `Provenance` tag on `GuildSettings` records whether the value came from Postgres or is a fallback default. Its `Default` is the *safe* value (`Fallback`), so anything not explicitly loaded is never written back. The shutdown loop filters on it. Separately, the config log switches from derived `Debug` to the existing redacting `Display`, and the Dockerfile gains a `migrate` target so migrations can be applied by a container instead of by hand.
+
+**Tech Stack:** Rust (9-member cargo workspace), serenity/poise, sqlx 0.8.2 + Postgres, Docker multi-stage build, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-09-11-production-database-design.md`
+
+## Global Constraints
+
+- Every commit MUST end with exactly this trailer and **no other** `Co-Authored-By` line: `Co-Authored-By: Claude & Lothrop (cycle.five@proton.me)`
+- `Provenance::Fallback` MUST be the `#[derive(Default)]` variant. The safe direction is "do not write back".
+- `Provenance` MUST NOT become a database column and MUST NOT appear in serialized output — it is `#[serde(skip)]`.
+- `GuildSettings`'s `PartialEq` MUST ignore `provenance`, so existing equality tests are unperturbed.
+- sqlx-cli is pinned `~0.8` to match the `sqlx = "0.8.2"` that writes `_sqlx_migrations`.
+- The Dockerfile's existing `runner` stage MUST remain what the bot image builds. Adding a later stage silently changes the default target — both build steps get an explicit `target:`.
+- Do NOT fix the 11 `database_pool.as_ref().unwrap()` calls or the `No database pool available` log level. Both are explicitly out of scope.
+- Run `cargo fmt --all` before every commit; `cargo clippy --workspace --all-targets` must be clean.
+
+---
+
+### Task 1: Stop logging the database password (#473)
+
+**Files:**
+- Modify: `crack-cli/src/main.rs:70`
+- Test: `crack-cli/src/main.rs` (new `#[cfg(test)] mod tests` at end of file)
+- Test: `crack-core/src/lib.rs` (add to the existing test module, or create one)
+
+**Interfaces:**
+- Consumes: `crack_core::BotConfig`'s existing `Display` impl (`crack-core/src/lib.rs:237`) and `crack_core::redact_url` (`:169`).
+- Produces: nothing later tasks depend on.
+
+**Background:** `BotConfig` has a hand-written `Display` that redacts `database_url` through `redact_url`. The startup log uses `{:?}` — the *derived* `Debug` — which prints the password verbatim. Observed live on TuneTitan 2026-09-10:
+
+```
+WARN cracktunes: Using config: BotConfig { ... database_url: Some("postgres://cracktunes:xYNH...@postgres:5432/cracktunes"), ... }
+```
+
+`redact_url` turns `postgres://user:pw@host:5432/db` into `postgres://user:<redacted>@host:5432/db`.
+
+- [ ] **Step 1: Write the failing test for `Display` redaction**
+
+Add to `crack-core/src/lib.rs`, at the end of the file:
+
+```rust
+#[cfg(test)]
+mod redaction_tests {
+    use super::*;
+
+    /// The config is logged at startup. A password must not survive the trip
+    /// through `Display`. See #473.
+    #[test]
+    fn display_redacts_the_database_password() {
+        let mut config = BotConfig::default();
+        config.database_url =
+            Some("postgres://cracktunes:sup3rs3cr3t@postgres:5432/cracktunes".to_string());
+
+        let rendered = format!("{}", config);
+
+        assert!(
+            !rendered.contains("sup3rs3cr3t"),
+            "Display leaked the password:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("<redacted>"),
+            "Display did not redact at all:\n{rendered}"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run it and confirm it PASSES**
+
+Run: `cargo test -p crack-core redaction_tests -- --nocapture`
+Expected: **PASS**. `Display` already redacts — this test pins behaviour that exists, so that the fix in Step 4 has something guarding it. If it FAILS, `Display` is broken too and that is a bigger bug: stop and report.
+
+- [ ] **Step 3: Write the failing test for the call site**
+
+The actual bug is the *formatter used at the log site*, not `Display`. Add to the end of `crack-cli/src/main.rs`:
+
+```rust
+#[cfg(test)]
+mod log_site_tests {
+    /// #473: the startup config log must use `Display` (`{}`), which redacts,
+    /// not the derived `Debug` (`{:?}`), which does not. A unit test cannot
+    /// observe a `tracing` macro's format string, so this reads the source.
+    #[test]
+    fn the_config_is_logged_with_display_not_debug() {
+        let src = include_str!("main.rs");
+        let line = src
+            .lines()
+            .find(|l| l.contains("Using config:"))
+            .expect("the startup config log line vanished; update this test");
+
+        assert!(
+            !line.contains("{:?}"),
+            "config is logged with derived Debug, which leaks the password (#473): {line}"
+        );
+        assert!(
+            line.contains("{}"),
+            "config log line no longer uses Display: {line}"
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Run it and confirm it FAILS**
+
+Run: `cargo test -p cracktunes log_site_tests`
+Expected: **FAIL** — `config is logged with derived Debug, which leaks the password (#473)`.
+
+- [ ] **Step 5: Apply the one-character fix**
+
+`crack-cli/src/main.rs:70`, change:
+
+```rust
+    tracing::warn!("Using config: {:?}", config);
+```
+
+to:
+
+```rust
+    // 🔑 `{}` not `{:?}`. BotConfig's hand-written Display redacts
+    // database_url through redact_url; the derived Debug does not, and this
+    // line is what put the Postgres password into `docker logs` (#473).
+    tracing::warn!("Using config: {}", config);
+```
+
+- [ ] **Step 6: Run both tests and confirm they PASS**
+
+Run: `cargo test -p cracktunes log_site_tests && cargo test -p crack-core redaction_tests`
+Expected: both PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt --all
+git add crack-cli/src/main.rs crack-core/src/lib.rs
+git commit -m "$(cat <<'EOF'
+fix(config): log the config with Display, not Debug, so the password is redacted
+
+BotConfig has a hand-written Display impl that runs database_url through
+redact_url. main.rs logged it with {:?} -- the derived Debug -- so the
+Postgres password went into docker logs verbatim on every boot.
+
+Production has no DATABASE_URL today and therefore no password to leak;
+this lands before it gets one. Guarded by a test that reads the log line
+and rejects {:?}, because a tracing macro's format string is not otherwise
+observable from a test.
+
+Closes #473.
+
+Co-Authored-By: Claude & Lothrop (cycle.five@proton.me)
+EOF
+)"
+```
+
+---
+
+### Task 2: The `Provenance` type
+
+**Files:**
+- Modify: `crack-core/src/guild/settings.rs` (add enum near the `GuildSettings` struct at `:309`; add field to the struct; add field to the struct literal in `GuildSettings::new` at `:451`; add `with_provenance`; hand-write `PartialEq`)
+- Test: `crack-core/src/guild/settings.rs` (existing `mod test` at `:1065`)
+
+**Interfaces:**
+- Produces, for Task 3:
+  - `pub enum Provenance { Fallback, Database }` — `Default`, `Debug`, `Clone`, `Copy`, `PartialEq`, `Eq`
+  - `GuildSettings.provenance: Provenance` — public field
+  - `pub fn GuildSettings::with_provenance(self, provenance: Provenance) -> Self` — consuming builder, matching the existing `with_volume` style
+  - `pub fn GuildSettings::is_persistable(&self) -> bool` — `provenance == Provenance::Database`
+
+**Background:** `GuildSettings` currently derives `Deserialize, Serialize, Debug, Clone, PartialEq`. It is the type `save()` serializes, so the new field must not reach the wire or the database.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the existing `mod test` in `crack-core/src/guild/settings.rs`:
+
+```rust
+    use crate::guild::settings::{GuildSettings, Provenance};
+
+    #[test]
+    fn a_fresh_settings_value_is_fallback() {
+        // The safe direction: anything not explicitly loaded from Postgres
+        // must never be written back over a stored row.
+        let settings = GuildSettings::new(GuildId::new(123), None, None);
+        assert_eq!(settings.provenance, Provenance::Fallback);
+        assert!(!settings.is_persistable());
+    }
+
+    #[test]
+    fn the_default_provenance_is_the_safe_one() {
+        assert_eq!(Provenance::default(), Provenance::Fallback);
+    }
+
+    #[test]
+    fn with_provenance_marks_it_persistable() {
+        let settings = GuildSettings::new(GuildId::new(123), None, None)
+            .with_provenance(Provenance::Database);
+        assert_eq!(settings.provenance, Provenance::Database);
+        assert!(settings.is_persistable());
+    }
+
+    #[test]
+    fn provenance_does_not_affect_equality() {
+        // GuildSettings derives PartialEq and is compared in existing tests.
+        // Provenance is bookkeeping, not part of a guild's settings.
+        let fallback = GuildSettings::new(GuildId::new(123), None, None);
+        let from_db = fallback.clone().with_provenance(Provenance::Database);
+        assert_eq!(fallback, from_db);
+    }
+
+    #[test]
+    fn provenance_is_not_serialized() {
+        // It is not a column and must not reach the wire.
+        let from_db = GuildSettings::new(GuildId::new(123), None, None)
+            .with_provenance(Provenance::Database);
+        let json = serde_json::to_string(&from_db).expect("serialize");
+        assert!(
+            !json.contains("provenance"),
+            "provenance leaked into serialized output: {json}"
+        );
+    }
+
+    #[test]
+    fn a_builder_that_copies_self_preserves_provenance() {
+        // `with_volume` and friends use `..self`. A mutation must not silently
+        // downgrade a Database-loaded value back to Fallback.
+        let from_db = GuildSettings::new(GuildId::new(123), None, None)
+            .with_provenance(Provenance::Database)
+            .with_volume(0.8);
+        assert_eq!(from_db.provenance, Provenance::Database);
+    }
+```
+
+- [ ] **Step 2: Run and confirm they FAIL**
+
+Run: `cargo test -p crack-core --lib guild::settings`
+Expected: FAIL to compile — `cannot find type Provenance in this scope`.
+
+- [ ] **Step 3: Add the enum**
+
+Insert immediately **above** `pub struct GuildSettings` (currently `crack-core/src/guild/settings.rs:309`):
+
+```rust
+/// Where a guild's in-memory settings came from, and therefore whether writing
+/// them back to Postgres is safe.
+///
+/// 🔑 `Fallback` is the `Default` **deliberately**. The shutdown handler writes
+/// every in-memory guild back to the database, and `on_guild_create` falls back
+/// to `GuildSettings::new()` defaults when the load fails. Without this tag a
+/// transient read failure at boot becomes a permanent write at shutdown --
+/// defaults silently replacing a guild's stored settings, with no backup to
+/// restore from. Defaulting to `Fallback` means anything we did not explicitly
+/// load from Postgres is never written back.
+///
+/// 🪤 **Mutations must not reset this.** `set_volume` and friends use
+/// `and_modify` / `..self`, which leave the tag alone -- the behaviour we want.
+/// A future mutation site that *replaces* the map entry with a fresh
+/// `GuildSettings::new()` would silently re-arm the bug.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Provenance {
+    /// Defaults, built in memory. NOT safe to write back.
+    #[default]
+    Fallback,
+    /// Round-tripped through Postgres, so the row exists and a write updates
+    /// a row we actually read. Safe to write back.
+    Database,
+}
+```
+
+- [ ] **Step 4: Add the field to the struct**
+
+In `pub struct GuildSettings`, after `pub additional_prefixes: Vec<String>,`, add:
+
+```rust
+    /// Not a column and not on the wire -- see [`Provenance`].
+    #[serde(skip)]
+    pub provenance: Provenance,
+```
+
+- [ ] **Step 5: Add the field to the struct literal in `new`**
+
+`GuildSettings::new` (currently `:451`) builds a full struct literal. After `additional_prefixes: Vec::new(),` add:
+
+```rust
+            provenance: Provenance::Fallback,
+```
+
+Note: `guild/operations.rs:335` also constructs `GuildSettings { .. }` but ends with `..Default::default()`, so it needs no change — it inherits `Fallback`, which is correct.
+
+- [ ] **Step 6: Replace the derived `PartialEq` with a hand-written one**
+
+Change the derive on `GuildSettings` from:
+
+```rust
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+```
+
+to:
+
+```rust
+#[derive(Deserialize, Serialize, Debug, Clone)]
+```
+
+and add, immediately after the struct's closing brace:
+
+```rust
+/// 🔑 Hand-written to exclude `provenance`, which is bookkeeping about where a
+/// value came from rather than part of a guild's settings. Two guilds with
+/// identical settings are equal regardless of how they were loaded, and the
+/// existing equality tests should not care.
+impl PartialEq for GuildSettings {
+    fn eq(&self, other: &Self) -> bool {
+        self.guild_id == other.guild_id
+            && self.guild_name == other.guild_name
+            && self.prefix == other.prefix
+            && self.premium == other.premium
+            && self.command_settings == other.command_settings
+            && self.autopause == other.autopause
+            && self.autoplay == other.autoplay
+            && self.reply_with_embed == other.reply_with_embed
+            && self.allow_all_domains == other.allow_all_domains
+            && self.allowed_domains == other.allowed_domains
+            && self.banned_domains == other.banned_domains
+            && self.authorized_users == other.authorized_users
+            && self.authorized_groups == other.authorized_groups
+            && self.ignored_channels == other.ignored_channels
+            && self.old_volume == other.old_volume
+            && self.volume == other.volume
+            && self.self_deafen == other.self_deafen
+            && self.timeout == other.timeout
+            && self.welcome_settings == other.welcome_settings
+            && self.log_settings == other.log_settings
+            && self.additional_prefixes == other.additional_prefixes
+    }
+}
+```
+
+⚠️ If the struct has gained or lost a field since this plan was written, match the *current* field list — every field except `provenance`.
+
+- [ ] **Step 7: Add the two methods**
+
+Inside `impl GuildSettings` (starts at `:433`), next to `with_volume`:
+
+```rust
+    /// Record where these settings came from. See [`Provenance`].
+    pub fn with_provenance(self, provenance: Provenance) -> Self {
+        Self { provenance, ..self }
+    }
+
+    /// Whether the shutdown handler may write these settings back to Postgres.
+    ///
+    /// Only settings that round-tripped through the database may be written:
+    /// writing a fallback default over a stored row destroys it.
+    pub fn is_persistable(&self) -> bool {
+        self.provenance == Provenance::Database
+    }
+```
+
+- [ ] **Step 8: Run the tests and confirm they PASS**
+
+Run: `cargo test -p crack-core --lib guild::settings`
+Expected: all PASS, including the pre-existing `test_default`.
+
+- [ ] **Step 9: Confirm nothing else broke**
+
+Run: `SQLX_OFFLINE=true cargo check -p crack-core --all-targets`
+Expected: clean. If a struct literal elsewhere now fails to compile, add `provenance: Provenance::Fallback` to it — `Fallback` is always the correct default for a value not loaded from the database.
+
+- [ ] **Step 10: Commit**
+
+```bash
+cargo fmt --all
+git add crack-core/src/guild/settings.rs
+git commit -m "$(cat <<'EOF'
+feat(settings): record whether settings came from Postgres or are defaults
+
+The shutdown handler writes every in-memory guild back to the database, and
+on_guild_create falls back to GuildSettings::new() defaults when the load
+fails. A transient read failure at boot therefore becomes a permanent write
+at shutdown, replacing a guild's stored settings with defaults.
+
+Provenance tags each value with where it came from. Fallback is the Default
+deliberately: anything not explicitly loaded from Postgres is never written
+back, so a mistag costs a redundant write rather than a lost row.
+
+Not a column and not on the wire (serde(skip)), and PartialEq is hand-written
+to ignore it so existing equality tests are unperturbed.
+
+No behaviour change yet -- nothing reads the tag until the next commit.
+
+Co-Authored-By: Claude & Lothrop (cycle.five@proton.me)
+EOF
+)"
+```
+
+---
+
+### Task 3: Set the tag on load, honour it at shutdown
+
+**Files:**
+- Modify: `crack-core/src/handlers/serenity.rs` (the `Ok` arm of `on_guild_create`, around `:356`)
+- Modify: `crack-core/src/config.rs` (the shutdown loop, around `:410-428`)
+- Test: `crack-core/src/handlers/serenity.rs` (new `#[cfg(test)] mod provenance_wiring_tests`)
+
+**Interfaces:**
+- Consumes from Task 2: `Provenance::{Fallback, Database}`, `GuildSettings::with_provenance`, `GuildSettings::is_persistable`.
+- Produces: nothing later tasks depend on.
+
+**Background:** `on_guild_create` has exactly three outcomes. Only one is safe to write back:
+
+| arm | value | tag |
+|---|---|---|
+| pool present, `get_or_create` → `Ok` | the stored row | `Database` |
+| pool present, `get_or_create` → `Err` | `GuildSettings::new()` | `Fallback` (leave alone) |
+| no pool | `GuildSettings::new()` | `Fallback` (leave alone) |
+
+`GuildEntity::get_or_create` is an upsert (`INSERT … ON CONFLICT DO UPDATE … RETURNING *`), so `Ok` means the row exists in Postgres — including for a guild the bot just joined. That is exactly the condition that makes a write-back safe.
+
+- [ ] **Step 1: Write the failing wiring test**
+
+Add at the end of `crack-core/src/handlers/serenity.rs`:
+
+```rust
+#[cfg(test)]
+mod provenance_wiring_tests {
+    /// `on_guild_create` is an async serenity event handler taking a live
+    /// `Context`; it cannot be called from a unit test. The property that
+    /// matters is which of its three arms marks settings persistable, so this
+    /// reads the source.
+    ///
+    /// If this test becomes annoying, the fix is to extract the arm selection
+    /// into a pure function and test that -- not to delete the test.
+    #[test]
+    fn only_the_database_arm_marks_settings_persistable() {
+        let src = include_str!("serenity.rs");
+
+        let marks: Vec<&str> = src
+            .lines()
+            .filter(|l| l.contains("with_provenance"))
+            .map(|l| l.trim())
+            .collect();
+
+        assert_eq!(
+            marks.len(),
+            1,
+            "expected exactly one with_provenance call in this file, found {}: {:#?}",
+            marks.len(),
+            marks
+        );
+        assert!(
+            marks[0].contains("Provenance::Database"),
+            "the only with_provenance call should mark Database: {}",
+            marks[0]
+        );
+        assert!(
+            marks[0].contains("Ok(("),
+            "with_provenance must be on the Ok arm of get_or_create, so a failed \
+             load keeps the Fallback default: {}",
+            marks[0]
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run and confirm it FAILS**
+
+Run: `cargo test -p crack-core --lib provenance_wiring_tests`
+Expected: FAIL — `expected exactly one with_provenance call in this file, found 0`.
+
+- [ ] **Step 3: Mark the `Ok` arm**
+
+In `on_guild_create`, change:
+
+```rust
+                Ok((_guild, settings)) => settings,
+```
+
+to:
+
+```rust
+                // 🔑 The ONLY place settings become persistable. get_or_create
+                // is an upsert returning the live row, so Ok means Postgres and
+                // memory agree the row exists -- including for a guild just
+                // joined. The Err and no-pool arms below deliberately keep the
+                // Fallback default, so a transient read failure cannot become a
+                // permanent write at shutdown.
+                Ok((_guild, settings)) => settings.with_provenance(Provenance::Database),
+```
+
+Add the import at the top of the file:
+
+```rust
+use crate::guild::settings::Provenance;
+```
+
+(Adjust to match the file's existing import style.)
+
+- [ ] **Step 4: Run and confirm it PASSES**
+
+Run: `cargo test -p crack-core --lib provenance_wiring_tests`
+Expected: PASS.
+
+- [ ] **Step 5: Make the shutdown loop honour the tag**
+
+In `crack-core/src/config.rs`, the shutdown block currently reads:
+
+```rust
+        println!("Saving guilds...");
+        if let Some(p) = pool {
+            for (k, v) in guilds {
+                //tracing::warn!("Saving Guild: {}", k);
+                match v.save(&p).await {
+                    Ok(_) => {
+                        saved_guilds.push(k);
+                    },
+                    Err(e) => {
+                        tracing::error!("Error saving guild settings: {}", e);
+                    },
+                }
+            }
+            p.close().await;
+        }
+```
+
+Replace with:
+
+```rust
+        println!("Saving guilds...");
+        if let Some(p) = pool {
+            let mut skipped = 0usize;
+            for (k, v) in guilds {
+                // 🔑 Only write back settings that came FROM the database. A
+                // guild whose load failed is holding defaults, and writing
+                // those over its stored row destroys it -- permanently, and
+                // with no backup behind it. See guild::settings::Provenance.
+                if !v.is_persistable() {
+                    skipped += 1;
+                    continue;
+                }
+                match v.save(&p).await {
+                    Ok(_) => {
+                        saved_guilds.push(k);
+                    },
+                    Err(e) => {
+                        tracing::error!("Error saving guild settings: {}", e);
+                    },
+                }
+            }
+            if skipped > 0 {
+                // Loud on purpose: a large skip count means many guilds failed
+                // to load at boot, which is worth knowing about.
+                tracing::warn!(
+                    "Skipped {} guild(s) at shutdown whose settings never loaded from the database",
+                    skipped
+                );
+            }
+            p.close().await;
+        }
+```
+
+`GuildSettings::save` is `pub async fn save(&self, pool: &PgPool)` (`crack-core/src/guild/settings.rs:506`) — one argument, verified. This step only adds the guard and the counter; the `save` call is unchanged.
+
+- [ ] **Step 6: Verify the whole crate still builds and tests pass**
+
+Run: `SQLX_OFFLINE=true cargo check -p crack-core --all-targets && cargo test -p crack-core --lib`
+Expected: clean, all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt --all
+git add crack-core/src/handlers/serenity.rs crack-core/src/config.rs
+git commit -m "$(cat <<'EOF'
+fix(settings): never write fallback defaults over a guild's stored settings
+
+on_guild_create marks settings Database only on the Ok arm of get_or_create,
+which is an upsert returning the live row -- so Ok means Postgres and memory
+agree the row exists. The Err and no-pool arms keep the Fallback default.
+
+The shutdown handler now skips guilds whose settings are not persistable and
+logs how many it skipped, so a boot where many guilds failed to load is
+visible rather than silent.
+
+Without this a transient read failure at boot became a permanent write at
+shutdown: defaults replacing a guild's stored settings, unrecoverably, since
+production has no backups yet.
+
+The wiring is guarded by a source-reading test because on_guild_create takes
+a live serenity Context and cannot be called from a unit test.
+
+Co-Authored-By: Claude & Lothrop (cycle.five@proton.me)
+EOF
+)"
+```
+
+---
+
+### Task 4: A `migrate` image, so migrations are never applied by hand
+
+**Files:**
+- Modify: `Dockerfile`
+- Modify: `.github/workflows/docker.yml`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: the image `ghcr.io/cycle-five/cracktunes-migrate:<tag>`, which homelab's `bots/docker-compose.yml` will run as a one-shot before the bot starts. Its entrypoint runs `sqlx migrate run --source /migrations`; it needs `DATABASE_URL` in the environment and nothing else.
+
+**Background:** the bot does not run migrations — every `sqlx::migrate!` in the tree is inside a test module pointed at `./test_migrations`. All 22 production migrations are applied out of band today. A manual step that must not be forgotten is the same shape as the skipped Docker job that let ct#451's broken image reach master.
+
+⚠️ **The stage-ordering trap.** The Dockerfile's last stage is the default build target. `runner` is last today. Adding `migrate` after it would silently make the *migrate* image the bot image. Both build steps therefore get an explicit `target:`.
+
+- [ ] **Step 1: Install sqlx-cli in the builder, before the source copy**
+
+In `Dockerfile`, the builder stage currently reads:
+
+```dockerfile
+RUN apk add --no-cache \
+  build-base \
+  musl-dev \
+  cmake \
+  git
+
+# Default directory
+WORKDIR /app
+```
+
+Insert the install **between** the `apk add` and the `WORKDIR`:
+
+```dockerfile
+# 🔑 BEFORE `COPY . .`, deliberately. sqlx-cli takes minutes to build and never
+# changes with our source, so keeping it above the copy means the layer caches
+# across every source change and only rebuilds when this base image moves.
+#
+# Pinned to ~0.8 to match the sqlx 0.8.2 that writes the _sqlx_migrations
+# ledger; a mismatched CLI can disagree with the library about that table.
+RUN cargo install sqlx-cli --version '~0.8' --no-default-features --features rustls,postgres
+```
+
+- [ ] **Step 2: Add the migrate stage**
+
+Append to the **end** of `Dockerfile`:
+
+```dockerfile
+# STAGE3: the migration runner, used as a one-shot before the bot starts.
+#
+# 🪤 This stage is LAST, which makes it the default build target. The bot image
+# must therefore be built with an explicit `--target runner`; the Docker
+# workflow does this. Building with no target gets you this image, which is
+# emphatically not the bot.
+FROM alpine:3.22 AS migrate
+COPY --from=builder /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
+COPY --from=builder /app/migrations /migrations
+# Needs DATABASE_URL in the environment and nothing else.
+ENTRYPOINT ["sqlx", "migrate", "run", "--source", "/migrations"]
+```
+
+- [ ] **Step 3: Pin the bot image's target explicitly**
+
+In `.github/workflows/docker.yml`, the existing build step is:
+
+```yaml
+      - 
+        name: Build & Push Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+```
+
+Add `target: runner`:
+
+```yaml
+      - 
+        name: Build & Push Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          # 🪤 EXPLICIT. The Dockerfile's last stage is `migrate`, and an
+          # unspecified target builds the last stage -- which would publish the
+          # migration runner as the bot.
+          target: runner
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+```
+
+- [ ] **Step 4: Publish the migrate image alongside**
+
+Append two steps to the same job, after the existing build step:
+
+```yaml
+      -
+        name: Extract Git Metadata (migrate image)
+        id: meta-migrate
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-migrate
+      -
+        name: Build & Push Migration Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: migrate
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta-migrate.outputs.tags }}
+          labels: ${{ steps.meta-migrate.outputs.labels }}
+```
+
+This publishes `ghcr.io/cycle-five/cracktunes-migrate` with the same `v`-prefixed tags the bot image gets, because it uses the same `metadata-action` defaults.
+
+- [ ] **Step 5: Validate the workflow YAML parses**
+
+Run: `python3 -c "import yaml,sys; d=yaml.safe_load(open('.github/workflows/docker.yml')); steps=d['jobs']['push']['steps']; names=[s.get('name') for s in steps]; print(names); assert 'Build & Push Migration Image' in names"`
+Expected: prints the step names including the new one, no assertion error.
+
+- [ ] **Step 6: Verify both targets resolve**
+
+Do **not** build the images here — container DNS is broken on this workstation and image builds happen on the staging host. Confirm the stage names exist and are distinct:
+
+Run: `grep -n '^FROM' Dockerfile`
+Expected: exactly three lines, ending with `FROM alpine:3.22 AS migrate`. Confirm `runner` and `migrate` are both present and are different stages.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Dockerfile .github/workflows/docker.yml
+git commit -m "$(cat <<'EOF'
+build(docker): publish a migration-runner image
+
+The bot does not run migrations -- every sqlx::migrate! in the tree is in a
+test module -- so all 22 are applied out of band. Production is about to get
+a database, and a manual step that must not be forgotten is the same shape
+as the skipped Docker job that let #451's broken image reach master.
+
+Adds a `migrate` stage carrying sqlx-cli and the migrations, published as
+cracktunes-migrate with the same tags as the bot image. homelab runs it as a
+one-shot with service_completed_successfully before the bot starts.
+
+sqlx-cli is installed above `COPY . .` so the layer caches across source
+changes, and pinned to ~0.8 to match the sqlx that writes _sqlx_migrations.
+
+🪤 The new stage is last, which makes it the default build target, so the bot
+image's build step now names `target: runner` explicitly. Without that, an
+unspecified target publishes the migration runner as the bot.
+
+Co-Authored-By: Claude & Lothrop (cycle.five@proton.me)
+EOF
+)"
+```
+
+---
+
+### Task 5: Version bump to 0.9.1
+
+**Files:**
+- Modify: `crack-bf/Cargo.toml`, `crack-cli/Cargo.toml`, `crack-core/Cargo.toml`, `crack-gpt/Cargo.toml`, `crack-osint/Cargo.toml`, `crack-sleevenote/Cargo.toml`, `crack-testing/Cargo.toml`, `crack-types/Cargo.toml`, `crack-voting/Cargo.toml`
+- Modify: `Cargo.lock` (by running cargo, not by hand)
+
+**Interfaces:** none.
+
+**Background:** there is no `[workspace.package] version`; all nine members carry a literal `version`, so a partial bump compiles clean and ships a lie. That is issue #424(b).
+
+- [ ] **Step 1: Confirm the current version is 0.9.0 everywhere**
+
+Run: `grep -m1 '^version = ' */Cargo.toml`
+Expected: nine lines, every one `version = "0.9.0"`. If any differs, stop and report — a partial bump already happened.
+
+- [ ] **Step 2: Bump all nine**
+
+```bash
+sed -i '0,/^version = "0.9.0"/s//version = "0.9.1"/' \
+  crack-bf/Cargo.toml crack-cli/Cargo.toml crack-core/Cargo.toml \
+  crack-gpt/Cargo.toml crack-osint/Cargo.toml crack-sleevenote/Cargo.toml \
+  crack-testing/Cargo.toml crack-types/Cargo.toml crack-voting/Cargo.toml
+```
+
+- [ ] **Step 3: Verify all nine moved**
+
+Run: `grep -m1 '^version = ' */Cargo.toml`
+Expected: nine lines, every one `version = "0.9.1"`. This is the check #424(b) exists because of — count them.
+
+- [ ] **Step 4: Update the lockfile**
+
+Run: `cargo metadata --format-version 1 > /dev/null && grep -A1 '^name = "cracktunes"' Cargo.lock`
+Expected: `version = "0.9.1"`.
+
+- [ ] **Step 5: Confirm the lock is coherent**
+
+Run: `cargo metadata --locked --format-version 1 > /dev/null && echo OK`
+Expected: `OK`. A failure here means the lockfile disagrees with the manifests and CI would reject it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add */Cargo.toml Cargo.lock
+git commit -m "$(cat <<'EOF'
+chore: bump to 0.9.1
+
+Patch release: the two prerequisites for giving production a database --
+redacting the config log (#473) and refusing to write fallback defaults over
+stored guild settings -- plus the migration-runner image.
+
+All nine members bumped together; there is no [workspace.package] version,
+so a partial bump compiles clean and ships a lie (#424).
+
+Co-Authored-By: Claude & Lothrop (cycle.five@proton.me)
+EOF
+)"
+```
+
+---
+
+## Final verification (run before finishing the branch)
+
+- [ ] `cargo fmt --all --check` — clean
+- [ ] `cargo clippy --workspace --all-targets` — clean
+- [ ] `SQLX_OFFLINE=true cargo check -p crack-core --all-targets` — clean
+- [ ] `cargo test --workspace` — all pass except the known-unrelated `crack-testing::tests::test_enqueue_query`, which fails on master too (a deleted YouTube video id; fixed in open PR #471)
+- [ ] `grep -m1 '^version = ' */Cargo.toml` — nine lines, all `0.9.1`
+- [ ] `grep -c '^FROM' Dockerfile` — `3`

--- a/docs/superpowers/specs/2026-09-11-production-database-design.md
+++ b/docs/superpowers/specs/2026-09-11-production-database-design.md
@@ -1,0 +1,301 @@
+# Postgres in production — design
+
+**Status:** approved 2026-09-11
+**Scope:** cracktunes `v0.9.1` (code) + homelab `bots/` (infrastructure)
+**Closes:** #473. Prerequisite for giving production a database at all.
+
+## Goal
+
+Production (the `bots` stack, VM 108, 139 guilds) runs with no `DATABASE_URL`
+today, deliberately. This turns that on: guild settings, play history, playlists
+and `/gp` persistence start working for the guilds that actually use the bot.
+
+The beta tenant (TuneTitan) has had a Postgres since homelab #58, so the pattern
+exists. Production is not a copy of it, because production has data worth
+keeping and TuneTitan explicitly does not.
+
+## Constraints that shaped this
+
+**Durability: real data, backups deferred.** Production's rows are worth
+keeping, but the backup job is a follow-up rather than a blocker. That decision
+is what makes the corruption path below a must-fix rather than a nice-to-have:
+without backups, anything silently destroyed is destroyed for good.
+
+**Sequencing: code first, then infrastructure.** `v0.9.1` ships both code fixes
+and reaches production *before* any `DATABASE_URL` exists. Production never runs
+for a moment with a database and a known unrecoverable-overwrite path.
+
+**Placement: same compose project.** Postgres joins `bots/`, like TuneTitan's.
+Service-name resolution, no published port, no firewall in the path. The stack's
+own comments already argue for co-location; nothing here overturns that.
+
+---
+
+## Part 1 — cracktunes `v0.9.1`
+
+### 1.1 #473 — the password is logged in cleartext
+
+`BotConfig` has a hand-written `Display` impl that redacts the URL through
+`redact_url` (`crack-core/src/lib.rs:237`, redacting at `:266`). `crack-cli/src/main.rs:70` logs the
+config with `{:?}` — the **derived `Debug`**, which does not redact:
+
+```
+WARN cracktunes: Using config: BotConfig { ... database_url: Some("postgres://cracktunes:<PASSWORD>@postgres:5432/cracktunes"), ... }
+```
+
+**Fix:** `{:?}` → `{}` at that call site.
+
+🔑 **This is a prerequisite, not a follow-up.** Production has no
+`DATABASE_URL` today, so it has no password to leak. Adding one is precisely
+what creates the exposure. Observed live on TuneTitan on 2026-09-10.
+
+**Guard:** a test asserting the rendered config contains no `@`-delimited
+password segment, so a future edit cannot silently fall back to `Debug`.
+
+⚠️ **TuneTitan's existing password still needs rotating.** This stops new
+leaks; it cannot un-log what is already in that host's `docker logs`. Out of
+scope here, tracked separately.
+
+### 1.2 The shutdown write can overwrite settings that never loaded
+
+**The mechanism.** `config.rs:410` writes every guild in the in-memory
+`guild_settings_map` back to Postgres on `SIGTERM`. `on_guild_create`
+(`handlers/serenity.rs:347`) populates that map, with three outcomes:
+
+| arm | result | today |
+|---|---|---|
+| pool present, `get_or_create` `Ok` | the stored row | safe to write back |
+| pool present, `get_or_create` `Err` | `GuildSettings::new()` defaults | **unsafe** |
+| no pool | `GuildSettings::new()` defaults | **unsafe** |
+
+A **transient read failure at boot therefore becomes a permanent write at
+shutdown.** One slow or wedged Postgres, and that guild's stored settings are
+silently replaced by defaults. Harmless today (nothing to lose); unrecoverable
+once there is data and no backups.
+
+🔑 **Half of this was already fixed.** Settings used to load in
+`on_cache_ready`, which never fires at ~150 guilds — the code carries a long
+comment explaining the move to the per-guild event. "Settings never load" is
+fixed. The defaults fallback is what survived.
+
+**The fix: a provenance tag.**
+
+```rust
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub enum Provenance {
+    #[default]
+    Fallback,   // defaults -- NOT safe to write back
+    Database,   // round-tripped through Postgres -- safe
+}
+```
+
+`Fallback` is the `Default` **deliberately**: anything not explicitly loaded
+from Postgres is never written back. `GuildSettings::new()` gets the safe value
+for free, and so does anything deserialized.
+
+Set in exactly one place — the `Ok` arm of `on_guild_create`:
+
+```rust
+Ok((_guild, settings)) => settings.with_provenance(Provenance::Database),
+```
+
+The `Err` and no-pool arms leave the default untouched.
+
+The shutdown loop skips `Fallback` entries and logs how many it skipped, so a
+skip storm is visible rather than silent.
+
+🔑 **`Database` means "Postgres and memory agree the row exists."**
+`GuildEntity::get_or_create` is an upsert
+(`INSERT … ON CONFLICT (guild_id) DO UPDATE SET guild_name = $2 RETURNING *`),
+so both branches return the live row — an existing guild only has its name
+refreshed. A **brand-new** guild is therefore `Database` too, correctly: the
+`INSERT` created the row, so writing back updates a row we read.
+
+🪤 **Mutations must not reset provenance.** `set_volume` and friends use
+`and_modify`, which mutates in place and leaves the tag alone — the behaviour we
+want. A future mutation site that *replaces* the entry would silently re-arm the
+bug. This goes in a doc comment on the enum.
+
+🪤 **`set_volume` has a second route into the same hole.** It ends with
+`or_insert(GuildSettings::new(...))`, lazily creating a defaults entry for a
+guild not in the map. Under this change that entry is `Fallback` and cannot
+overwrite a stored row.
+
+### 1.3 The shutdown write must NOT simply be deleted
+
+Recorded because it is the obvious "simplification" and it is wrong.
+
+Of the 8 commands under `commands/settings/set/` (excluding `mod.rs`), 4 call
+`save()` and 4 do not. These mutate the in-memory map and **never** touch
+Postgres:
+
+- `set_volume.rs`
+- `set_idle_timeout.rs`
+- `set_all_log_channel.rs`
+- `set_premium.rs`
+
+`commands/settings/prefix.rs` — a directory up, not under `set/` — is a fifth,
+and also mutates the map without saving.
+
+For those five, the shutdown write is the **only** persistence path. Deleting it
+trades a rare data-loss bug for a guaranteed one. Verified by reading
+`set_volume`, which does `and_modify`/`or_insert` and no `save()`.
+
+Dirty-tracking (write only mutated guilds) is the better long-term model and
+was considered. It was rejected **for this change** because it inverts the
+default to "don't write", so a missed mutation site silently breaks persistence
+forever — and five sites already mutate without saving. Provenance fails safe in
+the other direction: a mistag costs a redundant write, never a lost row.
+
+### 1.4 Cost accepted
+
+`GuildSettings` derives `PartialEq`. A provenance field would make two otherwise
+identical settings compare unequal, perturbing existing tests. `PartialEq` is
+hand-written to exclude it.
+
+### 1.5 Explicitly out of scope
+
+- **The 11 `database_pool.as_ref().unwrap()` calls.** They panic when the pool
+  is `None`, which is production's state *today* — so `/playlist create`,
+  `/delete_playlist`, `set_music_channel` and `set_auto_role` panic in
+  production right now. Adding a pool makes them succeed. They still deserve
+  real errors, but fixing them here is scope creep on a release that gates
+  infrastructure. Own issue.
+- **`No database pool available` logging at ERROR on nearly every gateway
+  event.** Moot once production has a pool. Own issue.
+
+---
+
+## Part 2 — infrastructure
+
+### 2.1 The migrate image
+
+The bot does not run migrations: every `sqlx::migrate!` in the tree is inside a
+test module, pointed at `./test_migrations`. All 22 production migrations are
+applied out of band. A manual step that must not be forgotten is the same shape
+as the skipped Docker job that let ct#451's broken image reach master, so this
+automates it.
+
+The runtime image has no sqlx, so the one-shot needs its own. New target in the
+existing Dockerfile, reusing the builder already present:
+
+```dockerfile
+FROM rust:1.98.0-alpine3.22 AS builder
+RUN apk add --no-cache build-base musl-dev cmake git
+# 🔑 BEFORE `COPY . .` deliberately: sqlx-cli takes minutes to build and never
+# changes with our source, so this layer caches across every source change.
+# Pinned to ~0.8 to match the sqlx 0.8.2 that writes _sqlx_migrations.
+RUN cargo install sqlx-cli --version '~0.8' --no-default-features --features rustls,postgres
+WORKDIR /app
+COPY . .
+RUN cargo build -p cracktunes --profile=dist
+
+FROM alpine:3.22 AS migrate
+COPY --from=builder /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
+COPY --from=builder /app/migrations /migrations
+ENTRYPOINT ["sqlx", "migrate", "run", "--source", "/migrations"]
+```
+
+Published as `ghcr.io/cycle-five/cracktunes-migrate:<tag>` by the existing
+Docker workflow, with the same `v`-prefixed tag as the bot image.
+
+**Cost, stated:** a second published image and a CI change. Layer ordering keeps
+the sqlx-cli build off the hot path, but the first build after any base-image
+bump is slow.
+
+### 2.2 Compose
+
+```yaml
+  postgres:
+    image: postgres:16-alpine
+    # Named and DURABLE. Unlike tunetitan's, this volume is NOT test data.
+    volumes: [bots-pgdata:/var/lib/postgresql/data]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cracktunes -d cracktunes"]
+      interval: 5s
+      retries: 20
+
+  migrate:
+    image: ghcr.io/cycle-five/cracktunes-migrate:v0.9.1
+    environment:
+      DATABASE_URL: postgres://cracktunes:${POSTGRES_PASSWORD:?}@postgres:5432/cracktunes
+    depends_on:
+      postgres: {condition: service_healthy}
+    restart: "no"
+
+  cracktunes:
+    environment:
+      DATABASE_URL: postgres://cracktunes:${POSTGRES_PASSWORD:?}@postgres:5432/cracktunes
+    depends_on:
+      postgres: {condition: service_healthy}
+      migrate:  {condition: service_completed_successfully}
+```
+
+🪤 **`service_healthy`, not `service_started`.** Postgres' entrypoint starts the
+cluster, initialises it, then **restarts** it, so the port is briefly open to
+nothing. The bot builds its pool once at startup and does not retry, so racing
+that window is a bot with no database that looks configured. Carried over from
+TuneTitan, where it was found the hard way.
+
+🔑 **`service_completed_successfully` on `migrate`.** The ledger must be current
+before the first query.
+
+**No published port**, unlike TuneTitan — automating migrations removes the only
+reason that loopback tunnel existed.
+
+### 2.3 Secrets
+
+`POSTGRES_PASSWORD` joins the gitignored `.env.bots`, passed via `--env-file`
+from the workstation, so it never lands on the host — the same treatment the
+Discord token gets. Source of truth in Vaultwarden.
+
+This is a **new** password; nothing here needs rotating.
+
+### 2.4 verify.sh
+
+```
+applied=$(psql -tAc "SELECT count(*) FROM _sqlx_migrations WHERE success")
+ondisk=$(ls migrations/*.sql | wc -l)     # 22 at time of writing
+[ "$applied" = "$ondisk" ] || FAIL
+```
+
+Catches a forgotten migration at deploy time rather than at first query. Plus:
+Postgres healthy, and the **absence** of `No database pool available` in the
+startup log — the bot does not crash when the pool fails to build, so its
+silence is the only signal that it worked.
+
+🪤 Assertions read the **head** of the log, and use bash `case` rather than
+`grep -q`, for the two reasons documented in `tunetitan/verify.sh`.
+
+### 2.5 Cutover and rollback
+
+**Cutover is a clean slate.** Production has never had a Postgres, so there is
+no data to migrate. First boot creates 139 rows at defaults via the upsert —
+which is exactly the effective state today, since settings currently live only
+in memory and are discarded on every restart.
+
+**Rollback is cheap.** Remove `DATABASE_URL` and redeploy. The bot returns to
+today's behaviour, the volume keeps its rows, nothing is destroyed.
+
+### 2.6 Deferred: backups
+
+From this landing until a backup job exists, production has data worth losing
+and no way to restore it. The provenance fix removes the *silent* corruption
+path; what remains is blunt loss — volume destroyed, host lost.
+
+Filed as its own issue with a concrete shape (`pg_dump` on a timer to somewhere
+off VM 108) so it does not drift. The window should be days, not weeks.
+
+---
+
+## Success criteria
+
+1. `v0.9.1` reaches production with no `DATABASE_URL` and the config log shows
+   no password.
+2. A guild whose settings fail to load is skipped by the shutdown write, and the
+   skip is logged.
+3. The five save-less settings commands still persist across a restart.
+4. `bots` comes up with Postgres healthy, all 22 migrations applied, and no
+   `No database pool available` in the log.
+5. `verify bots` fails if a migration is missing.
+6. Removing `DATABASE_URL` returns the bot to its current behaviour.

--- a/docs/superpowers/specs/2026-09-11-production-database-design.md
+++ b/docs/superpowers/specs/2026-09-11-production-database-design.md
@@ -126,25 +126,29 @@ overwrite a stored row.
 Recorded because it is the obvious "simplification" and it is wrong.
 
 Of the 8 commands under `commands/settings/set/` (excluding `mod.rs`), 4 call
-`save()` and 4 do not. These mutate the in-memory map and **never** touch
-Postgres:
+`save()` and 4 do not. Three of those four mutate the in-memory map and
+**never** touch Postgres:
 
 - `set_volume.rs`
 - `set_idle_timeout.rs`
 - `set_all_log_channel.rs`
-- `set_premium.rs`
 
-`commands/settings/prefix.rs` — a directory up, not under `set/` — is a fifth,
-and also mutates the map without saving.
+(`set_premium.rs` is the fourth that skips `save()`, but it is not in this
+list — it calls `GuildEntity::update_premium` directly and persists on its
+own.)
 
-For those five, the shutdown write is the **only** persistence path. Deleting it
+`commands/settings/prefix.rs` — a directory up, not under `set/` — is a
+fourth command with no persistence path of its own, and also mutates the map
+without saving.
+
+For those four, the shutdown write is the **only** persistence path. Deleting it
 trades a rare data-loss bug for a guaranteed one. Verified by reading
 `set_volume`, which does `and_modify`/`or_insert` and no `save()`.
 
 Dirty-tracking (write only mutated guilds) is the better long-term model and
 was considered. It was rejected **for this change** because it inverts the
 default to "don't write", so a missed mutation site silently breaks persistence
-forever — and five sites already mutate without saving. Provenance fails safe in
+forever — and four sites already mutate without saving. Provenance fails safe in
 the other direction: a mistag costs a redundant write, never a lost row.
 
 ### 1.4 Cost accepted


### PR DESCRIPTION
Closes #473. Prerequisite for putting Postgres on the production `bots` stack.

Spec: `docs/superpowers/specs/2026-09-11-production-database-design.md`
Plan: `docs/superpowers/plans/2026-09-11-production-database.md`

Production runs 139 guilds with **no `DATABASE_URL`**, deliberately. This ships the two code fixes that must reach production **before** it gets one, plus the image that will apply migrations. It changes nothing about how the bot behaves today — with no pool, every path here is inert.

## 1. The password was in the logs (#473)

`BotConfig` has a hand-written `Display` that redacts `database_url` through `redact_url`. `crack-cli/src/main.rs:70` logged it with `{:?}` — the **derived `Debug`**, which doesn't redact. Observed live on the beta tenant on 2026-09-10:

```
WARN cracktunes: Using config: BotConfig { ... database_url: Some("postgres://cracktunes:<PASSWORD>@postgres:5432/cracktunes"), ... }
```

One character. The redaction already existed and was simply bypassed by the wrong formatter.

**This is a prerequisite, not a follow-up:** production has no password to leak today. Adding a database is exactly what creates the exposure. Guarded by a test that reads the log line and rejects `{:?}`, since a `tracing` macro's format string isn't otherwise observable from a test.

## 2. A transient read failure became a permanent write

`config.rs` writes every in-memory guild's settings back to Postgres on `SIGTERM`. `on_guild_create` falls back to `GuildSettings::new()` defaults when `get_or_create` fails. So **one slow or wedged Postgres at boot, and that guild's stored settings are silently replaced by defaults at the next shutdown** — unrecoverably, since there are no backups yet.

Fixed with a `Provenance` tag whose `Default` is the *safe* value:

```rust
#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
pub enum Provenance {
    #[default]
    Fallback,   // defaults — NOT safe to write back
    Database,   // round-tripped through Postgres — safe
}
```

Set in exactly one place: the `Ok` arm of `on_guild_create`. `get_or_create` is an upsert returning the live row, so `Ok` means Postgres and memory agree the row exists — including for a just-joined guild. The `Err` and no-pool arms keep `Fallback`. The shutdown loop skips non-persistable guilds and logs the skip count.

🔑 **Half of this was already fixed and I nearly missed it.** Settings used to load in `on_cache_ready`, which never fires at ~150 guilds; someone had already moved them to the per-guild event. "Settings never load" was fixed. The defaults fallback is what survived.

### 🪤 Why the shutdown write could NOT simply be deleted

That was my first instinct and it was wrong. **Four commands mutate the in-memory map and never call `save()`** — `set_volume`, `set_idle_timeout`, `set_all_log_channel`, and `prefix`. For those, that write is the *only* path to disk. Deleting it would trade a rare data-loss bug for a guaranteed one.

Dirty-tracking is the better long-term model and was rejected *here*, because it inverts the default to "don't write" and a missed mutation site then fails silently — with four sites already mutating without saving. Provenance fails safe the other way: a mistag costs a redundant write, never a lost row.

## 3. A migration runner, so migrations stop being a manual step

The bot doesn't run migrations — every `sqlx::migrate!` in the tree is in a test module. All 22 are applied by hand today. A manual step that must not be forgotten is the same shape as the skipped Docker job that let #451's broken image reach master.

New `migrate` Dockerfile stage carrying sqlx-cli (pinned `~0.8` to match `sqlx 0.8.2`) and the migrations, published as `cracktunes-migrate` with the same tags as the bot. homelab will run it with `service_completed_successfully` before the bot starts.

🪤 **The new stage is last, which makes it the Dockerfile's default build target.** Both build steps now name an explicit `target:` — and the whole-branch review caught that `dockerhub.yml` has a *second* build step that the plan never mentioned. Without that fix, tagging `v0.9.1` would have published the migration runner to Docker Hub as `cracktunes:latest`, silently, because the build and push both succeed.

## Deliberately not fixed here

**[#482](https://github.com/cycle-five/cracktunes/issues/482) — six command paths still write back without a provenance check.** Real, pre-existing, and unreachable in production today (no pool). Not fixed here for a specific reason: it would put a **new, unexercised database write path into the release whose entire purpose is to precede the database**, where it cannot be observed working. #482 gates setting `DATABASE_URL` on production, not this merge.

Also out of scope per the spec: the 11 `database_pool.as_ref().unwrap()` calls (which *currently* panic in production, and which a pool fixes) and the `No database pool available` ERROR log level.

## Verification

`cargo fmt --all --check` clean · `cargo clippy --workspace --all-targets` **0 warnings** · `SQLX_OFFLINE=true cargo check -p crack-core --all-targets` clean · `cargo metadata --locked` OK · all nine members at `0.9.1`.

`cargo test --workspace` passes except `crack-testing::tests::test_enqueue_query`, which **fails on master too** — a YouTube video id deleted upstream, already fixed in open PR #471.

Five tasks, each independently reviewed, then a whole-branch review on the strongest model and one fix wave with a scoped re-review. The wiring test was sabotage-verified: reverting the `with_provenance` call makes it fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8PrF3gizKqXCStjCuWL3d