### PR TITLE
fix(settings): guard every command write-back, and persist deauthorize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,14 +1012,14 @@ dependencies = [
 
 [[package]]
 name = "crack-bf"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "crack-core"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "crack-gpt"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-openai",
  "const_format",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "crack-osint"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "crack-types",
  "ipinfo",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "crack-sleevenote"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "crack-testing"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "crack-types"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "humantime",
  "poise",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "crack-voting"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "chrono",
  "dbl-rs",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "cracktunes"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "config-file",
  "crack-core",

--- a/crack-bf/Cargo.toml
+++ b/crack-bf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-bf"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-cli/Cargo.toml
+++ b/crack-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "cracktunes"
-version = "0.9.1"
+version = "0.9.2"
 description = "Cracktunes is a hassle-free, highly performant, host-it-yourself, cracking smoking, discord-music-bot."
 publish = true
 edition = "2021"

--- a/crack-core/Cargo.toml
+++ b/crack-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-core"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 edition = "2021"
 description = "Core module for the cracking smoking, discord-music-bot Cracktunes."

--- a/crack-core/src/commands/admin/authorize.rs
+++ b/crack-core/src/commands/admin/authorize.rs
@@ -40,6 +40,11 @@ pub async fn authorize(
     let id = user.id;
     let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
 
+    // 🔑 Before mutating: make sure what is in memory came from Postgres. A
+    // guild whose boot load failed holds defaults, and `save()` below is a
+    // full-row upsert that would write them over its stored row.
+    ctx.data().ensure_settings_loaded(guild_id).await?;
+
     let guild_settings = ctx
         .data()
         .guild_settings_map

--- a/crack-core/src/commands/admin/deauthorize.rs
+++ b/crack-core/src/commands/admin/deauthorize.rs
@@ -33,6 +33,11 @@ pub async fn deauthorize(
         .map(|g| g.name)
         .unwrap_or_else(|_| <FixedString>::from_str(UNKNOWN).expect(""));
 
+    // 🔑 Before mutating: make sure what is in memory came from Postgres. A
+    // guild whose boot load failed holds defaults, and `save()` below is a
+    // full-row upsert that would write them over its stored row.
+    ctx.data().ensure_settings_loaded(guild_id).await?;
+
     let res = ctx
         .data()
         .guild_settings_map
@@ -51,6 +56,18 @@ pub async fn deauthorize(
             .clone()
         })
         .clone();
+
+    // 🔴 This save was MISSING. `authorize` persisted, `deauthorize` did not, so
+    // a revoked authorization was only ever held in memory -- a crash, an OOM
+    // kill, or (since v0.9.1) a guild skipped at shutdown for holding Fallback
+    // settings would all silently restore access that was deliberately removed.
+    let pool = ctx
+        .data()
+        .database_pool
+        .clone()
+        .ok_or(CrackedError::Other("No database pool"))?;
+    res.save(&pool).await?;
+
     tracing::info!("User Deauthorized: UserId = {}, GuildId = {}", id, res);
 
     let mention = user.mention();

--- a/crack-core/src/commands/settings/set/set_auto_role.rs
+++ b/crack-core/src/commands/settings/set/set_auto_role.rs
@@ -62,13 +62,25 @@ pub async fn auto_role_internal(ctx: Context<'_>, auto_role: RoleId) -> Result<(
     let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
     let mention = auto_role.mention();
 
+    // 🔑 Before mutating: make sure what is in memory came from Postgres. A
+    // guild whose boot load failed holds defaults, and `save()` below is a
+    // full-row upsert that would write them over its stored row.
+    ctx.data().ensure_settings_loaded(guild_id).await?;
+
     ctx.data().set_auto_role(guild_id, auto_role.get()).await;
     let res = ctx
         .data()
         .get_guild_settings(guild_id)
         .await
         .ok_or(CrackedError::NoGuildSettings)?;
-    res.save(&ctx.data().database_pool.clone().unwrap()).await?;
+    // 🪤 `unwrap()` here panicked on a tokio worker whenever there was no pool,
+    // which is production's deliberate config today.
+    let pool = ctx
+        .data()
+        .database_pool
+        .clone()
+        .ok_or(CrackedError::Other("No database pool"))?;
+    res.save(&pool).await?;
 
     //ctx.say(format!("Auto role set to {}", mention)).await?;
     let params = SendMessageParams::new(CrackedMessage::Other(format!(

--- a/crack-core/src/commands/settings/set/set_join_leave_log_channel.rs
+++ b/crack-core/src/commands/settings/set/set_join_leave_log_channel.rs
@@ -45,6 +45,11 @@ pub async fn join_leave_log_channel(
     //     .unwrap()
     //     .get_mut(&guild_id);
 
+    // 🔑 Before mutating: make sure what is in memory came from Postgres. A
+    // guild whose boot load failed holds defaults, and `save()` below is a
+    // full-row upsert that would write them over its stored row.
+    ctx.data().ensure_settings_loaded(guild_id).await?;
+
     let data = ctx.data();
     let _ = data
         .guild_settings_map
@@ -58,8 +63,15 @@ pub async fn join_leave_log_channel(
     let settings_temp = data.get_guild_settings(guild_id).await;
     let settings = settings_temp.as_ref();
 
-    let pg_pool = ctx.data().database_pool.clone().unwrap();
-    settings.map(|s| s.save(&pg_pool)).unwrap().await?;
+    // 🪤 `unwrap()` here panicked on a tokio worker whenever there was no pool.
+    let pg_pool = ctx
+        .data()
+        .database_pool
+        .clone()
+        .ok_or(CrackedError::Other("No database pool"))?;
+    if let Some(s) = settings {
+        s.save(&pg_pool).await?;
+    }
 
     send_reply(
         &ctx,

--- a/crack-core/src/commands/settings/set/set_music_channel.rs
+++ b/crack-core/src/commands/settings/set/set_music_channel.rs
@@ -35,6 +35,11 @@ pub async fn music_channel(
         channel_id.unwrap()
     };
 
+    // 🔑 Before mutating: make sure what is in memory came from Postgres. A
+    // guild whose boot load failed holds defaults, and `save()` below is a
+    // full-row upsert that would write them over its stored row.
+    ctx.data().ensure_settings_loaded(guild_id).await?;
+
     let data = ctx.data();
     let _ = data.set_music_channel(guild_id, channel_id).await;
 
@@ -42,8 +47,15 @@ pub async fn music_channel(
     let settings = opt_settings.get(&guild_id);
 
     // FIXME: Do this with the async work queue.
-    let pg_pool = ctx.data().database_pool.clone().unwrap();
-    settings.map(|s| s.save(&pg_pool)).unwrap().await?;
+    // 🪤 `unwrap()` here panicked on a tokio worker whenever there was no pool.
+    let pg_pool = ctx
+        .data()
+        .database_pool
+        .clone()
+        .ok_or(CrackedError::Other("No database pool"))?;
+    if let Some(s) = settings {
+        s.save(&pg_pool).await?;
+    }
 
     let _ = send_reply(
         &ctx,
@@ -64,14 +76,26 @@ pub async fn music_denied_user(
 ) -> Result<(), Error> {
     let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
 
+    // 🔑 Before mutating: make sure what is in memory came from Postgres. A
+    // guild whose boot load failed holds defaults, and `save()` below is a
+    // full-row upsert that would write them over its stored row.
+    ctx.data().ensure_settings_loaded(guild_id).await?;
+
     let data = ctx.data();
     let _ = data.add_denied_music_user(guild_id, user).await;
 
     let opt_settings = data.guild_settings_map.read().await.clone();
     let settings = opt_settings.get(&guild_id);
 
-    let pg_pool = ctx.data().database_pool.clone().unwrap();
-    settings.map(|s| s.save(&pg_pool)).unwrap().await?;
+    // 🪤 `unwrap()` here panicked on a tokio worker whenever there was no pool.
+    let pg_pool = ctx
+        .data()
+        .database_pool
+        .clone()
+        .ok_or(CrackedError::Other("No database pool"))?;
+    if let Some(s) = settings {
+        s.save(&pg_pool).await?;
+    }
 
     let _ = send_reply(
         &ctx,

--- a/crack-core/src/commands/settings/toggle/self_deafen.rs
+++ b/crack-core/src/commands/settings/toggle/self_deafen.rs
@@ -43,6 +43,11 @@ pub async fn toggle_self_deafen(
     guild_name: Option<String>,
     prefix: String,
 ) -> Result<GuildSettings, CrackedError> {
+    // 🔑 Before mutating: make sure what is in memory came from Postgres. A
+    // guild whose boot load failed holds defaults, and `save()` below is a
+    // full-row upsert that would write them over its stored row.
+    data.ensure_settings_loaded(guild_id).await?;
+
     let res = data
         .guild_settings_map
         .write()

--- a/crack-core/src/commands/settings/toggle/toggle_autopause.rs
+++ b/crack-core/src/commands/settings/toggle/toggle_autopause.rs
@@ -43,7 +43,10 @@ pub async fn toggle_autopause_internal(
     guild_name: Option<FixedString>,
     prefix: String,
 ) -> Result<GuildSettings, CrackedError> {
-
+    // 🔑 Before mutating: make sure what is in memory came from Postgres. A
+    // guild whose boot load failed holds defaults, and `save()` below is a
+    // full-row upsert that would write them over its stored row.
+    data.ensure_settings_loaded(guild_id).await?;
 
     let res = data
         .guild_settings_map

--- a/crack-core/src/guild/operations.rs
+++ b/crack-core/src/guild/operations.rs
@@ -6,7 +6,7 @@ use serenity::{
 use std::str::FromStr;
 use std::{future::Future, sync::Arc};
 
-use super::settings::DEFAULT_VOLUME_LEVEL;
+use super::settings::{Provenance, DEFAULT_VOLUME_LEVEL};
 
 pub trait GuildSettingsOperations {
     fn get_guild_settings(&self, guild_id: GuildId) -> impl Future<Output = Option<GuildSettings>>;
@@ -21,7 +21,7 @@ pub trait GuildSettingsOperations {
         name: Option<String>,
         prefix: Option<&str>,
     ) -> impl Future<Output = GuildSettings>;
-    fn save_guild_settings(
+    fn ensure_settings_loaded(
         &self,
         guild_id: GuildId,
     ) -> impl Future<Output = Result<(), CrackedError>>;
@@ -115,17 +115,79 @@ impl GuildSettingsOperations for Data {
             .or_insert_with(|| GuildSettings::new(guild_id, None, None));
     }
 
-    /// Save the guild settings to the database.
+    /// Make sure this guild's in-memory settings came from Postgres, before a
+    /// command mutates them and writes them back.
     ///
-    /// Writes back without checking `Provenance`; currently unused. Anything
-    /// wiring this up must check `is_persistable()` first or it will overwrite
-    /// stored settings with fallback defaults.
-    async fn save_guild_settings(&self, guild_id: GuildId) -> Result<(), CrackedError> {
-        let opt_settings = self.guild_settings_map.read().await;
-        let settings = opt_settings.get(&guild_id);
+    /// 🔑 **Call this before any command path that ends in
+    /// [`GuildSettings::save`].** A guild whose boot load failed is holding
+    /// `GuildSettings::new()` defaults. `save()` is a full-row 14-column
+    /// upsert, so mutating those defaults and saving them replaces the guild's
+    /// stored row wholesale -- the same unrecoverable loss the shutdown
+    /// handler's `is_persistable()` guard prevents, reached through a
+    /// different door. See [`crate::guild::settings::Provenance`].
+    ///
+    /// 🪤 **The guard belongs here, not inside `save()`.** `save()` itself
+    /// calls `get_or_create`, so a blanket `is_persistable()` check in there
+    /// would refuse the legitimate first write for a guild that has no row
+    /// yet, silently doing nothing.
+    ///
+    /// Returns `Ok(())` and changes nothing when there is no pool: with no
+    /// database there is nothing to overwrite and no write to guard.
+    ///
+    /// No lock is held across the `get_or_create` await -- both read guards
+    /// below are statement-scoped temporaries. There is a benign race: a
+    /// concurrent command could mutate the map between the read and the write,
+    /// and lose that mutation to the freshly-loaded row. Deliberately not
+    /// serialised, because the harm is bounded to an in-memory change on
+    /// settings that were `Fallback` and therefore unsafe to persist anyway --
+    /// the stored row, which is what this guard protects, is never at risk.
+    async fn ensure_settings_loaded(&self, guild_id: GuildId) -> Result<(), CrackedError> {
+        let Some(pool) = self.database_pool.as_ref() else {
+            return Ok(());
+        };
 
-        let pg_pool = self.database_pool.clone().unwrap();
-        settings.map(|s| s.save(&pg_pool)).unwrap().await
+        // Already round-tripped through Postgres -- nothing to do. Read lock is
+        // dropped before the await below.
+        if self
+            .guild_settings_map
+            .read()
+            .await
+            .get(&guild_id)
+            .is_some_and(|s| s.is_persistable())
+        {
+            return Ok(());
+        }
+
+        let name = self
+            .guild_settings_map
+            .read()
+            .await
+            .get(&guild_id)
+            .map(|s| s.guild_name.clone())
+            .unwrap_or_default();
+        let prefix = self.bot_settings.get_prefix();
+
+        // 🪤 Returning Err here is the point: the caller must NOT fall through to
+        // `save()`. If the row cannot be read, whatever is in memory is still
+        // defaults, and writing those back is the loss this guard exists to
+        // stop. The detail goes to the log; the caller only needs "not safe".
+        let (_guild, settings) =
+            crate::db::GuildEntity::get_or_create(pool, guild_id.get() as i64, name, prefix)
+                .await
+                .map_err(|err| {
+                    tracing::error!(
+                        "Refusing to write guild {guild_id} settings: could not re-load \
+                         them from the database: {err}"
+                    );
+                    CrackedError::Other("guild settings could not be loaded; refusing to overwrite")
+                })?;
+
+        self.guild_settings_map
+            .write()
+            .await
+            .insert(guild_id, settings.with_provenance(Provenance::Database));
+
+        Ok(())
     }
 
     /// Get the idle timeout for the bot in VC for the guild.
@@ -712,5 +774,108 @@ mod test {
         })));
 
         assert!(!data.get_autoplay(guild_id).await);
+    }
+
+    /// With no pool there is nothing to overwrite and no write to guard, so the
+    /// helper must succeed and leave the map exactly as it found it. This is
+    /// production's configuration today, so it is the case that must not break.
+    #[tokio::test]
+    async fn ensure_settings_loaded_is_a_noop_without_a_pool() {
+        use crate::guild::settings::Provenance;
+
+        let guild_id = GuildId::new(1);
+        let mut map = HashMap::new();
+        map.insert(guild_id, GuildSettings::new(guild_id, Some("!"), None));
+        let data = Data::default().with_guild_settings_map(Arc::new(RwLock::new(map)));
+
+        assert!(
+            data.database_pool.is_none(),
+            "this test needs the no-pool path"
+        );
+
+        data.ensure_settings_loaded(guild_id)
+            .await
+            .expect("must succeed with no pool");
+
+        let after = data
+            .get_guild_settings(guild_id)
+            .await
+            .expect("still present");
+        assert_eq!(
+            after.provenance,
+            Provenance::Fallback,
+            "with no pool nothing round-tripped through Postgres, so the tag must stay Fallback"
+        );
+        assert_eq!(after.prefix, "!", "settings must be untouched");
+    }
+
+    /// A guild absent from the map is also a no-op without a pool -- the helper
+    /// must not invent an entry, because an invented entry is exactly the
+    /// fallback-default value that must never be written back.
+    #[tokio::test]
+    async fn ensure_settings_loaded_does_not_invent_an_entry_without_a_pool() {
+        let guild_id = GuildId::new(42);
+        let data = Data::default().with_guild_settings_map(Arc::new(RwLock::new(HashMap::new())));
+
+        data.ensure_settings_loaded(guild_id)
+            .await
+            .expect("must succeed with no pool");
+
+        assert!(
+            data.get_guild_settings(guild_id).await.is_none(),
+            "the helper must not create a Fallback entry that a later save() could write back"
+        );
+    }
+
+    /// 🔑 The regression this whole change exists to prevent: a NEW command that
+    /// writes guild settings back but forgets the guard.
+    ///
+    /// Every command file that calls `GuildSettings::save` must also call
+    /// `ensure_settings_loaded`. Reading the tree is the only way to assert
+    /// this -- there is no type that forces it, and the failure is silent.
+    #[test]
+    fn every_command_that_saves_settings_also_guards_first() {
+        use std::path::Path;
+
+        fn walk(dir: &Path, out: &mut Vec<(String, String)>) {
+            for entry in std::fs::read_dir(dir).expect("readable") {
+                let path = entry.expect("entry").path();
+                if path.is_dir() {
+                    walk(&path, out);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    let src = std::fs::read_to_string(&path).expect("readable");
+                    out.push((path.display().to_string(), src));
+                }
+            }
+        }
+
+        let mut files = Vec::new();
+        walk(Path::new("src/commands"), &mut files);
+        assert!(!files.is_empty(), "found no command sources to scan");
+
+        let mut unguarded = Vec::new();
+        for (path, src) in &files {
+            // The bug needs BOTH halves: read the in-memory settings map, then
+            // write it back. A file that saves some other type (GpSaved,
+            // WelcomeSettings) never touches `guild_settings_map` and so cannot
+            // be this bug -- requiring both keeps the scan precise instead of
+            // maintaining a list of filenames to skip.
+            let saves = src
+                .lines()
+                .filter(|l| !l.trim_start().starts_with("//"))
+                .any(|l| l.contains(".save(&pool)") || l.contains(".save(&pg_pool)"));
+            let reads_the_map =
+                src.contains("guild_settings_map") || src.contains("get_guild_settings");
+            if saves && reads_the_map && !src.contains("ensure_settings_loaded") {
+                unguarded.push(path.clone());
+            }
+        }
+
+        assert!(
+            unguarded.is_empty(),
+            "these command files write guild settings back without first calling \
+             ensure_settings_loaded, which lets a guild whose load failed overwrite \
+             its stored row with defaults: {unguarded:#?}"
+        );
     }
 }

--- a/crack-core/src/guild/settings.rs
+++ b/crack-core/src/guild/settings.rs
@@ -1095,20 +1095,6 @@ impl GuildSettings {
     }
 }
 
-/// Save the guild settings to the database.
-///
-/// Writes back without checking `Provenance`; currently unused. Anything
-/// wiring this up must check `is_persistable()` first or it will overwrite
-/// stored settings with fallback defaults.
-pub async fn save_guild_settings(
-    guild_settings_map: &HashMap<GuildId, GuildSettings>,
-    pool: &PgPool,
-) {
-    for guild_settings in guild_settings_map.values() {
-        let _ = guild_settings.save(pool).await;
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct CommandSettingsMap;
 

--- a/crack-core/src/handlers/serenity.rs
+++ b/crack-core/src/handlers/serenity.rs
@@ -464,44 +464,6 @@ impl SerenityHandler {
     //     );
     // }
 
-    async fn _load_guilds_settings(&self, ctx: &SerenityContext, ready: &Ready) {
-        let prefix = self.data.bot_settings.get_prefix();
-        tracing::info!("Loading guilds' settings");
-
-        for guild in &ready.guilds {
-            let guild_id = guild.id;
-            let guild_name = match guild_id.to_guild_cached(&ctx.cache) {
-                Some(guild_match) => guild_match.name.clone(),
-                None => {
-                    tracing::error!("Guild not found in cache");
-                    continue;
-                },
-            };
-            let to_write = guild_name.clone();
-            tracing::info!("Loading guild settings for {guild_id}, {to_write}");
-
-            let mut default = GuildSettings::new(guild_id, Some(&prefix), Some(guild_name));
-
-            let pool = self.data.database_pool.clone().unwrap();
-            let _ = default.load_if_exists(&pool).await.map_err(|err| {
-                tracing::error!("Failed to load guild {} settings due to {}", guild_id, err);
-            });
-
-            tracing::warn!("GuildSettings: {:?}", default);
-
-            self.data
-                .guild_settings_map
-                .write()
-                .await
-                .insert(guild_id, default.clone());
-
-            match default.save(&pool).await {
-                Ok(()) => tracing::info!("Saved guild {to_write}..."),
-                Err(err) => tracing::error!("Failed to save guild {to_write} due to {err}"),
-            }
-        }
-    }
-
     async fn self_deafen(&self, ctx: &SerenityContext, guild: Option<GuildId>, new: VoiceState) {
         if self.data.bot_settings.self_deafen.is_some() {
             return;

--- a/crack-gpt/Cargo.toml
+++ b/crack-gpt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-gpt"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-osint/Cargo.toml
+++ b/crack-osint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-osint"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-sleevenote/Cargo.toml
+++ b/crack-sleevenote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-sleevenote"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-testing/Cargo.toml
+++ b/crack-testing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "crack-testing"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/crack-types/Cargo.toml
+++ b/crack-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-types"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-voting/Cargo.toml
+++ b/crack-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-voting"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true


### PR DESCRIPTION
Closes #482. The second of the two gates on setting `DATABASE_URL` on production.

## Root cause

v0.9.1 (#483) stopped the **shutdown handler** writing fallback defaults over a guild's stored settings. That guarded **one of eight** write-back sites.

Seven command paths still take a value straight out of the in-memory settings map and call `save()`, which is a full-row 14-column upsert. So a guild whose boot load failed — sitting on `GuildSettings::new()` defaults with `Provenance::Fallback` — had its stored row replaced the moment anyone ran one of those commands. Same unrecoverable loss, different door. The shutdown fix closed the door that fires once per restart and left open the seven that fire on user action.

## Fix

`Data::ensure_settings_loaded(guild_id)` re-attempts `GuildEntity::get_or_create` and upgrades provenance when a guild is sitting on `Fallback`; it returns `Err` when the re-load fails. All eight write-back sites call it before mutating.

🪤 **The guard is deliberately NOT inside `save()`.** `save()` itself calls `get_or_create`, so a blanket `is_persistable()` check there would refuse the legitimate *first* write for a guild that has no row yet — silently doing nothing. Returning `Err` from the helper is the point: a caller that cannot re-load must not fall through to `save()`.

## 🔴 Found along the way: `deauthorize` never persisted

`authorize` saved. `deauthorize` only mutated memory. A crash, an OOM kill, or a guild skipped at shutdown for holding `Fallback` settings would **silently restore access that had been deliberately revoked**. It now saves, behind the same guard.

## Also in this PR

- **Four `database_pool.clone().unwrap()`** calls on those same lines → `ok_or`. They panicked on a tokio worker whenever there was no pool, which is production's deliberate configuration *today*.
- **Three dead unguarded write-backs deleted** rather than guarded: the free `save_guild_settings` in `guild/settings.rs`, the trait method of the same name in `operations.rs`, and `handlers/serenity.rs`'s `_load_guilds_settings` — which also unwrapped the pool and discarded a failed load before saving the defaults it was left holding. `on_guild_create` already does that job correctly per guild; the `Ready`-based bulk loader it descends from never completed at ~139 guilds.

## Test

A source-scanning test asserts that every command file which **both** reads the settings map **and** calls `save()` also calls the guard, so a future unguarded site fails the build. **Sabotage-verified:** removing the guard from `self_deafen` makes it fail.

Full gate green locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets`, `SQLX_OFFLINE=true cargo check`, `cargo test --workspace` (except the known pre-existing `test_enqueue_query`, a deleted YouTube video id — fails on master too, fixed in #471).

Version bumped 0.9.1 → 0.9.2 across all nine members.

Spec: `docs/superpowers/specs/2026-09-11-production-database-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8PrF3gizKqXCStjCuWL3d
