### PR TITLE
ci: retire the tarpaulin coverage job, and stop httpbin owning CI's signal

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,24 @@
 name: coverage
 
-on: [push]
+# 🔴 DISABLED 2026-09-12: manual-only, was `on: [push]`.
+#
+# tarpaulin took 9-16 minutes on EVERY push -- tags included, so it ran twice
+# more during each release -- making it far and away the slowest job in the
+# repo. It gated nothing: master's branch protection lists no required status
+# checks, so a red coverage run never blocked anything, and nobody was reading
+# the codecov result.
+#
+# Kept rather than deleted because the scaffolding below is the expensive part
+# and a replacement needs all of it verbatim: a real Postgres service, `sqlx
+# database create` + `migrate run`, `cargo sqlx prepare`, and the three
+# `db-tests` features. Only the measurement tool should change.
+#
+# 🔑 When replacing it, prefer `cargo-llvm-cov` over tarpaulin: it uses LLVM
+# source-based coverage instead of ptrace, runs on stable rather than nightly,
+# needs no separate instrumented rebuild of the world, and emits lcov for the
+# same codecov upload. Point it at the same env this job already sets up.
+on:
+  workflow_dispatch:
 
 # Least privilege: these jobs only check out and build.
 permissions:

--- a/README.md
+++ b/README.md
@@ -157,11 +157,20 @@ cargo +nightly test --all-features --workspace
 
 Some tests are available inside the `src/tests` folder, others are in their respective
 files. It's recommended that you run the tests before submitting a Pull Request.
-Increasing the test coverage is also welcome. Test coverage is tracked using
-[tarpaulin]().
+Increasing the test coverage is also welcome.
+
+Coverage is **not measured in CI right now.** The tarpaulin job took 9-16
+minutes on every push, gated nothing, and nobody read its output, so it was
+made manual-only (`workflow_dispatch`) in `.github/workflows/coverage.yml`
+pending a faster replacement -- most likely
+[cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov), which uses LLVM
+source-based coverage and runs on stable.
+
+To measure locally in the meantime:
 
 ```shell
-cargo +nightly tarpaulin --all-features --workspace
+cargo install cargo-llvm-cov
+cargo llvm-cov --workspace
 ```
 
 ## Linting

--- a/crack-types/src/http.rs
+++ b/crack-types/src/http.rs
@@ -29,6 +29,21 @@ pub async fn resolve_final_url2(client: Client, url: Url) -> Result<Url, Error> 
 mod test {
     use super::*;
 
+    // 🪤 IGNORED, not deleted, and not gated on `env::var("CI")`. These two
+    // reach httpbin.org -- a live third party -- so their pass/fail is owned by
+    // someone else's uptime. They failed the v0.9.2 `coverage` run and again on
+    // the v0.9.4 `Build` run, both times while passing locally, and both times
+    // costing a real investigation before the cause turned out to be "httpbin
+    // was unreachable from GitHub's runners".
+    //
+    // `#[ignore]` and not a CI guard: a guard that skips the body and returns
+    // Ok is a VACUOUS PASS -- the suite reports green for a test that never
+    // ran. An ignored test is reported as ignored, which is the honest answer.
+    // Same reasoning as ct#448/#449 for the live-YouTube tests.
+    //
+    // Run them deliberately with `cargo test -p crack-types -- --ignored`.
+    // The two `test_parse_url*` tests below are pure and keep running.
+    #[ignore = "hits httpbin.org; a third party's uptime is not this repo's CI signal"]
     #[tokio::test]
     async fn test_resolve_final_url() {
         let client = reqwest::Client::new();
@@ -37,6 +52,7 @@ mod test {
         assert_eq!(final_url.as_str(), "https://example.com/");
     }
 
+    #[ignore = "hits httpbin.org; a third party's uptime is not this repo's CI signal"]
     #[tokio::test]
     async fn test_resolve_final_url2() {
         let client = reqwest::Client::new();


### PR DESCRIPTION
Two CI-hygiene changes. Both are about **CI spending time and credibility on things nobody can act on.** Closes #485.

## 1. The tarpaulin coverage job → manual-only

| | |
|---|---|
| ran on | **every push** — `on: [push]`, tags included, so twice more per release |
| duration | **9–16 min** — the slowest job in the repo |
| required status check? | **no** — master's branch protection lists none, so a red run never blocked a merge |
| anyone reading codecov? | no |

`on: [push]` → `on: workflow_dispatch`. **Switched off, not deleted:** the scaffolding is the expensive part and a replacement needs all of it verbatim — a real Postgres service, `sqlx database create` + `migrate run`, `cargo sqlx prepare`, and the three `db-tests` features. Only the measurement tool should change.

Suggested replacement, recorded in the workflow and README: [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) — LLVM source-based coverage instead of ptrace, **stable** rather than nightly, no separate instrumented rebuild, and it emits lcov for the same codecov upload.

Also fixes the README, which pointed at a tarpaulin link with an **empty target** and told contributors to run a tool CI no longer runs.

## 2. Ignore the two httpbin.org tests (#485)

`crack-types`'s `test_resolve_final_url` / `_url2` reach **httpbin.org**, a live third party, so their pass/fail belongs to someone else's uptime.

They failed the **v0.9.2 `coverage`** run and again on the **v0.9.4 `Build`** run — both times passing locally, both times costing a real investigation that resolved to "httpbin was unreachable from GitHub's runners". `http.rs` was last touched in v0.3.14, so neither failure was ever a regression.

🪤 **`#[ignore]`, not a gate on `env::var("CI")`.** A guard that skips the body and returns Ok is a **vacuous pass** — the suite reports green for a test that never ran, which is worse than a red one. An ignored test reports as ignored. Same reasoning as #448/#449 for the live-YouTube tests.

The two pure `parse_url` tests in the same module keep running. Run the ignored ones deliberately with `cargo test -p crack-types -- --ignored`.

## No version bump

CI, docs and tests only — ships no artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8PrF3gizKqXCStjCuWL3d
