### PR TITLE
fix(sleevenote): model extraction_silent, and retry it once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,14 +1012,14 @@ dependencies = [
 
 [[package]]
 name = "crack-bf"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "crack-core"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "crack-gpt"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "async-openai",
  "const_format",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "crack-osint"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "crack-types",
  "ipinfo",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "crack-sleevenote"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "crack-testing"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "crack-types"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "humantime",
  "poise",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "crack-voting"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "chrono",
  "dbl-rs",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "cracktunes"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "config-file",
  "crack-core",

--- a/crack-bf/Cargo.toml
+++ b/crack-bf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-bf"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-cli/Cargo.toml
+++ b/crack-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "cracktunes"
-version = "0.9.3"
+version = "0.9.4"
 description = "Cracktunes is a hassle-free, highly performant, host-it-yourself, cracking smoking, discord-music-bot."
 publish = true
 edition = "2021"

--- a/crack-core/Cargo.toml
+++ b/crack-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-core"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 edition = "2021"
 description = "Core module for the cracking smoking, discord-music-bot Cracktunes."

--- a/crack-core/src/messaging/messages.rs
+++ b/crack-core/src/messaging/messages.rs
@@ -210,6 +210,11 @@ pub const SPOTIFY_TIMEOUT: &str = "⏳ **Spotify took too long to answer.**\nTry
 // Deliberately offers no retry: the lookup service stopped matching Spotify's
 // page, so retrying the same link fails identically until it is fixed.
 pub const SPOTIFY_LOOKUP_BROKEN: &str = "⚠️ **Spotify lookup is broken right now.**\nThis has been logged. Search for the track by name and I'll play it.";
+/// `extraction_silent` that survived the client's retry. Unlike
+/// [`SPOTIFY_LOOKUP_BROKEN`] this one IS worth retrying -- measured at ~14%
+/// per attempt with every failing id succeeding later -- so the message says
+/// so instead of sending the user off to search by name.
+pub const SPOTIFY_LOOKUP_FLAKY: &str = "⚠️ **Spotify didn't answer that one.**\nThis usually clears on a second try — run the same link again.";
 // Distinct from the above, and the distinction is the whole reason sleevenote
 // keeps these two apart: something *was* recovered, just not all of it. The
 // service returns the shortfall rather than a partial listing, so there is

--- a/crack-core/src/sources/sleevenote.rs
+++ b/crack-core/src/sources/sleevenote.rs
@@ -23,9 +23,9 @@
 use crate::errors::CrackedError;
 use crate::http_utils;
 use crate::messaging::messages::{
-    SPOTIFY_INVALID_QUERY, SPOTIFY_LOOKUP_BROKEN, SPOTIFY_LOOKUP_FAILED, SPOTIFY_NOTHING_PLAYABLE,
-    SPOTIFY_NOT_CONFIGURED, SPOTIFY_NOT_FOUND, SPOTIFY_PARTIAL_LISTING, SPOTIFY_TIMEOUT,
-    SPOTIFY_UNREACHABLE,
+    SPOTIFY_INVALID_QUERY, SPOTIFY_LOOKUP_BROKEN, SPOTIFY_LOOKUP_FAILED, SPOTIFY_LOOKUP_FLAKY,
+    SPOTIFY_NOTHING_PLAYABLE, SPOTIFY_NOT_CONFIGURED, SPOTIFY_NOT_FOUND, SPOTIFY_PARTIAL_LISTING,
+    SPOTIFY_TIMEOUT, SPOTIFY_UNREACHABLE,
 };
 use crack_sleevenote::{
     Client as Sleevenote, ClientBuilder as SleevenoteBuilder, Error as SleevenoteError, Track,
@@ -437,8 +437,21 @@ pub fn user_message(err: &SleevenoteError) -> &'static str {
         SleevenoteError::NotFound(_) => SPOTIFY_NOT_FOUND,
         SleevenoteError::InvalidId(_) => SPOTIFY_INVALID_QUERY,
         SleevenoteError::Timeout(_) => SPOTIFY_TIMEOUT,
+        // 🔑 Retried ALREADY, by the client, and still failed -- so both
+        // attempts lost. Measured transient at ~14% per attempt, which is why
+        // this tells the user to try again where ExtractionEmpty below tells
+        // them not to bother. Logged at warn, not error: a flake that survived
+        // one retry is notable, not a service defect.
+        SleevenoteError::ExtractionSilent(_) => {
+            tracing::warn!("sleevenote extraction silent after retry: {err}");
+            SPOTIFY_LOOKUP_FLAKY
+        },
         // Not the caller's fault and not retryable by them: the service
         // stopped matching Spotify's page. Offering a retry would be a lie.
+        //
+        // 🪤 Reads almost identically to ExtractionSilent above and means
+        // something different: that one is a flake, this one is extraction
+        // genuinely no longer matching. Do not merge the arms.
         SleevenoteError::ExtractionEmpty(_) => {
             tracing::error!("sleevenote extraction returned nothing: {err}");
             SPOTIFY_LOOKUP_BROKEN

--- a/crack-gpt/Cargo.toml
+++ b/crack-gpt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-gpt"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-osint/Cargo.toml
+++ b/crack-osint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-osint"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-sleevenote/Cargo.toml
+++ b/crack-sleevenote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-sleevenote"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-sleevenote/src/client.rs
+++ b/crack-sleevenote/src/client.rs
@@ -33,6 +33,15 @@ pub const TIMEOUT_SECS_ENV: &str = "SLEEVENOTE_TIMEOUT_SECS";
 /// A warm hit still returns in single-digit milliseconds.
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(180);
 
+/// Default re-requests after an `extraction_silent` failure.
+///
+/// One, not more. Measured in production: ~14% of requests fail this way and
+/// every failing id succeeded on a later attempt, so a single retry takes
+/// user-visible failure from roughly 1-in-7 to roughly 1-in-50. A second retry
+/// would buy about another 1%, against a request that costs 4-6 seconds -- the
+/// bot is holding a Discord interaction open the whole time.
+pub const DEFAULT_EXTRACTION_SILENT_RETRIES: u8 = 1;
+
 /// The id pattern the service enforces, mirrored client-side.
 pub const ID_PATTERN: &str = "^[A-Za-z0-9]{1,64}$";
 
@@ -158,6 +167,7 @@ pub struct ClientBuilder {
     user_agent: String,
     http: Option<reqwest::Client>,
     allow_partial_listings: bool,
+    extraction_silent_retries: u8,
 }
 
 impl Default for ClientBuilder {
@@ -170,6 +180,8 @@ impl Default for ClientBuilder {
             // Strict, matching the service's own default: a caller that has
             // not thought about partial listings must not be handed one.
             allow_partial_listings: false,
+            // One retry, on `extraction_silent` alone. See the builder method.
+            extraction_silent_retries: DEFAULT_EXTRACTION_SILENT_RETRIES,
         }
     }
 }
@@ -243,6 +255,24 @@ impl ClientBuilder {
         self
     }
 
+    /// How many times to re-request after an `extraction_silent` failure.
+    ///
+    /// Defaults to [`DEFAULT_EXTRACTION_SILENT_RETRIES`]. Set `0` to disable.
+    ///
+    /// 🔑 **Only `extraction_silent` is retried, and deliberately so.** It is
+    /// the one code in the taxonomy measured as transient: production logs
+    /// show ~14% of requests failing this way and **every** failing id
+    /// succeeding on a later attempt. `extraction_empty` reads almost
+    /// identically and is NOT retried -- it means extraction genuinely stopped
+    /// matching Spotify's page, which a retry cannot fix and a deploy can.
+    /// Widening this to other codes would re-merge the taxonomy the error
+    /// module exists to keep apart.
+    #[must_use]
+    pub fn extraction_silent_retries(mut self, retries: u8) -> Self {
+        self.extraction_silent_retries = retries;
+        self
+    }
+
     /// Reuse an existing [`reqwest::Client`] and its connection pool.
     ///
     /// The timeout configured here still applies: it is set per request, so it
@@ -291,6 +321,7 @@ impl ClientBuilder {
             base_url,
             timeout: self.timeout,
             allow_partial_listings: self.allow_partial_listings,
+            extraction_silent_retries: self.extraction_silent_retries,
         })
     }
 }
@@ -313,6 +344,7 @@ pub struct Client {
     base_url: Url,
     timeout: Duration,
     allow_partial_listings: bool,
+    extraction_silent_retries: u8,
 }
 
 impl Client {
@@ -431,12 +463,51 @@ impl Client {
     }
 
     /// Issue one entity request and interpret the response.
+    /// One attempt, plus up to [`Client::extraction_silent_retries`] more on
+    /// `extraction_silent`.
+    ///
+    /// 🪤 The retry is here, at the single chokepoint every entity method
+    /// funnels through, rather than in each of `track`/`album`/`playlist`.
+    /// Putting it in the three public methods would mean a fourth endpoint
+    /// added later silently does not retry.
     async fn fetch<T: DeserializeOwned>(
         &self,
         endpoint: Endpoint,
         id: &str,
     ) -> Result<(T, Option<CacheStatus>)> {
+        // Validate ONCE, outside the loop: a bad id is not transient and
+        // re-checking it per attempt only obscures where the error came from.
         validate_id(id)?;
+
+        let mut attempt = 0u8;
+        loop {
+            let result = self.fetch_once(endpoint, id).await;
+            let Err(err) = result else { return result };
+
+            // Only `extraction_silent`, and only while attempts remain. Every
+            // other error -- including `extraction_empty`, which reads almost
+            // the same -- returns untouched.
+            if !matches!(err, Error::ExtractionSilent(_))
+                || attempt >= self.extraction_silent_retries
+            {
+                return Err(err);
+            }
+            attempt += 1;
+            tracing::warn!(
+                %id,
+                attempt,
+                retries = self.extraction_silent_retries,
+                "sleevenote returned extraction_silent; retrying: {err}"
+            );
+        }
+    }
+
+    /// A single request, with no retry policy of its own.
+    async fn fetch_once<T: DeserializeOwned>(
+        &self,
+        endpoint: Endpoint,
+        id: &str,
+    ) -> Result<(T, Option<CacheStatus>)> {
         let url = self.entity_url(endpoint, id)?;
         tracing::debug!(%url, "sleevenote request");
 
@@ -622,5 +693,134 @@ mod tests {
         assert_eq!("miss".parse(), Ok(CacheStatus::Miss));
         assert_eq!("negative".parse(), Ok(CacheStatus::Negative));
         assert_eq!("FRESH".parse::<CacheStatus>(), Err(()));
+    }
+}
+
+#[cfg(test)]
+mod retry_tests {
+    //! The `extraction_silent` retry, proven by counting REQUESTS rather than
+    //! by inspecting the returned value. A retry that quietly never re-requests
+    //! still returns the right error, so the request count is the only thing
+    //! that distinguishes "retried and both failed" from "never retried".
+    //!
+    //! A hand-rolled listener rather than a mock-server dev-dependency: the
+    //! crate's tests are otherwise offline and unit-level, and the whole
+    //! contract under test is "how many times did it ask".
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// Serves `bodies` in order, one per connection, then 200s forever.
+    /// Returns the base url and a live count of requests served.
+    async fn serve(bodies: Vec<(u16, &'static str)>) -> (String, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let hits = Arc::new(AtomicUsize::new(0));
+        let served = Arc::clone(&hits);
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    return;
+                };
+                let n = served.fetch_add(1, Ordering::SeqCst);
+                let (status, body) = bodies
+                    .get(n)
+                    .copied()
+                    .unwrap_or((200, r#"{"id":"x","type":"track","name":"ok","artists":[],"album":null,"url":"u","durationMs":1}"#));
+                // Read the request line so the client is not writing into a
+                // socket nobody drained.
+                let mut buf = [0u8; 1024];
+                let _ = sock.read(&mut buf).await;
+                let resp = format!(
+                    "HTTP/1.1 {status} X\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            }
+        });
+        (format!("http://{addr}"), hits)
+    }
+
+    const SILENT: (u16, &str) = (
+        502,
+        r#"{"error":"extraction_silent","id":"x","message":"nothing matched"}"#,
+    );
+    const EMPTY: (u16, &str) = (
+        502,
+        r#"{"error":"extraction_empty","id":"x","message":"zero tracks"}"#,
+    );
+
+    #[tokio::test]
+    async fn extraction_silent_is_retried_and_can_succeed() {
+        let (base, hits) = serve(vec![SILENT]).await;
+        let client = ClientBuilder::new().base_url(base).build().unwrap();
+
+        client.track("abc").await.expect("second attempt succeeds");
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            2,
+            "one failure plus one retry == two requests"
+        );
+    }
+
+    #[tokio::test]
+    async fn extraction_silent_past_the_budget_surfaces_the_error() {
+        // Both attempts fail: the caller must see ExtractionSilent, not a
+        // success and not some flattened variant.
+        let (base, hits) = serve(vec![SILENT, SILENT]).await;
+        let client = ClientBuilder::new().base_url(base).build().unwrap();
+
+        let err = client.track("abc").await.expect_err("both attempts fail");
+        assert!(matches!(err, Error::ExtractionSilent(_)), "got {err}");
+        assert_eq!(hits.load(Ordering::SeqCst), 2, "bounded at one retry");
+    }
+
+    #[tokio::test]
+    async fn extraction_empty_is_never_retried() {
+        // 🔑 The distinction the taxonomy exists for. `extraction_empty` means
+        // extraction stopped matching Spotify's page -- retrying it burns 4-6
+        // seconds of a held Discord interaction to fail identically.
+        let (base, hits) = serve(vec![EMPTY, (200, r#"{"id":"x"}"#)]).await;
+        let client = ClientBuilder::new().base_url(base).build().unwrap();
+
+        let err = client.track("abc").await.expect_err("must not retry");
+        assert!(matches!(err, Error::ExtractionEmpty(_)), "got {err}");
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            1,
+            "retrying this would have succeeded on the canned 200, which is exactly \
+             the bug: it must NOT reach the second response"
+        );
+    }
+
+    #[tokio::test]
+    async fn retries_can_be_disabled() {
+        let (base, hits) = serve(vec![SILENT]).await;
+        let client = ClientBuilder::new()
+            .base_url(base)
+            .extraction_silent_retries(0)
+            .build()
+            .unwrap();
+
+        let err = client.track("abc").await.expect_err("no retry configured");
+        assert!(matches!(err, Error::ExtractionSilent(_)), "got {err}");
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn an_invalid_id_is_never_retried_and_never_requested() {
+        let (base, hits) = serve(vec![]).await;
+        let client = ClientBuilder::new().base_url(base).build().unwrap();
+
+        let err = client.track("not!valid").await.expect_err("rejected");
+        assert!(matches!(err, Error::InvalidId(_)), "got {err}");
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            0,
+            "validated before any request"
+        );
     }
 }

--- a/crack-sleevenote/src/error.rs
+++ b/crack-sleevenote/src/error.rs
@@ -8,12 +8,13 @@
 //! |------|-------------------------|--------------------------------------------------|
 //! | 400  | `invalid_id`            | the id failed the pattern; nothing was fetched   |
 //! | 404  | `not_found`             | the entity does not exist (negative-cached)      |
+//! | 502  | `extraction_silent`     | navigated fine, nothing on the page matched     |
 //! | 502  | `extraction_empty`      | navigated fine, zero tracks -- extraction broke  |
 //! | 502  | `extraction_incomplete` | recovered fewer items than Spotify declared      |
 //! | 504  | `timeout`               | exceeded the whole-call budget                   |
 //! | 502  | `internal`              | anything else                                    |
 //!
-//! **These do not collapse.** Three of them share HTTP 502, and flattening any
+//! **These do not collapse.** Four of them share HTTP 502, and flattening any
 //! pair of them into one condition is precisely the failure mode sleevenote
 //! exists to prevent. "This id does not exist" is a permanent fact about the
 //! world; "our extraction stopped matching Spotify's page" is a bug on our
@@ -23,6 +24,17 @@
 //! a missing song. So this client keeps one [`Error`] variant per code, and
 //! deliberately does not offer a single `is_retryable()` shortcut that would
 //! quietly re-merge them.
+//!
+//! 🔑 **`extraction_silent` is the exception the taxonomy earned.** It reads
+//! like `extraction_empty` -- both say extraction stopped matching -- but it
+//! measures differently. Four days of production logs: 65 requests, 9
+//! `extraction_silent` failures (~14%), spread across both tracks and
+//! playlists, and **every one of the nine ids succeeded on a later attempt**.
+//! It is transient, not a shape change, so [`Client`] retries it and only it.
+//! That is exactly the distinction this taxonomy exists to make possible; it
+//! is not a step back toward `is_retryable()`.
+//!
+//! [`Client`]: crate::Client
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error as ThisError;
@@ -42,6 +54,11 @@ pub enum ErrorCode {
     InvalidId,
     /// HTTP 404. The entity does not exist. Negative-cached by the service.
     NotFound,
+    /// HTTP 502. Navigation succeeded but nothing on the page matched.
+    ///
+    /// Measured as transient rather than a shape change -- see the module
+    /// docs. [`crate::Client`] retries this code once by default.
+    ExtractionSilent,
     /// HTTP 502. Navigation succeeded but yielded zero tracks: extraction broke.
     ExtractionEmpty,
     /// HTTP 502. Fewer items recovered than Spotify declared.
@@ -97,6 +114,19 @@ pub enum Error {
     /// HTTP 404 `not_found`: the entity does not exist. Permanent.
     #[error("no such entity `{}`: {} (HTTP {})", .0.id, .0.message, .0.status)]
     NotFound(ErrorDetail),
+
+    /// HTTP 502 `extraction_silent`: navigation worked, nothing matched.
+    ///
+    /// 🔑 **Transient, despite reading like [`Error::ExtractionEmpty`].**
+    /// Measured in production over four days: ~14% of requests, both tracks
+    /// and playlists, and every failing id succeeded on a later attempt. A
+    /// fresh browser context on the same host recovers the entity data
+    /// perfectly, so this is not Spotify changing shape.
+    ///
+    /// [`crate::Client`] retries it once by default, so a caller normally
+    /// never sees this variant -- when it does, both attempts failed.
+    #[error("extraction found nothing for `{}`: {} (HTTP {})", .0.id, .0.message, .0.status)]
+    ExtractionSilent(ErrorDetail),
 
     /// HTTP 502 `extraction_empty`: navigation worked, zero tracks came back.
     ///
@@ -197,6 +227,7 @@ impl Error {
         match parsed.error {
             ErrorCode::InvalidId => Error::InvalidId(detail),
             ErrorCode::NotFound => Error::NotFound(detail),
+            ErrorCode::ExtractionSilent => Error::ExtractionSilent(detail),
             ErrorCode::ExtractionEmpty => Error::ExtractionEmpty(detail),
             ErrorCode::ExtractionIncomplete => Error::ExtractionIncomplete(detail),
             ErrorCode::Timeout => Error::Timeout(detail),
@@ -213,6 +244,7 @@ impl Error {
         match self {
             Error::InvalidId(_) => Some(ErrorCode::InvalidId),
             Error::NotFound(_) => Some(ErrorCode::NotFound),
+            Error::ExtractionSilent(_) => Some(ErrorCode::ExtractionSilent),
             Error::ExtractionEmpty(_) => Some(ErrorCode::ExtractionEmpty),
             Error::ExtractionIncomplete(_) => Some(ErrorCode::ExtractionIncomplete),
             Error::Timeout(_) => Some(ErrorCode::Timeout),
@@ -228,6 +260,7 @@ impl Error {
         match self {
             Error::InvalidId(detail)
             | Error::NotFound(detail)
+            | Error::ExtractionSilent(detail)
             | Error::ExtractionEmpty(detail)
             | Error::ExtractionIncomplete(detail)
             | Error::Timeout(detail)

--- a/crack-sleevenote/src/lib.rs
+++ b/crack-sleevenote/src/lib.rs
@@ -58,7 +58,7 @@ pub mod model;
 
 pub use client::{
     CacheStatus, Client, ClientBuilder, Health, BASE_URL_ENV, CACHE_HEADER, DEFAULT_BASE_URL,
-    DEFAULT_TIMEOUT, ID_PATTERN, TIMEOUT_SECS_ENV,
+    DEFAULT_EXTRACTION_SILENT_RETRIES, DEFAULT_TIMEOUT, ID_PATTERN, TIMEOUT_SECS_ENV,
 };
 pub use error::{Error, ErrorBody, ErrorCode, ErrorDetail, Result};
 pub use model::{

--- a/crack-testing/Cargo.toml
+++ b/crack-testing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "crack-testing"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/crack-types/Cargo.toml
+++ b/crack-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-types"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-voting/Cargo.toml
+++ b/crack-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-voting"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true


### PR DESCRIPTION
Closes #488.

## The gap

The client had **no variant for `extraction_silent`**, so the single most common real failure — **9 of 9** over four days of production logs — fell through to `ErrorCode::Unrecognized` and reached users as:

```
sleevenote lookup failed: unrecognized sleevenote code `extraction_silent` on `7maHIz9FnZkqISbzOuw2r4`
```

The documented taxonomy table in `error.rs` was missing the row too.

## 🔑 It is transient — and the taxonomy assumed it was not

The module doc asserted:

> "our extraction stopped matching Spotify's page" is a bug on our side that **a retry will not fix** but a deploy will

True of `extraction_empty`. **False of `extraction_silent`**, and the measurement is the counter-evidence:

| | |
|---|---|
| production requests, 4 days | **65** |
| `extraction_silent` failures | **9 (~14%, 1 in 7)** |
| across | **both** tracks (5) and playlists (4) |
| failing ids that succeeded on a later attempt | **9 of 9** |

Probing inside the production container, a **fresh browser context recovers the entity data perfectly** — 6/6 pathfinder responses, all carrying `playlistV2`. So this is not Spotify changing shape.

I corrected the module doc rather than leaving a claim the data contradicts.

## The change

`Client` retries `extraction_silent`, **and only it**, once by default. One retry takes user-visible failure from roughly 1-in-7 to roughly 1-in-50; a second buys about another 1% against a 4–6 second request with a Discord interaction held open, so `DEFAULT_EXTRACTION_SILENT_RETRIES` is 1 and the builder exposes it.

🪤 **`extraction_empty` reads almost identically and is deliberately NOT retried.** It means extraction genuinely stopped matching, which a retry cannot fix and a deploy can. Keeping those apart is the entire reason this crate has one variant per code — this is not a step back toward the `is_retryable()` shortcut the module refuses, it is **one variant reclassified on evidence**.

🪤 **The retry lives in `fetch`**, the chokepoint all three entity methods funnel through — not in `track`/`album`/`playlist`, where a fourth endpoint added later would silently not retry. Id validation stays **outside** the loop: a bad id is not transient.

## User-facing message

Its own string, not `SPOTIFY_LOOKUP_BROKEN`. By the time it is shown the client has already retried and both attempts lost — but a third try still often works, so it says to try again rather than sending the user off to search by name. Logged at **warn**, not error: a flake that survived a retry is notable, not a service defect.

## Tests

Five, and they count **requests**, not return values — a retry that quietly never re-requests still returns the right error, so the count is the only thing separating "retried and both failed" from "never retried".

The `extraction_empty` case queues a **200 as its second response**, so a wrongly-added retry there would *succeed* and fail the test.

No mock-server dev-dependency: a small local `TcpListener`, since the crate's tests are otherwise offline and the whole contract under test is "how many times did it ask".

## Still open

**Why the extraction goes silent ~14% of the time is not established.** This is a mitigation, not a root-cause fix. sleevenote#12 — the evidence truncation that hid this — is the thread to pull next.

Version bumped 0.9.3 → 0.9.4 across all nine members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8PrF3gizKqXCStjCuWL3d
