### PR TITLE
fix(playback): log play history on the list paths too, and pin the enqueue surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,14 +1012,14 @@ dependencies = [
 
 [[package]]
 name = "crack-bf"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "crack-core"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "crack-gpt"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-openai",
  "const_format",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "crack-osint"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "crack-types",
  "ipinfo",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "crack-sleevenote"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "crack-testing"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "crack-types"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "humantime",
  "poise",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "crack-voting"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "chrono",
  "dbl-rs",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "cracktunes"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "config-file",
  "crack-core",

--- a/crack-bf/Cargo.toml
+++ b/crack-bf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-bf"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-cli/Cargo.toml
+++ b/crack-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "cracktunes"
-version = "0.9.4"
+version = "0.9.5"
 description = "Cracktunes is a hassle-free, highly performant, host-it-yourself, cracking smoking, discord-music-bot."
 publish = true
 edition = "2021"

--- a/crack-core/Cargo.toml
+++ b/crack-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-core"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 edition = "2021"
 description = "Core module for the cracking smoking, discord-music-bot Cracktunes."

--- a/crack-core/src/music/queue.rs
+++ b/crack-core/src/music/queue.rs
@@ -494,6 +494,10 @@ pub async fn queue_resolved_list_back(
         return Err(CrackedError::Other("Playlist resolved to no playable tracks").into());
     }
 
+    // Before `split_off`, so the whole list is logged rather than just the
+    // head that gets enqueued first.
+    ctx.send_resolved_metadata_write_msgs(&tracks);
+
     let rest = tracks.split_off(1);
     // Hold the guard across the enqueue AND the snapshot read right after it,
     // closing the window a concurrent command's insert could otherwise land
@@ -612,6 +616,10 @@ pub async fn queue_vec_query_type(
         .map(|t| t.with_user_id(user_id))
         .collect::<Vec<_>>();
 
+    // Logged before the guard is taken: the send is a non-blocking channel
+    // push, and keeping it off the guarded section costs playback nothing.
+    ctx.send_resolved_metadata_write_msgs(&resolved);
+
     let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let snapshot = enqueue_resolved_and_snapshot(&guard, ctx, &call, resolved).await?;
     drop(guard);
@@ -643,6 +651,12 @@ pub async fn queue_query_list_offset(
     // Resolved concurrently; this was a serial round trip per track. Runs
     // before the guard is taken -- see the doc comment above.
     let tracks = ctx.data().ct_client.resolve_track_many(queries).await?;
+
+    // 🪤 Sent HERE, once, rather than inside the two branches below. This
+    // function splits into a low-queue path (`enqueue_resolved_and_snapshot`)
+    // and a bulk loop; a send placed in either one silently misses the other,
+    // which is the shape of the bug this whole fix exists to close.
+    ctx.send_resolved_metadata_write_msgs(&tracks);
 
     let guard = ctx.data().lock_queue(guild_id, PlaybackOwner::Free).await?;
     let queue_size = {
@@ -1231,28 +1245,26 @@ mod queue_query_list_offset_ordering_tests {
 
 #[cfg(test)]
 mod play_history_wiring_tests {
-    //! Regression guard for #486.
+    //! Regression guard for #486, REWRITTEN after the first version of it
+    //! passed while the bug was still live.
     //!
-    //! Play history was never written on ANY commit in this repo's history:
-    //! both metadata-write call sites in this file sat commented out behind a
-    //! `// FIXME:`, and the channel-based sender had zero callers, so the
-    //! worker `config.rs` spawns idled forever on a channel nothing fed. The
-    //! visible symptom was not an empty `/playlog` -- it was autoplay failing
-    //! with "I can't pick a next track right now", because
-    //! `track_end.rs::get_recommended_track_query` seeds Spotify from
-    //! `get_last_played_by_guild`, which returned nothing.
+    //! v0.9.3 wired the three single-track call sites and this test asserted
+    //! exactly those three. It was green, and a Spotify playlist still wrote
+    //! nothing -- because the LIST paths (`queue_query_list_offset`,
+    //! `queue_vec_query_type`, `queue_resolved_list_back`) had no metadata
+    //! write at all and the test never knew to look for one.
     //!
-    //! That is invisible by construction: a missing call emits no log line and
-    //! no error, so nothing short of reading the source or querying the
-    //! database reveals it. Hence a source scan rather than a behavioural test
-    //! -- the write path needs a live songbird `Call` and a real voice
-    //! connection to exercise, which is why it went unnoticed for years.
+    //! 🔑 **A source scan is only ever as good as the set it enumerates.** The
+    //! first version hard-coded a count of call sites, so it encoded the
+    //! author's survey rather than the property. This version pins the whole
+    //! enqueue SURFACE: every public enqueue entry point is listed with what it
+    //! is expected to do, and a function added, renamed or removed fails the
+    //! test until someone states which case it is. That is the only shape that
+    //! could have caught the playlist gap.
 
-    /// 🪤 The scan STOPS at the first `#[cfg(test)]`. This test module names
-    /// the very functions it is counting, so scanning the whole file would
-    /// count this doc comment and pass vacuously no matter what the real code
-    /// did -- the same self-referential trap that made an earlier version of
-    /// the #484 guard unable to ever fail.
+    /// 🪤 Stops at the first `#[cfg(test)]`. This module names the very
+    /// functions and senders it counts, so scanning the whole file would match
+    /// its own text and pass no matter what the real code did.
     fn production_source() -> String {
         let src = std::fs::read_to_string("src/music/queue.rs").expect("readable");
         let end = src
@@ -1261,39 +1273,176 @@ mod play_history_wiring_tests {
         src[..end].to_string()
     }
 
-    /// Count call sites, ignoring commented-out ones -- the exact state #486
-    /// was in.
-    fn live_call_sites(src: &str, needle: &str) -> usize {
-        src.lines()
+    /// What each public enqueue entry point is expected to do about history.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum Expect {
+        /// Takes `ctx` and must contain a live metadata-sender call.
+        Logs,
+        /// Takes `ctx` but enqueues only via the named entry point, which logs.
+        Delegates(&'static str),
+        /// Takes a `QueueGuard` and NO `ctx`, so it structurally cannot log --
+        /// it has no channel to send on. Its ctx-bearing callers do.
+        Primitive(&'static str),
+        /// Takes `ctx` and deliberately does not log, reason recorded.
+        Exempt(&'static str),
+    }
+    use Expect::{Delegates, Exempt, Logs, Primitive};
+
+    /// THE PINNED SURFACE. Adding a `pub async fn queue_*`/`enqueue_*` without
+    /// adding it here fails `the_enqueue_surface_is_exactly_what_we_reviewed`.
+    const SURFACE: &[(&str, Expect)] = &[
+        ("queue_track_front", Logs),
+        ("queue_track_back", Logs),
+        ("queue_resolved_list_back", Logs),
+        ("queue_vec_query_type", Logs),
+        ("queue_query_list_offset", Logs),
+        ("queue_keyword_list_back", Delegates("queue_vec_query_type")),
+        (
+            "queue_track_ready_front",
+            Primitive("caller: queue_track_front"),
+        ),
+        (
+            "queue_resolved_track_back",
+            Primitive("caller: queue_track_back"),
+        ),
+        (
+            "enqueue_resolved_tracks_back",
+            Primitive("callers: queue_vec_query_type, queue_resolved_list_back"),
+        ),
+        (
+            "enqueue_track_back",
+            Primitive("caller: gp.rs, which keeps submissions out of history before the reveal"),
+        ),
+        (
+            "enqueue_input_back",
+            Primitive(
+                "caller: track_end.rs autoplay. ⚠️ KNOWN GAP: an autoplayed track \
+                 is not logged. Harmless today only because autoplay is dead on \
+                 production (no Spotify client credentials, and Spotify blocked \
+                 new Web API apps ~2025-12). Revisit if autoplay ever returns.",
+            ),
+        ),
+    ];
+
+    /// Any call that puts metadata on the db worker channel.
+    const SENDERS: &[&str] = &[
+        "send_track_metadata_write_msg(",
+        "send_resolved_metadata_write_msg(",
+        "send_resolved_metadata_write_msgs(",
+    ];
+
+    /// Every `pub async fn` in the production source whose name enqueues.
+    fn declared_entry_points(src: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        for line in src.lines() {
+            let line = line.trim_start();
+            let Some(rest) = line.strip_prefix("pub async fn ") else {
+                continue;
+            };
+            let Some(name) = rest.split('(').next() else {
+                continue;
+            };
+            if name.starts_with("queue_") || name.starts_with("enqueue_") {
+                out.push(name.to_owned());
+            }
+        }
+        out
+    }
+
+    /// A function's body: its signature line through to the next `pub async fn`.
+    fn body_of<'a>(src: &'a str, name: &str) -> &'a str {
+        let sig = format!("pub async fn {name}(");
+        let start = src.find(&sig).unwrap_or_else(|| panic!("{name} not found"));
+        let after = &src[start + sig.len()..];
+        match after.find("\npub async fn ") {
+            Some(end) => &after[..end],
+            None => after,
+        }
+    }
+
+    fn has_live_sender(body: &str) -> bool {
+        body.lines()
             .filter(|l| !l.trim_start().starts_with("//"))
-            .filter(|l| l.contains(needle))
-            .count()
+            .any(|l| SENDERS.iter().any(|s| l.contains(s)))
     }
 
     #[test]
-    fn both_queue_paths_still_log_play_history() {
+    fn the_enqueue_surface_is_exactly_what_we_reviewed() {
         let src = production_source();
+        let mut found = declared_entry_points(&src);
+        found.sort();
+        let mut pinned: Vec<String> = SURFACE.iter().map(|(n, _)| (*n).to_owned()).collect();
+        pinned.sort();
 
-        // `queue_track_front`, plus the `ready_query` FALLBACK branch inside
-        // `queue_track_back` -- that branch returns early, so it needs its own
-        // send and is the easiest of the three to drop in a refactor.
-        let ready = live_call_sites(&src, "send_track_metadata_write_msg(");
-        assert!(
-            ready >= 2,
-            "expected at least 2 live send_track_metadata_write_msg call sites \
-             (queue_track_front, and queue_track_back's ready_query fallback), \
-             found {ready}. Play history stops being written and autoplay dies \
-             with it -- silently, with no error in the log."
+        assert_eq!(
+            found, pinned,
+            "the set of public enqueue entry points changed. Add the new one to \
+             SURFACE with Logs / DelegatesTo / Exempt -- an unreviewed enqueue \
+             path is exactly how playlists went unlogged through v0.9.3 while \
+             this test was green."
         );
+    }
 
-        // `queue_track_back`'s fast leg goes ct_client -> ResolvedTrack and
-        // never builds a TrackReadyData, so it cannot use the sender above.
-        let resolved = live_call_sites(&src, "send_resolved_metadata_write_msg(");
+    #[test]
+    fn every_logging_entry_point_actually_sends() {
+        let src = production_source();
+        let mut missing = Vec::new();
+        for (name, expect) in SURFACE {
+            if *expect != Logs {
+                continue;
+            }
+            if !has_live_sender(body_of(&src, name)) {
+                missing.push(*name);
+            }
+        }
         assert!(
-            resolved >= 1,
-            "expected at least 1 live send_resolved_metadata_write_msg call site \
-             (queue_track_back's resolved fast path), found {resolved}. This is \
-             the leg MOST plays take, so losing it loses nearly all history."
+            missing.is_empty(),
+            "these enqueue paths are marked Logs but contain no live metadata \
+             sender, so plays through them vanish silently -- no error, no log \
+             line, just an empty play_log: {missing:#?}"
         );
+    }
+
+    #[test]
+    fn delegation_targets_exist_and_log() {
+        let src = production_source();
+        for (name, expect) in SURFACE {
+            let Delegates(target) = expect else { continue };
+            let entry = SURFACE
+                .iter()
+                .find(|(n, _)| n == target)
+                .unwrap_or_else(|| panic!("{name} delegates to unknown {target}"));
+            assert_eq!(
+                entry.1, Logs,
+                "{name} delegates to {target}, which is not marked Logs -- a \
+                 delegation chain has to end somewhere that writes"
+            );
+            assert!(
+                body_of(&src, name).contains(target),
+                "{name} is marked as delegating to {target} but does not call it"
+            );
+        }
+    }
+
+    /// A `Primitive` is only safe to leave unlogged because it has no `ctx` --
+    /// it physically cannot reach the db channel, so responsibility sits with
+    /// its caller. If one ever gains a `ctx`, that reasoning evaporates and
+    /// this test says so.
+    #[test]
+    fn primitives_really_have_no_context_to_log_with() {
+        let src = production_source();
+        for (name, expect) in SURFACE {
+            let Primitive(note) = expect else { continue };
+            let sig_end = body_of(&src, name)
+                .find(')')
+                .expect("a signature has a closing paren");
+            let params = &body_of(&src, name)[..sig_end];
+            assert!(
+                !params.contains("ctx: CrackContext"),
+                "{name} is marked Primitive ({note}) but now takes a CrackContext -- \
+                 it can reach the db channel, so it must either log or be \
+                 re-marked Exempt with a reason"
+            );
+        }
     }
 }

--- a/crack-core/src/poise_ext.rs
+++ b/crack-core/src/poise_ext.rs
@@ -28,6 +28,14 @@ pub trait ContextExt<'ctx> {
     /// [`ResolvedTrack`] -- so without this overload that path has no way to log
     /// a play at all.
     fn send_resolved_metadata_write_msg(self, resolved: &ResolvedTrack<'_>);
+    /// Log a whole resolved list: playlists, albums, and multi-track searches.
+    ///
+    /// 🔑 The list paths are not reachable from
+    /// [`ContextExt::send_resolved_metadata_write_msg`] one track at a time by
+    /// the caller, because they branch internally (low-queue vs bulk) and
+    /// would need the call duplicated per branch. Sending the whole slice once,
+    /// right after resolution, covers every branch by construction.
+    fn send_resolved_metadata_write_msgs(self, resolved: &[ResolvedTrack<'_>]);
     /// The one place a [`MetadataMsg`] is actually put on the worker channel.
     /// Both senders above funnel through it so the "no channel means no pool,
     /// degrade quietly" rule lives in exactly one place.
@@ -223,6 +231,22 @@ impl<'ctx> ContextExt<'ctx> for crate::Context<'ctx> {
         };
         let username = Some(self.author().name.to_string());
         self.queue_metadata_write(aux_metadata, Some(resolved.user_id), username);
+    }
+
+    fn send_resolved_metadata_write_msgs(self, resolved: &[ResolvedTrack<'_>]) {
+        // 🪤 `self.author().id`, NOT `t.user_id`. On the list paths
+        // `with_user_id` is applied per branch AFTER resolution -- in one
+        // branch not until the enqueue loop -- so reading it here would log
+        // every playlist track under a default id. The invoking user is the
+        // requester for every track in a list play by definition.
+        let user_id = Some(self.author().id);
+        let username = Some(self.author().name.to_string());
+        for track in resolved {
+            let Some(aux_metadata) = track.metadata.clone() else {
+                continue;
+            };
+            self.queue_metadata_write(aux_metadata, user_id, username.clone());
+        }
     }
 
     /// Return the call that the bot is currently in, if it is in one.

--- a/crack-gpt/Cargo.toml
+++ b/crack-gpt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-gpt"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-osint/Cargo.toml
+++ b/crack-osint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-osint"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-sleevenote/Cargo.toml
+++ b/crack-sleevenote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-sleevenote"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-testing/Cargo.toml
+++ b/crack-testing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "crack-testing"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/crack-types/Cargo.toml
+++ b/crack-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-types"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-voting/Cargo.toml
+++ b/crack-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-voting"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true


### PR DESCRIPTION
Closes #486 — properly this time.

## v0.9.3 claimed to fix this and did not

A real Spotify playlist played on production after the v0.9.3 deploy left `play_log` at **0**.

**The fix covered single tracks only.** A playlist routes through `queue_query_list_offset`; v0.9.3 wired three call sites in `queue_track_front` / `queue_track_back`. The list paths had **no metadata write at all** — not even a commented-out one.

| path | before | now |
|---|---|---|
| `queue_track_front`, `queue_track_back` | ✅ v0.9.3 | ✅ |
| `queue_vec_query_type` | ❌ none | ✅ (also covers `queue_keyword_list_back`, which delegates to it entirely) |
| `queue_query_list_offset` | ❌ none | ✅ |
| `queue_resolved_list_back` | ❌ none | ✅ |

## 🪤 Two placement traps

**In `queue_query_list_offset` the send goes immediately after `resolve_track_many`, not inside either branch.** That function splits into a low-queue path (`enqueue_resolved_and_snapshot`) and a bulk loop — a send placed in one silently misses the other, which is the same shape as the bug being fixed.

**`send_resolved_metadata_write_msgs` uses `ctx.author().id`, not `t.user_id`.** On the list paths `with_user_id` is applied per branch *after* resolution — in one branch not until the enqueue loop — so reading it here would log every playlist track under a default id.

## 🔑 The old guard test passed while the bug was live

It asserted a hard-coded count of the three call sites its author knew about, so it encoded a **survey** rather than a **property**. A source scan is only as good as the set it enumerates.

Replaced with one that pins the whole enqueue **surface**: every public `queue_*`/`enqueue_*` entry point is listed as `Logs`, `Delegates`, `Primitive` or `Exempt`, and a function added, renamed or removed fails the test until someone states which it is.

**Pinning immediately found two entry points the manual survey had missed outright** — `enqueue_input_back` and `enqueue_resolved_tracks_back`.

`Primitive` is *checked*, not merely asserted: those take a `QueueGuard` and no `ctx`, so they physically cannot reach the db channel — and a test fails if one ever gains a `ctx` while keeping the exemption.

**Sabotage-verified** by running the built test binary against a temporarily-edited source:

| sabotage | result |
|---|---|
| comment the playlist send — **the exact v0.9.3 bug** | ✅ FAIL |
| add an unreviewed `pub async fn queue_*` | ✅ FAIL |
| restore | ✅ 4 passed, file byte-identical |

## ⚠️ One known gap, recorded rather than hidden

`enqueue_input_back` is `track_end.rs`'s **autoplay** path and stays unlogged. Harmless today only because autoplay is dead on production.

## 🔴 Correction to #486's original claim

I said empty play history is what breaks autoplay. **It is not.** `get_recommended_track_query` checks Spotify auth *before* reading history:

```rust
let spotify = verify(spotify.as_ref(), CrackedError::SpotifyAuth)?;   // fails here
let last_played = pool.get_last_played_by_guild(guild_id, 5).await?;  // never reached
```

Production logs `autoplay DISABLED -- no client credentials`, and Spotify blocked new Web API app creation ~2025-12, so it is likely unfixable. The real cost of this bug is **`/playlog`, track reactions, and having no history at all** — not autoplay.

Version bumped 0.9.4 → 0.9.5 across all nine members.

⚠️ Verification is a real playlist play after deploy, then `select count(*) from play_log`. Not the deploy succeeding, and not this test being green — that is exactly what fooled us last time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8PrF3gizKqXCStjCuWL3d
