### PR TITLE
fix(playback): actually write play history, and stop panicking without a pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,14 +1012,14 @@ dependencies = [
 
 [[package]]
 name = "crack-bf"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "crack-core"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "crack-gpt"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-openai",
  "const_format",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "crack-osint"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "crack-types",
  "ipinfo",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "crack-sleevenote"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "crack-testing"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "crack-types"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "humantime",
  "poise",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "crack-voting"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "chrono",
  "dbl-rs",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "cracktunes"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "config-file",
  "crack-core",

--- a/crack-bf/Cargo.toml
+++ b/crack-bf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-bf"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-cli/Cargo.toml
+++ b/crack-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "cracktunes"
-version = "0.9.2"
+version = "0.9.3"
 description = "Cracktunes is a hassle-free, highly performant, host-it-yourself, cracking smoking, discord-music-bot."
 publish = true
 edition = "2021"

--- a/crack-core/Cargo.toml
+++ b/crack-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-core"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 edition = "2021"
 description = "Core module for the cracking smoking, discord-music-bot Cracktunes."

--- a/crack-core/src/music/queue.rs
+++ b/crack-core/src/music/queue.rs
@@ -3,6 +3,7 @@ use crate::{
     handlers::track_end::update_queue_messages,
     http_utils::CacheHttpExt,
     music::{NewQueryType, PlaybackOwner, QueueGuard},
+    poise_ext::ContextExt,
     utils::{set_track_handle_metadata, set_track_handle_requesting_user, TrackData},
     Context as CrackContext, Error,
 };
@@ -303,8 +304,10 @@ pub async fn queue_track_front(
 ) -> Result<Vec<TrackHandle>, CrackedError> {
     let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
     let ready_track = ready_query(ctx, query_type.clone()).await?;
-    // FIXME:
-    //ctx.async_send_track_metadata_write_msg(&ready_track);
+    // Logged BEFORE the guard is taken and before `ready_track` is moved into
+    // the enqueue below. The send is a non-blocking channel push, so it costs
+    // the play path nothing.
+    ctx.send_track_metadata_write_msg(&ready_track);
     let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let q = queue_track_ready_front(&guard, call, ready_track).await?;
     Ok(q)
@@ -337,6 +340,11 @@ pub async fn queue_track_back(
             match e1.into() {
                 Some(_e) => {
                     let ready_track = ready_query(ctx, query_type.clone()).await?;
+                    // 🪤 This branch RETURNS, so the send below never runs for
+                    // it. A play that fell back to `ready_query` is still a
+                    // play and must be logged here, or the fallback path stays
+                    // silently unlogged exactly as it was before this fix.
+                    ctx.send_track_metadata_write_msg(&ready_track);
                     let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
                     return _queue_track_ready_back(&guard, call, ready_track).await;
                 },
@@ -349,8 +357,12 @@ pub async fn queue_track_back(
         },
     };
     let after_ready = std::time::Instant::now();
-    // FIXME:
-    //ctx.async_send_track_metadata_write_msg(&ready_track);
+    // 🪤 `ready_track` is NOT in scope here -- it exists only in the fallback
+    // branch above, which returns. This leg goes `ct_client` -> ResolvedTrack
+    // and never builds one, which is why simply uncommenting the old
+    // `//ctx.async_send_track_metadata_write_msg(&ready_track);` line did not
+    // even compile, and why this path needs its own sender.
+    ctx.send_resolved_metadata_write_msg(&resolved);
     let after_send = std::time::Instant::now();
     //let queue = queue_track_ready_back(call, ready_track).await;
     let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
@@ -1213,6 +1225,75 @@ mod queue_query_list_offset_ordering_tests {
              length is read and acted on, the check-then-act race this \
              guard exists to close (fixed in 6f2d8b4) is back: the length \
              can go stale between the check and the insert."
+        );
+    }
+}
+
+#[cfg(test)]
+mod play_history_wiring_tests {
+    //! Regression guard for #486.
+    //!
+    //! Play history was never written on ANY commit in this repo's history:
+    //! both metadata-write call sites in this file sat commented out behind a
+    //! `// FIXME:`, and the channel-based sender had zero callers, so the
+    //! worker `config.rs` spawns idled forever on a channel nothing fed. The
+    //! visible symptom was not an empty `/playlog` -- it was autoplay failing
+    //! with "I can't pick a next track right now", because
+    //! `track_end.rs::get_recommended_track_query` seeds Spotify from
+    //! `get_last_played_by_guild`, which returned nothing.
+    //!
+    //! That is invisible by construction: a missing call emits no log line and
+    //! no error, so nothing short of reading the source or querying the
+    //! database reveals it. Hence a source scan rather than a behavioural test
+    //! -- the write path needs a live songbird `Call` and a real voice
+    //! connection to exercise, which is why it went unnoticed for years.
+
+    /// 🪤 The scan STOPS at the first `#[cfg(test)]`. This test module names
+    /// the very functions it is counting, so scanning the whole file would
+    /// count this doc comment and pass vacuously no matter what the real code
+    /// did -- the same self-referential trap that made an earlier version of
+    /// the #484 guard unable to ever fail.
+    fn production_source() -> String {
+        let src = std::fs::read_to_string("src/music/queue.rs").expect("readable");
+        let end = src
+            .find("#[cfg(test)]")
+            .expect("this file has test modules");
+        src[..end].to_string()
+    }
+
+    /// Count call sites, ignoring commented-out ones -- the exact state #486
+    /// was in.
+    fn live_call_sites(src: &str, needle: &str) -> usize {
+        src.lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .filter(|l| l.contains(needle))
+            .count()
+    }
+
+    #[test]
+    fn both_queue_paths_still_log_play_history() {
+        let src = production_source();
+
+        // `queue_track_front`, plus the `ready_query` FALLBACK branch inside
+        // `queue_track_back` -- that branch returns early, so it needs its own
+        // send and is the easiest of the three to drop in a refactor.
+        let ready = live_call_sites(&src, "send_track_metadata_write_msg(");
+        assert!(
+            ready >= 2,
+            "expected at least 2 live send_track_metadata_write_msg call sites \
+             (queue_track_front, and queue_track_back's ready_query fallback), \
+             found {ready}. Play history stops being written and autoplay dies \
+             with it -- silently, with no error in the log."
+        );
+
+        // `queue_track_back`'s fast leg goes ct_client -> ResolvedTrack and
+        // never builds a TrackReadyData, so it cannot use the sender above.
+        let resolved = live_call_sites(&src, "send_resolved_metadata_write_msg(");
+        assert!(
+            resolved >= 1,
+            "expected at least 1 live send_resolved_metadata_write_msg call site \
+             (queue_track_back's resolved fast path), found {resolved}. This is \
+             the leg MOST plays take, so losing it loses nearly all history."
         );
     }
 }

--- a/crack-core/src/poise_ext.rs
+++ b/crack-core/src/poise_ext.rs
@@ -8,10 +8,12 @@ use crate::{
 };
 use colored::Colorize;
 use core::panic;
+use crack_testing::ResolvedTrack;
 use crack_types::NewAuxMetadata;
 use poise::serenity_prelude as serenity;
 use poise::{CreateReply, ReplyHandle};
 use serenity::all::{CreateEmbed, GenericChannelId, GuildId, Message, UserId};
+use songbird::input::AuxMetadata;
 use songbird::tracks::{PlayMode, TrackQueue};
 use songbird::Call;
 use std::{future::Future, sync::Arc};
@@ -21,6 +23,20 @@ use tokio::sync::Mutex;
 pub trait ContextExt<'ctx> {
     /// Send a message to tell the worker pool to do a db write when it feels like it.
     fn send_track_metadata_write_msg(self, ready_track: &TrackReadyData);
+    /// Same, for the resolved path. `queue_track_back`'s fast leg never builds a
+    /// [`TrackReadyData`] -- it goes straight from `ct_client` to a
+    /// [`ResolvedTrack`] -- so without this overload that path has no way to log
+    /// a play at all.
+    fn send_resolved_metadata_write_msg(self, resolved: &ResolvedTrack<'_>);
+    /// The one place a [`MetadataMsg`] is actually put on the worker channel.
+    /// Both senders above funnel through it so the "no channel means no pool,
+    /// degrade quietly" rule lives in exactly one place.
+    fn queue_metadata_write(
+        self,
+        aux_metadata: AuxMetadata,
+        user_id: Option<UserId>,
+        username: Option<String>,
+    );
     fn async_send_track_metadata_write_msg(
         self,
         ready_track: &TrackReadyData,
@@ -127,7 +143,11 @@ impl<'ctx> ContextExt<'ctx> for crate::Context<'ctx> {
         let username = ready_track.username.clone();
         let NewAuxMetadata(aux_metadata) = ready_track.metadata.clone();
         let user_id = ready_track.user_id;
-        let guild_id = self.guild_id().unwrap();
+        // 🪤 Both of these were `.unwrap()`. This runs on a tokio worker, so a
+        // DM context (no guild) or a deployment with no `DATABASE_URL` -- still
+        // a supported mode, since rollback is "delete DATABASE_URL" -- panicked
+        // the worker rather than skipping a log line nobody reads.
+        let guild_id = self.guild_id().ok_or(CrackedError::NoGuildId)?;
         let channel_id = self.channel_id();
 
         let write_data: MetadataMsg = MetadataMsg {
@@ -138,30 +158,71 @@ impl<'ctx> ContextExt<'ctx> for crate::Context<'ctx> {
             channel_id,
         };
 
-        let pool = self.data().get_db_pool().unwrap();
+        let pool = self.data().get_db_pool()?;
         crate::db::write_metadata_pg(&pool, write_data).await?;
         Ok(())
     }
 
+    fn queue_metadata_write(
+        self,
+        aux_metadata: AuxMetadata,
+        user_id: Option<UserId>,
+        username: Option<String>,
+    ) {
+        // 🔑 `db_channel` is None exactly when there is no pool, which is still
+        // a supported deployment (rollback is "delete DATABASE_URL"). Returning
+        // quietly is the whole reason this is the safe sender: the async one
+        // needs a pool in hand and errors without it.
+        let Some(channel) = &self.data().db_channel else {
+            return;
+        };
+        // 🪤 Was `.unwrap()` in both senders. These run from command paths that
+        // are guild-only today, but a panic here takes a tokio worker down over
+        // a log line; skipping the write is the right failure.
+        let Some(guild_id) = self.guild_id() else {
+            tracing::debug!("no guild id on context; skipping play log");
+            return;
+        };
+        let write_data: MetadataMsg = MetadataMsg {
+            aux_metadata,
+            user_id,
+            username,
+            guild_id,
+            channel_id: self.channel_id(),
+        };
+        // try_send, not send: the worker owns a 1024-deep channel, and a full
+        // one means the writer is wedged. Blocking the PLAY path on a wedged
+        // logger is strictly worse than dropping the log line.
+        if let Err(e) = channel.try_send(write_data) {
+            tracing::error!("Error sending metadata to db_channel: {}", e);
+        }
+    }
+
     /// Send a message to tell the worker pool to do a db write when it feels like it.
     fn send_track_metadata_write_msg(self, ready_track: &TrackReadyData) {
-        let username = ready_track.username.clone();
         let NewAuxMetadata(aux_metadata) = ready_track.metadata.clone();
-        let user_id = ready_track.user_id;
-        let guild_id = self.guild_id().unwrap();
-        let channel_id = self.channel_id();
-        if let Some(channel) = &self.data().db_channel {
-            let write_data: MetadataMsg = MetadataMsg {
-                aux_metadata,
-                user_id,
-                username,
-                guild_id,
-                channel_id,
-            };
-            if let Err(e) = channel.try_send(write_data) {
-                tracing::error!("Error sending metadata to db_channel: {}", e);
-            }
-        }
+        self.queue_metadata_write(
+            aux_metadata,
+            ready_track.user_id,
+            ready_track.username.clone(),
+        );
+    }
+
+    /// Send a message to tell the worker pool to do a db write when it feels like it.
+    ///
+    /// 🪤 [`ResolvedTrack`] carries no username -- it is built by `ct_client`,
+    /// which never saw the invoking message -- so the author's name is taken
+    /// from the context here. Passing `None` instead would write every play
+    /// under an empty username.
+    fn send_resolved_metadata_write_msg(self, resolved: &ResolvedTrack<'_>) {
+        let Some(aux_metadata) = resolved.metadata.clone() else {
+            // A resolve that produced no metadata has nothing to log. Not an
+            // error: the track still plays.
+            tracing::debug!("no metadata on resolved track; skipping play log");
+            return;
+        };
+        let username = Some(self.author().name.to_string());
+        self.queue_metadata_write(aux_metadata, Some(resolved.user_id), username);
     }
 
     /// Return the call that the bot is currently in, if it is in one.

--- a/crack-gpt/Cargo.toml
+++ b/crack-gpt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-gpt"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-osint/Cargo.toml
+++ b/crack-osint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-osint"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-sleevenote/Cargo.toml
+++ b/crack-sleevenote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-sleevenote"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-testing/Cargo.toml
+++ b/crack-testing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "crack-testing"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/crack-types/Cargo.toml
+++ b/crack-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-types"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-voting/Cargo.toml
+++ b/crack-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-voting"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true


### PR DESCRIPTION
Closes #486.

## Root cause

**Play history has never been written, on any commit in this repo's history.** Both metadata-write call sites in `music/queue.rs` sat commented out behind a `// FIXME:`, and the channel-based sender had **zero callers** — so the worker `config.rs:286` spawns idled forever on a channel nothing ever fed.

Confirmed against both tenants: `play_log`, `metadata` and `user` are **0 rows** while `guild` is 139 and `gp_game` has rows — the database plumbing was fine, only this path was disconnected.

The lines were commented out years ago while debugging a queue performance problem (double-resolution), to remove a variable. **That underlying problem was fixed at the start of this arc** (`6f2d8b4`, then the ownership lease in v0.9.0), so the original reason for the comment is gone.

## 🔑 The visible symptom was not an empty `/playlog`

It was **autoplay failing**:

```
WARN crack_core::handlers::track_end: autoplay disabled for <guild>:
     ⚠️ **I can't pick a next track right now.**
```

`track_end.rs::get_recommended_track_query` seeds Spotify recommendations from `get_last_played_by_guild`, which returned nothing. That has been **indistinguishable from a Spotify API problem** this whole time.

## 🪤 Three call sites, not two — and two different senders

My own first read of this (in the issue) was wrong, and is corrected there. In `queue_track_back`, `ready_track` is **not in scope** at the commented-out line — it exists only inside the `Err` fallback branch, which `return`s early. The fast leg goes `ct_client` → `ResolvedTrack` and never builds a `TrackReadyData`, so **simply uncommenting the old line does not compile.**

| site | in scope | sender |
|---|---|---|
| `queue_track_front` | `TrackReadyData` | `send_track_metadata_write_msg` |
| `queue_track_back` **fallback branch** | `TrackReadyData` | `send_track_metadata_write_msg` |
| `queue_track_back` **resolved fast path** | `ResolvedTrack` | new `send_resolved_metadata_write_msg` |

The fallback branch is the easy one to miss precisely *because* it returns before reaching the FIXME.

🪤 `ResolvedTrack` carries **no username** — it is built by `ct_client`, which never saw the invoking message — so the new sender takes the author's name from the context. Passing `None` would have written every play under an empty username.

## Uses the channel sender, not the async one

`async_send_track_metadata_write_msg` needs a pool in hand. The channel sender is `if let Some(channel)` and degrades quietly when there is none, which is **still a supported deployment** since rollback is "delete `DATABASE_URL`". It also keeps the write off the play path, which matters because `resolve_track_many` is 8–15s cold.

## Three panics removed

`get_db_pool().unwrap()` plus **two** `guild_id().unwrap()` calls in the senders — all on a tokio worker. A panic over a log line nobody reads is strictly worse than skipping the log line. Both senders now funnel through one `queue_metadata_write`, so the degrade-without-a-pool rule lives in exactly one place.

## The guard test, and why it is a source scan

Behaviour here needs a live songbird `Call` and a real voice connection — which is exactly why this went unnoticed for years: **a missing call emits no log line and no error.** So the wiring is guarded by a source scan, in the shape of #484's.

🪤 **The scan stops at the first `#[cfg(test)]`.** The test module names the very functions it counts, so scanning the whole file would count its own doc comment and pass vacuously no matter what the real code did — the same self-referential trap that bit an earlier draft of the #484 guard.

**Sabotage-verified three ways**, by running the built test binary against a temporarily-edited source:

| sabotage | result |
|---|---|
| comment the resolved send | ✅ FAIL — "found 0 … the leg MOST plays take" |
| comment the fallback send | ✅ FAIL — "found 1", *with the commented line still in the file*, proving the comment filter works |
| restore the original #486 state (all three commented) | ✅ FAIL — the guard would have caught the original bug |
| restore | ✅ PASS, file byte-identical |

## Semantics worth noting

The write happens at **enqueue** time, not at track-end — the same placement the original commented-out call had. So `/playlog` reflects what was queued, which is also the right seed for autoplay recommendations.

`gp.rs` uses `enqueue_track_back` directly and is deliberately untouched.

## Gate

`cargo fmt --check`, `cargo clippy --workspace --all-targets`, `SQLX_OFFLINE=true cargo check --workspace`, and `cargo test --workspace` all clean except the known pre-existing `crack-testing::tests::test_enqueue_query` (deleted YouTube video id; fails on master too, fixed in #471).

Version bumped 0.9.2 → 0.9.3 across all nine members.

⚠️ Final proof is a real play after deploy — `select count(*) from play_log` should go from 0 to 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8PrF3gizKqXCStjCuWL3d
