### PR TITLE
fix: the permission gate's own blind spot, and three more from ct#495's review

### DIFF
--- a/crack-core/src/commands/music/diagnose.rs
+++ b/crack-core/src/commands/music/diagnose.rs
@@ -123,8 +123,17 @@ pub async fn diagnose(ctx: Context<'_>) -> Result<(), Error> {
         Some(p) => render(&p),
         // Fail open in the wording too: say we could not read, not that
         // something is wrong.
-        None => "I couldn't read my own permissions from cache just now — \
-                 try again in a moment."
+        //
+        // 🪤 Not "try again in a moment". The commonest way to land here is a
+        // thread: threads live in `guild.threads`, not `guild.channels`, so
+        // `resolve` finds no channel and gives up, and waiting changes
+        // nothing. A retry that can never succeed is a worse answer than no
+        // answer. Resolving threads is not a copy change -- posting in one
+        // needs SEND_MESSAGES_IN_THREADS rather than SEND_MESSAGES, so
+        // `TEXT_REQUIRED` would have to vary by channel type.
+        None => "I couldn't read my own permissions for this channel. That \
+                 usually means it's a thread, or a channel I can't see — try \
+                 running this in a regular text channel in this server."
             .to_string(),
     };
     ctx.say(out).await?;

--- a/crack-core/src/commands/music/diagnose.rs
+++ b/crack-core/src/commands/music/diagnose.rs
@@ -6,9 +6,9 @@
 //! configuration reason is the worst possible diagnostic, because the reason
 //! to run it is that the bot is being silent.
 
-use crate::music::perms::{resolve, MusicPermissions};
+use crate::music::perms::{resolve, MusicPermissions, VoiceCheck};
 use crate::{Context, Error};
-use poise::serenity_prelude::all::Mentionable;
+use poise::serenity_prelude::all::{Mentionable, Permissions};
 
 fn tick(ok: bool) -> &'static str {
     if ok {
@@ -30,14 +30,22 @@ fn render(p: &MusicPermissions) -> String {
             p.text.channel.mention()
         ));
     }
-    if let Some(v) = &p.voice {
-        if !v.can_join() {
-            problems.push(format!(
-                "• **{}** in {} — /play will refuse to connect",
-                v.missing(),
-                v.channel.mention()
-            ));
-        }
+    match &p.voice {
+        VoiceCheck::Resolved(v) if !v.can_join() => problems.push(format!(
+            "• **{}** in {} — /play will refuse to connect",
+            v.missing(),
+            v.channel.mention()
+        )),
+        // 🪤 A channel we cannot see is a problem too, and a different one:
+        // the author IS in a voice channel, and the missing permission is the
+        // one that hid it. Connect and Speak are unknown here, so they are
+        // not named -- see `perms::unreadable_refusal`.
+        VoiceCheck::Unreadable(cid) => problems.push(format!(
+            "• **{}** in {} — I can't even see it, so /play will refuse to connect",
+            Permissions::VIEW_CHANNEL,
+            cid.mention()
+        )),
+        VoiceCheck::Resolved(_) | VoiceCheck::NotInVoice => {},
     }
 
     // All-clear requires that we actually checked both halves. With no voice
@@ -45,7 +53,7 @@ fn render(p: &MusicPermissions) -> String {
     // "all clear" on a voice channel we never looked at would be a lie the
     // user only discovers when /play refuses.
     if problems.is_empty() {
-        if let Some(v) = &p.voice {
+        if let VoiceCheck::Resolved(v) = &p.voice {
             return format!(
                 "✅ All clear — I have everything I need in {} and {}.",
                 p.text.channel.mention(),
@@ -63,14 +71,23 @@ fn render(p: &MusicPermissions) -> String {
         tick(p.text.embed()),
     ));
     match &p.voice {
-        Some(v) => out.push_str(&format!(
+        VoiceCheck::Resolved(v) => out.push_str(&format!(
             "**Voice** {}  {} Connect  {} Speak\n",
             v.channel.mention(),
             tick(v.connect()),
             tick(v.speak()),
         )),
+        // 🪤 Not "you're not in a voice channel" — the author is in one, and
+        // saying otherwise was the false, unactionable answer this state was
+        // added to replace.
+        VoiceCheck::Unreadable(cid) => out.push_str(&format!(
+            "**Voice** {}  {} View Channel — I can't even see that channel, so \
+             I can't check Connect/Speak.\n",
+            cid.mention(),
+            tick(false),
+        )),
         // Absent is not denied.
-        None => out.push_str(
+        VoiceCheck::NotInVoice => out.push_str(
             "**Voice** — you're not in a voice channel, so I can't check \
              Connect/Speak. Join one and run this again.\n",
         ),
@@ -129,7 +146,11 @@ mod tests {
 
     #[test]
     fn all_clear_says_so_and_lists_no_problems() {
-        let p = compute(text_ch(), TEXT_REQUIRED, Some((voice_ch(), VOICE_REQUIRED)));
+        let p = compute(
+            text_ch(),
+            TEXT_REQUIRED,
+            VoiceCheck::resolved(voice_ch(), VOICE_REQUIRED),
+        );
         let out = render(&p);
         assert!(out.contains("All clear"), "got {out}");
         assert!(
@@ -143,7 +164,7 @@ mod tests {
         let p = compute(
             text_ch(),
             TEXT_REQUIRED - Permissions::EMBED_LINKS,
-            Some((voice_ch(), VOICE_REQUIRED - Permissions::SPEAK)),
+            VoiceCheck::resolved(voice_ch(), VOICE_REQUIRED - Permissions::SPEAK),
         );
         let out = render(&p);
         assert!(out.contains("2 problems"), "got {out}");
@@ -156,7 +177,7 @@ mod tests {
 
     #[test]
     fn no_voice_channel_asks_the_user_to_join_one_rather_than_reporting_a_denial() {
-        let p = compute(text_ch(), TEXT_REQUIRED, None);
+        let p = compute(text_ch(), TEXT_REQUIRED, VoiceCheck::NotInVoice);
         let out = render(&p);
         // 🪤 Absent is not denied. Rendering this as a missing permission
         // would send someone to grant Connect when Connect is already
@@ -173,10 +194,37 @@ mod tests {
         let p = compute(
             text_ch(),
             TEXT_REQUIRED - Permissions::EMBED_LINKS,
-            Some((voice_ch(), VOICE_REQUIRED)),
+            VoiceCheck::resolved(voice_ch(), VOICE_REQUIRED),
         );
         let out = render(&p);
         assert!(out.contains("1 problem"), "got {out}");
         assert!(!out.contains("1 problems"), "got {out}");
+    }
+
+    #[test]
+    fn a_voice_channel_we_cannot_see_is_named_as_such_not_as_no_voice_channel() {
+        let p = compute(text_ch(), TEXT_REQUIRED, VoiceCheck::Unreadable(voice_ch()));
+        let out = render(&p);
+        // 🪤 The whole point of the third state. Telling someone sitting in a
+        // voice channel that they are not in one is false and unactionable,
+        // and it is what the two-state version did.
+        assert!(
+            !out.contains("not in a voice channel"),
+            "the author IS in one: {out}"
+        );
+        assert!(!out.contains("All clear"), "voice is not fine: {out}");
+        assert!(out.contains("View Channel"), "name the fix: {out}");
+        assert!(out.contains("can't even see"), "say what is wrong: {out}");
+        assert!(
+            out.contains(&format!("<#{}>", voice_ch())),
+            "name the channel: {out}"
+        );
+        assert!(out.contains("1 problem"), "it is a problem: {out}");
+        // Connect and Speak are unknown for a channel Discord never sent us,
+        // so the table must not tick or cross them.
+        assert!(
+            !out.contains("Connect  "),
+            "Connect is unknown, not denied: {out}"
+        );
     }
 }

--- a/crack-core/src/commands/music/doplay.rs
+++ b/crack-core/src/commands/music/doplay.rs
@@ -285,6 +285,39 @@ fn degraded_notice(text: Option<&TextPerms>) -> Option<String> {
     ))
 }
 
+/// Where the note has to ride to actually be seen.
+///
+/// 🪤 An embed field is invisible in exactly the case that needs it most. On a
+/// prefix `r!play` in a channel without `EMBED_LINKS`, Discord strips the
+/// embed from the message — and takes "Missing **Embed Links** here" with it.
+/// The one reader who needs that sentence is the only one who never gets it.
+/// Message content is not stripped, so that is where the note goes whenever
+/// `EMBED_LINKS` is among the missing set.
+///
+/// Slash commands are not affected (interaction responses bypass the
+/// channel's permission check), but the note is routed the same way for both:
+/// one rule, and the surviving delivery is correct everywhere.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum NoticeDelivery {
+    /// Embeds render here, so the note rides as a field on the reply's embed,
+    /// next to the queue entry it qualifies.
+    Field(String),
+    /// `EMBED_LINKS` is missing, so the embed may never be shown. The note
+    /// goes in the message content, which always survives.
+    Content(String),
+}
+
+/// Route [`degraded_notice`] to a delivery that will actually be seen.
+fn degraded_delivery(text: Option<&TextPerms>) -> Option<NoticeDelivery> {
+    let note = degraded_notice(text)?;
+    // `text` is Some here: degraded_notice returned a note.
+    if text.is_some_and(|t| !t.embed()) {
+        Some(NoticeDelivery::Content(note))
+    } else {
+        Some(NoticeDelivery::Field(note))
+    }
+}
+
 pub async fn build_play_embed<'a>(
     queue: &'a [TrackHandle],
     mode: Mode,
@@ -355,11 +388,34 @@ pub async fn build_play_embed<'a>(
                 .footer(CreateEmbedFooter::new("No tracks in queue!"))
         },
     };
-    let embed = match degraded_notice(text) {
-        Some(note) => embed.field("⚠️ Limited permissions", note, false),
-        None => embed,
+    let embed = match degraded_delivery(text) {
+        Some(NoticeDelivery::Field(note)) => embed.field("⚠️ Limited permissions", note, false),
+        // Deliberately not attached: the caller puts this one in the message
+        // content, because the embed it would ride on is exactly what Discord
+        // strips when EMBED_LINKS is missing.
+        Some(NoticeDelivery::Content(_)) | None => embed,
     };
     Ok(embed)
+}
+
+/// The whole play reply: the embed, plus the note that cannot ride inside it.
+///
+/// 🪤 Returned as a pair on purpose. The `Content` half exists precisely
+/// because a channel without `EMBED_LINKS` never shows the embed, so handing
+/// a caller only the embed is exactly how that note goes missing. A caller
+/// that drops the second element now has to do it in plain sight.
+pub async fn build_play_reply<'a>(
+    queue: &'a [TrackHandle],
+    mode: Mode,
+    query_type: NewQueryType,
+    text: Option<&TextPerms>,
+) -> Result<(CreateEmbed<'a>, Option<String>), Error> {
+    let content = match degraded_delivery(text) {
+        Some(NoticeDelivery::Content(note)) => Some(note),
+        Some(NoticeDelivery::Field(_)) | None => None,
+    };
+    let embed = build_play_embed(queue, mode, query_type, text).await?;
+    Ok((embed, content))
 }
 
 /// Does the actual playing of the song, all the other commands use this.
@@ -467,11 +523,12 @@ pub async fn play_internal(
         crate::music::perms::resolve(ctx.cache(), gid, ctx.channel_id(), ctx.author().id)
             .map(|p| p.text)
     });
-    let embed = build_play_embed(&queue, mode, query_type, text_perms.as_ref()).await?;
+    let (embed, notice_content) =
+        build_play_reply(&queue, mode, query_type, text_perms.as_ref()).await?;
 
     let _after_embed = std::time::Instant::now();
 
-    let _msg = edit_embed_response2(ctx, embed, search_msg.clone()).await?;
+    let _msg = edit_embed_response2(ctx, embed, search_msg.clone(), notice_content).await?;
 
     // A partial listing is a success with something missing, so it is said
     // after the queue embed rather than instead of it: the recovered tracks are
@@ -879,5 +936,127 @@ mod degraded_perms_notice_tests {
             .expect("degraded perms must produce a notice");
         assert!(note.contains("Send Messages"), "got {note}");
         assert!(note.contains("Embed Links"), "got {note}");
+    }
+
+    #[test]
+    fn a_missing_embed_links_is_delivered_as_content_not_as_an_embed_field() {
+        // 🪤 The one case where an embed field is invisible. On a prefix
+        // `r!play` Discord strips the embed from a message in a channel
+        // without EMBED_LINKS, so a note saying "Missing **Embed Links**
+        // here" attached to that embed reaches nobody -- the reader who needs
+        // it is the only one who never sees it.
+        match degraded_delivery(Some(&perms(TEXT_REQUIRED - Permissions::EMBED_LINKS))) {
+            Some(NoticeDelivery::Content(note)) => {
+                assert!(note.contains("Embed Links"), "got {note}");
+            },
+            other => panic!("a note about EMBED_LINKS must survive the embed: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_degradation_that_still_renders_embeds_rides_in_the_embed() {
+        match degraded_delivery(Some(&perms(TEXT_REQUIRED - Permissions::SEND_MESSAGES))) {
+            Some(NoticeDelivery::Field(note)) => {
+                assert!(note.contains("Send Messages"), "got {note}");
+            },
+            other => panic!("embeds render here, so the note belongs in one: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn whole_perms_are_delivered_nowhere() {
+        assert!(degraded_delivery(Some(&perms(TEXT_REQUIRED))).is_none());
+        assert!(degraded_delivery(None).is_none());
+    }
+}
+
+/// 🪤 The tests above all exercise the private helpers in isolation. Delete
+/// the notice from `build_play_embed` and the `text_perms` resolve at the call
+/// site, and every one of them still passes while the feature does nothing at
+/// all -- which is the same defect as a guard test that asserts a hard-coded
+/// count. These pin the **wiring**: what the built reply actually carries.
+#[cfg(test)]
+mod degraded_notice_wiring_tests {
+    use super::*;
+    use crate::music::perms::{TextPerms, TEXT_REQUIRED};
+    use poise::serenity_prelude::all::{GenericChannelId, Permissions};
+
+    fn perms(granted: Permissions) -> TextPerms {
+        TextPerms {
+            channel: GenericChannelId::new(1),
+            granted,
+        }
+    }
+
+    /// Build the reply the play path would send. An empty queue takes the
+    /// `Ordering::Less` branch, which needs no `TrackHandle` and therefore no
+    /// Discord, no songbird and no network.
+    async fn reply(text: Option<&TextPerms>) -> (String, Option<String>) {
+        let (embed, content) = build_play_reply(
+            &[],
+            Mode::End,
+            NewQueryType(QueryType::Keywords("anything".to_string())),
+            text,
+        )
+        .await
+        .expect("an empty queue still builds a reply");
+        // `CreateEmbed` is a third-party builder with no accessors, so its
+        // own `Serialize` is the only way to read one back. An opaque
+        // payload whose shape we do not own is exactly what `Value` is for.
+        let rendered = serde_json::to_value(&embed)
+            .expect("CreateEmbed serialises")
+            .to_string();
+        (rendered, content)
+    }
+
+    #[tokio::test]
+    async fn a_degraded_text_channel_actually_reaches_the_built_embed() {
+        let (embed, content) =
+            reply(Some(&perms(TEXT_REQUIRED - Permissions::SEND_MESSAGES))).await;
+        assert!(
+            embed.contains("Limited permissions"),
+            "the notice never reached the embed: {embed}"
+        );
+        assert!(embed.contains("Send Messages"), "got {embed}");
+        assert!(
+            content.is_none(),
+            "embeds render here, so nothing needs to escape one: {content:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn whole_text_perms_leave_the_built_reply_unmarked() {
+        let (embed, content) = reply(Some(&perms(TEXT_REQUIRED))).await;
+        assert!(
+            !embed.contains("Limited permissions"),
+            "nothing is wrong, so the embed must say nothing: {embed}"
+        );
+        assert!(content.is_none(), "got {content:?}");
+    }
+
+    #[tokio::test]
+    async fn absent_perms_leave_the_built_reply_unmarked() {
+        // `resolve` returned None (cache miss). Fail open: say nothing.
+        let (embed, content) = reply(None).await;
+        assert!(!embed.contains("Limited permissions"), "got {embed}");
+        assert!(content.is_none(), "got {content:?}");
+    }
+
+    #[tokio::test]
+    async fn a_missing_embed_links_leaves_the_embed_and_rides_in_the_content() {
+        // 🪤 The whole point of I3. This note must NOT be in the embed --
+        // Discord strips the embed in exactly this channel -- and it must be
+        // somewhere the caller can still deliver it.
+        let (embed, content) = reply(Some(&perms(TEXT_REQUIRED - Permissions::EMBED_LINKS))).await;
+        assert!(
+            !embed.contains("Limited permissions"),
+            "an embed that will be stripped must not be the only carrier: {embed}"
+        );
+        let content = content.expect("the note must survive outside the embed");
+        assert!(content.contains("Embed Links"), "got {content}");
+        assert!(
+            content.contains("/diagnose"),
+            "the notice must point at the diagnostic: {content}"
+        );
     }
 }

--- a/crack-core/src/commands/music/get_metadata.rs
+++ b/crack-core/src/commands/music/get_metadata.rs
@@ -71,7 +71,8 @@ pub async fn get_metadata(ctx: Context<'_>, query_or_url: String) -> Result<(), 
         .join("\n");
 
     let crack_msg = CrackedMessage::Other(str);
-    match crate::utils::edit_embed_response2(ctx, crack_msg.into(), search_msg.clone()).await {
+    match crate::utils::edit_embed_response2(ctx, crack_msg.into(), search_msg.clone(), None).await
+    {
         Ok(_) => {},
         Err(e) => {
             tracing::error!("Error editing embed: {:?}", e);

--- a/crack-core/src/commands/music/gp_persist.rs
+++ b/crack-core/src/commands/music/gp_persist.rs
@@ -654,8 +654,8 @@ pub async fn gp_resume_guild(data: &Data, ctx: &SerenityContext, guild: &Guild) 
             // Through the method, not the map: `gp_remove` is the one place a
             // game ends, and it is what releases the playback lease. A raw
             // remove here would leave the guild owned by a game that no longer
-            // exists, and /play refused forever. Its own bookkeeping write is
-            // superseded below: the free function is the authoritative
+            // exists, and /play refused forever. Its own bookkeeping write
+            // is superseded by `abandon_resume`, which owns the authoritative
             // database write for this path, since `gp_remove`'s in-memory
             // `game` reflects the pre-rejoin-failure state.
             abandon_resume(data, pool, guild_id, started_at, text_channel, &ctx.http).await;

--- a/crack-core/src/errors.rs
+++ b/crack-core/src/errors.rs
@@ -200,9 +200,10 @@ impl Display for CrackedError {
                     PermScope::Text => FAIL_MISSING_TEXT_PERMS,
                 };
                 // `missing` renders as permission names via serenity's own
-                // Display: two permissions render as "A and B", three or more as
-                // comma-separated "A, B, and C", so we name all of them without
-                // any joining logic here.
+                // Display: two permissions render as "A and B", three or more
+                // as "A, B and C" -- comma-separated, with no Oxford comma
+                // before the final "and". Either way we name all of them
+                // without any joining logic here.
                 f.write_fmt(format_args!(
                     "{} {} — I'm missing **{}** there.\n\n{}",
                     lead,

--- a/crack-core/src/music/perms.rs
+++ b/crack-core/src/music/perms.rs
@@ -165,6 +165,60 @@ pub fn roles_resolvable(
     is_known(RoleId::new(guild_id.get())) && member_roles.iter().all(|r| is_known(*r))
 }
 
+/// Classify the author's voice situation from already-looked-up facts.
+///
+/// Pure, so the distinction between "in no voice channel" and "in a channel
+/// we cannot see" is pinned without a populated [`Cache`]. 🪤 That
+/// distinction is the whole point of [`VoiceCheck`], and it lives **here**,
+/// not in [`compute`] — which only carries a `VoiceCheck` someone else
+/// decided. Leaving the decision inline in [`resolve`]'s cache reads left the
+/// one line that matters untested: flipping it back to `NotInVoice`
+/// reproduced the original bug with the whole suite still green.
+///
+/// `granted_in` is called only for a channel `channel_known` accepted, which
+/// is why callers may use a lookup that has no answer otherwise. The
+/// `granted_in_is_not_consulted_for_a_channel_we_cannot_see` test pins that
+/// order: reversing it would turn an unseeable channel into `Resolved` with
+/// an empty bitset, refusing for CONNECT and SPEAK instead of VIEW_CHANNEL.
+pub fn classify_voice(
+    author_channel: Option<ChannelId>,
+    channel_known: impl Fn(ChannelId) -> bool,
+    granted_in: impl Fn(ChannelId) -> Permissions,
+) -> VoiceCheck {
+    let Some(cid) = author_channel else {
+        return VoiceCheck::NotInVoice;
+    };
+    if !channel_known(cid) {
+        return VoiceCheck::Unreadable(cid);
+    }
+    VoiceCheck::resolved(cid, granted_in(cid))
+}
+
+/// Classify a join target from already-looked-up facts.
+///
+/// The same extraction as [`classify_voice`], for the same reason: the
+/// channel-miss arm is the line that decides whether the gate refuses or
+/// waves a join through, and inline in [`join_lookup`]'s cache reads nothing
+/// could pin it.
+///
+/// `guild_readable` is false when nothing is known — the guild is not cached,
+/// the bot's own member is not cached, or [`roles_resolvable`] said no.
+/// `granted_in` is called only for a channel `channel_known` accepted.
+pub fn classify_join(
+    channel: ChannelId,
+    guild_readable: bool,
+    channel_known: impl Fn(ChannelId) -> bool,
+    granted_in: impl Fn(ChannelId) -> Permissions,
+) -> JoinLookup {
+    if !guild_readable {
+        return JoinLookup::Unknown;
+    }
+    if !channel_known(channel) {
+        return JoinLookup::Withheld;
+    }
+    JoinLookup::Granted(granted_in(channel))
+}
+
 /// Read the bot's permissions out of the cache.
 ///
 /// Returns `None` when the guild, the bot's own member, or the text channel is
@@ -198,18 +252,23 @@ pub fn resolve(
     // The author's voice channel, if they are in one. Absent from the voice
     // states is not a denial; absent from an already-cached guild's channel
     // list is a different thing entirely, and gets its own state.
-    let voice = match guild.voice_states.get(&author).and_then(|vs| vs.channel_id) {
-        None => VoiceCheck::NotInVoice,
-        Some(cid) => match guild.channels.get(&cid) {
-            Some(chan) => VoiceCheck::resolved(cid, guild.user_permissions_in(chan, bot)),
-            // 🪤 Not a cache miss. The guild is cached, so Discord already
-            // sent its channel list, and it omits the channels the bot lacks
-            // VIEW_CHANNEL on. A channel the author is demonstrably sitting
-            // in that is missing from that list is therefore the answer, not
-            // the absence of one.
-            None => VoiceCheck::Unreadable(cid),
+    //
+    // 🪤 The classification is [`classify_voice`], not inline here. Discord
+    // omits the channels the bot lacks VIEW_CHANNEL on from GUILD_CREATE, so
+    // a channel missing from an already-cached guild is the answer rather
+    // than the absence of one -- and that call is exactly the line that has
+    // to stay pinned by a test.
+    let voice = classify_voice(
+        guild.voice_states.get(&author).and_then(|vs| vs.channel_id),
+        |cid| guild.channels.get(&cid).is_some(),
+        |cid| {
+            guild
+                .channels
+                .get(&cid)
+                .map(|chan| guild.user_permissions_in(chan, bot))
+                .unwrap_or_else(Permissions::empty)
         },
-    };
+    );
 
     Some(compute(text_channel, text_granted, voice))
 }
@@ -324,15 +383,20 @@ fn join_lookup(cache: &Cache, guild_id: GuildId, channel_id: ChannelId) -> JoinL
     let Some(bot) = guild.members.get(&bot_id) else {
         return JoinLookup::Unknown;
     };
-    // An under-reported bitset would refuse a join that works: see
-    // [`roles_resolvable`].
-    if !roles_resolvable(guild_id, &bot.roles, |r| guild.roles.get(&r).is_some()) {
-        return JoinLookup::Unknown;
-    }
-    match guild.channels.get(&channel_id) {
-        Some(chan) => JoinLookup::Granted(guild.user_permissions_in(chan, bot)),
-        None => JoinLookup::Withheld,
-    }
+    classify_join(
+        channel_id,
+        // An under-reported bitset would refuse a join that works: see
+        // [`roles_resolvable`].
+        roles_resolvable(guild_id, &bot.roles, |r| guild.roles.get(&r).is_some()),
+        |cid| guild.channels.get(&cid).is_some(),
+        |cid| {
+            guild
+                .channels
+                .get(&cid)
+                .map(|chan| guild.user_permissions_in(chan, bot))
+                .unwrap_or_else(Permissions::empty)
+        },
+    )
 }
 
 #[cfg(test)]
@@ -466,6 +530,101 @@ mod tests {
             !rendered.contains("Speak"),
             "Speak is unknown, not missing: {rendered}"
         );
+    }
+
+    // `classify_voice` is where the three-way distinction is actually made.
+    // `compute` only carries a `VoiceCheck` someone else decided, so testing
+    // `compute` proves nothing about whether `resolve` ever produces
+    // `Unreadable`. These are the tests that pin that.
+
+    #[test]
+    fn no_voice_channel_classifies_as_not_in_voice() {
+        let got = classify_voice(
+            None,
+            |_| panic!("nothing to look up"),
+            |_| panic!("nothing to look up"),
+        );
+        assert_eq!(got, VoiceCheck::NotInVoice);
+    }
+
+    #[test]
+    fn a_channel_the_guild_does_not_list_classifies_as_unreadable() {
+        // 🪤 THE regression. Discord omits channels the bot lacks
+        // VIEW_CHANNEL on from GUILD_CREATE, so an author sitting in one
+        // leaves the guild's channel list without an entry. Classifying that
+        // as `NotInVoice` tells them they are not in a voice channel -- false
+        // and unactionable -- and lets the gate wave the join through into
+        // songbird's ~10s timeout.
+        let got = classify_voice(Some(voice_ch()), |_| false, |_| VOICE_REQUIRED);
+        assert_eq!(
+            got,
+            VoiceCheck::Unreadable(voice_ch()),
+            "a channel we cannot see is not the same as no channel"
+        );
+        assert_ne!(
+            got,
+            VoiceCheck::NotInVoice,
+            "collapsing these two is the bug this state exists to prevent"
+        );
+        match got {
+            VoiceCheck::Unreadable(cid) => assert_eq!(cid, voice_ch(), "the id must survive"),
+            other => panic!("expected Unreadable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_channel_the_guild_lists_classifies_as_resolved_carrying_its_bitset() {
+        let granted = VOICE_REQUIRED - Permissions::SPEAK;
+        let got = classify_voice(Some(voice_ch()), |_| true, |_| granted);
+        let v = got.perms().expect("a known channel resolves");
+        assert_eq!(v.channel, voice_ch());
+        // Bit-exact: a bitset mangled on the way through would name the wrong
+        // permission in the refusal.
+        assert_eq!(v.granted, granted);
+        assert_eq!(v.missing(), Permissions::SPEAK);
+    }
+
+    #[test]
+    fn granted_in_is_not_consulted_for_a_channel_we_cannot_see() {
+        // 🪤 Order matters. If `granted_in` were consulted first, a caller
+        // whose lookup falls back to `Permissions::empty()` for an absent
+        // channel would produce `Resolved(empty)` -- a refusal naming Connect
+        // and Speak instead of View Channel, sending an admin to grant two
+        // permissions that are very likely already granted.
+        let got = classify_voice(
+            Some(voice_ch()),
+            |_| false,
+            |_| panic!("granted_in must not be asked about a channel we cannot see"),
+        );
+        assert_eq!(got, VoiceCheck::Unreadable(voice_ch()));
+    }
+
+    #[test]
+    fn an_unreadable_guild_classifies_a_join_as_unknown() {
+        let got = classify_join(
+            voice_ch(),
+            false,
+            |_| panic!("nothing to look up"),
+            |_| panic!("nothing to look up"),
+        );
+        assert_eq!(got, JoinLookup::Unknown, "fail open on genuine ignorance");
+    }
+
+    #[test]
+    fn a_join_target_the_guild_does_not_list_classifies_as_withheld() {
+        // 🪤 The gate half of the same regression: this arm returning
+        // `Unknown` is `Ok(())`, and the join proceeds to songbird's ~10s
+        // `JoinError::TimedOut`, which names nothing.
+        let got = classify_join(voice_ch(), true, |_| false, |_| VOICE_REQUIRED);
+        assert_eq!(got, JoinLookup::Withheld);
+        assert_ne!(got, JoinLookup::Unknown, "this is information, not a gap");
+    }
+
+    #[test]
+    fn a_join_target_the_guild_lists_classifies_as_granted_bit_exactly() {
+        let granted = VOICE_REQUIRED - Permissions::CONNECT;
+        let got = classify_join(voice_ch(), true, |_| true, |_| granted);
+        assert_eq!(got, JoinLookup::Granted(granted));
     }
 
     #[test]

--- a/crack-core/src/music/perms.rs
+++ b/crack-core/src/music/perms.rs
@@ -29,10 +29,47 @@ pub const VOICE_REQUIRED: Permissions = Permissions::CONNECT.union(Permissions::
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MusicPermissions {
     pub text: TextPerms,
-    /// `None` when the author is in no voice channel at all — deliberately a
-    /// distinct state from "in a channel we cannot join", because the two
-    /// need different messages.
-    pub voice: Option<VoicePerms>,
+    pub voice: VoiceCheck,
+}
+
+/// What we were able to learn about the voice channel the author is sitting in.
+///
+/// Three states, not two. 🪤 Collapsing "in a channel we cannot see" into "in
+/// no channel" is the bug this enum exists to prevent. Discord omits channels
+/// the bot lacks `VIEW_CHANNEL` on from `GUILD_CREATE`, so such a channel is
+/// simply absent from `guild.channels`; with only two states that came out as
+/// "you're not in a voice channel" to someone who was plainly in one, and
+/// [`ensure_can_join`] waved the join through into songbird's ~10s
+/// `JoinError::TimedOut` — the exact symptom this module exists to delete.
+///
+/// Named `VoiceCheck` rather than `VoiceState` because serenity already has a
+/// `VoiceState`, and [`resolve`] reads a map of those one line away.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VoiceCheck {
+    /// The author is in no voice channel. Not a denial, and not a problem.
+    NotInVoice,
+    /// The author is in a channel that is absent from an **already-cached**
+    /// guild. That absence is information, not ignorance: Discord would have
+    /// sent the channel if the bot could see it.
+    Unreadable(ChannelId),
+    /// Read successfully.
+    Resolved(VoicePerms),
+}
+
+impl VoiceCheck {
+    /// The resolved permissions, if we got that far. `None` for both of the
+    /// other states — callers that need to tell them apart must match.
+    pub fn perms(&self) -> Option<&VoicePerms> {
+        match self {
+            Self::Resolved(v) => Some(v),
+            Self::NotInVoice | Self::Unreadable(_) => None,
+        }
+    }
+
+    /// Build the resolved case from a raw bitset.
+    pub fn resolved(channel: ChannelId, granted: Permissions) -> Self {
+        Self::Resolved(VoicePerms { channel, granted })
+    }
 }
 
 /// What the bot may do in the channel a command was invoked in.
@@ -94,14 +131,14 @@ impl VoicePerms {
 pub fn compute(
     text_channel: GenericChannelId,
     text_granted: Permissions,
-    voice: Option<(ChannelId, Permissions)>,
+    voice: VoiceCheck,
 ) -> MusicPermissions {
     MusicPermissions {
         text: TextPerms {
             channel: text_channel,
             granted: text_granted,
         },
-        voice: voice.map(|(channel, granted)| VoicePerms { channel, granted }),
+        voice,
     }
 }
 
@@ -128,15 +165,21 @@ pub fn resolve(
     let text_chan = guild.channels.get(&text_channel.expect_channel())?;
     let text_granted = guild.user_permissions_in(text_chan, bot);
 
-    // The author's voice channel, if they are in one. Absent is not a denial.
-    let voice = guild
-        .voice_states
-        .get(&author)
-        .and_then(|vs| vs.channel_id)
-        .and_then(|cid| {
-            let chan = guild.channels.get(&cid)?;
-            Some((cid, guild.user_permissions_in(chan, bot)))
-        });
+    // The author's voice channel, if they are in one. Absent from the voice
+    // states is not a denial; absent from an already-cached guild's channel
+    // list is a different thing entirely, and gets its own state.
+    let voice = match guild.voice_states.get(&author).and_then(|vs| vs.channel_id) {
+        None => VoiceCheck::NotInVoice,
+        Some(cid) => match guild.channels.get(&cid) {
+            Some(chan) => VoiceCheck::resolved(cid, guild.user_permissions_in(chan, bot)),
+            // 🪤 Not a cache miss. The guild is cached, so Discord already
+            // sent its channel list, and it omits the channels the bot lacks
+            // VIEW_CHANNEL on. A channel the author is demonstrably sitting
+            // in that is missing from that list is therefore the answer, not
+            // the absence of one.
+            None => VoiceCheck::Unreadable(cid),
+        },
+    };
 
     Some(compute(text_channel, text_granted, voice))
 }
@@ -160,34 +203,100 @@ pub fn voice_refusal(channel: ChannelId, granted: Permissions) -> Option<Cracked
     }
 }
 
+/// The refusal a voice channel we cannot even see earns.
+///
+/// Legitimate only against an **already-cached** guild, which is what makes it
+/// compatible with failing open: we are not guessing at a permission state we
+/// could not read, we are reading Discord's decision not to send us the
+/// channel.
+///
+/// 🪤 Names `VIEW_CHANNEL` and nothing else. `CONNECT` and `SPEAK` may well be
+/// granted here — there is no way to compute them for a channel Discord never
+/// sent — and naming a permission that is already granted is precisely the
+/// failure this module exists to avoid.
+pub fn unreadable_refusal(channel: ChannelId) -> CrackedError {
+    CrackedError::MissingBotPermissions {
+        scope: PermScope::Voice,
+        channel: channel.widen(),
+        missing: Permissions::VIEW_CHANNEL,
+    }
+}
+
 /// The blocking gate: refuse a join Discord would silently drop.
 ///
-/// Call this immediately before every `songbird.join`. It takes cache handles
-/// rather than a poise `Context` on purpose — one of its call sites is a
-/// restart-resume with no invoking user and therefore no `Context`.
+/// Call this immediately before every `songbird.join`.
 ///
-/// Fails **open** on a cache miss: an unknown permission state must not refuse
-/// a join that would have worked.
+/// A thin cache layer over [`join_refusal`], which holds the actual rule.
 pub fn ensure_can_join(
     cache: &Cache,
     guild_id: GuildId,
     channel_id: ChannelId,
 ) -> Result<(), CrackedError> {
+    match join_refusal(channel_id, join_lookup(cache, guild_id, channel_id)) {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
+}
+
+/// What the cache was able to say about the channel a join is aimed at.
+///
+/// The three cases are deliberately not `Option<Permissions>`: "we know
+/// nothing" and "we know Discord withheld this channel" demand opposite
+/// answers, and flattening them into one `None` is the defect [`VoiceCheck`]
+/// exists to prevent, one layer down.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JoinLookup {
+    /// Genuine ignorance — the guild is not cached, or the bot's own member
+    /// is not cached.
+    Unknown,
+    /// The guild **is** cached and the channel is absent from it, which
+    /// Discord does exactly when the bot lacks `VIEW_CHANNEL` there.
+    Withheld,
+    /// Resolved.
+    Granted(Permissions),
+}
+
+/// The decision the gate makes once the cache has had its say.
+///
+/// Pure, so all three outcomes — fail open, refuse for `VIEW_CHANNEL`, refuse
+/// for `CONNECT`/`SPEAK` — are testable without a populated [`Cache`], the
+/// same split [`compute`]/[`resolve`] already use. It is also the split that
+/// matters most here: the two-state version of this decision answered
+/// `Ok(())` for [`JoinLookup::Withheld`] and nothing could catch it.
+pub fn join_refusal(channel: ChannelId, lookup: JoinLookup) -> Option<CrackedError> {
+    match lookup {
+        // 🪤 Fail OPEN. An unknown permission state must not refuse a join
+        // that would have worked; that would break working guilds during the
+        // cache warm-up after every restart.
+        JoinLookup::Unknown => None,
+        // 🪤 NOT a cache miss, and this is the one asymmetry worth its own
+        // state. The guild is cached, so its channel list is as complete as
+        // the bot is allowed to see it; a channel absent from that list is
+        // one Discord withheld. Refusing here is reading an answer, not
+        // guessing at one, so it does not violate fail-open. Returning
+        // `Ok(())` instead is what let the join run on into songbird's ~10s
+        // `JoinError::TimedOut`, naming nothing.
+        JoinLookup::Withheld => Some(unreadable_refusal(channel)),
+        JoinLookup::Granted(granted) => voice_refusal(channel, granted),
+    }
+}
+
+/// Ask the cache what it knows about a join target. No HTTP, no `await`.
+///
+/// Takes cache handles rather than a poise `Context` on purpose — one of
+/// [`ensure_can_join`]'s call sites is a restart-resume with no invoking user
+/// and therefore no `Context`.
+fn join_lookup(cache: &Cache, guild_id: GuildId, channel_id: ChannelId) -> JoinLookup {
     let Some(guild) = cache.guild(guild_id) else {
-        return Ok(());
+        return JoinLookup::Unknown;
     };
     let bot_id = cache.current_user().id;
     let Some(bot) = guild.members.get(&bot_id) else {
-        return Ok(());
+        return JoinLookup::Unknown;
     };
-    let Some(chan) = guild.channels.get(&channel_id) else {
-        return Ok(());
-    };
-
-    let granted = guild.user_permissions_in(chan, bot);
-    match voice_refusal(channel_id, granted) {
-        Some(err) => Err(err),
-        None => Ok(()),
+    match guild.channels.get(&channel_id) {
+        Some(chan) => JoinLookup::Granted(guild.user_permissions_in(chan, bot)),
+        None => JoinLookup::Withheld,
     }
 }
 
@@ -205,10 +314,14 @@ mod tests {
 
     #[test]
     fn everything_granted_is_whole_and_joinable() {
-        let p = compute(text_ch(), TEXT_REQUIRED, Some((voice_ch(), VOICE_REQUIRED)));
+        let p = compute(
+            text_ch(),
+            TEXT_REQUIRED,
+            VoiceCheck::resolved(voice_ch(), VOICE_REQUIRED),
+        );
         assert!(p.text.is_whole());
         assert!(p.text.missing().is_empty());
-        let v = p.voice.expect("voice was supplied");
+        let v = p.voice.perms().expect("voice was supplied");
         assert!(v.can_join());
         assert!(v.missing().is_empty());
     }
@@ -216,8 +329,12 @@ mod tests {
     #[test]
     fn a_missing_speak_blocks_the_join_and_names_only_speak() {
         let granted = VOICE_REQUIRED - Permissions::SPEAK;
-        let p = compute(text_ch(), TEXT_REQUIRED, Some((voice_ch(), granted)));
-        let v = p.voice.expect("voice was supplied");
+        let p = compute(
+            text_ch(),
+            TEXT_REQUIRED,
+            VoiceCheck::resolved(voice_ch(), granted),
+        );
+        let v = p.voice.perms().expect("voice was supplied");
         assert!(!v.can_join());
         assert_eq!(v.missing(), Permissions::SPEAK);
         assert!(
@@ -232,9 +349,9 @@ mod tests {
         let p = compute(
             text_ch(),
             TEXT_REQUIRED,
-            Some((voice_ch(), Permissions::empty())),
+            VoiceCheck::resolved(voice_ch(), Permissions::empty()),
         );
-        let v = p.voice.expect("voice was supplied");
+        let v = p.voice.perms().expect("voice was supplied");
         assert_eq!(v.missing(), VOICE_REQUIRED);
         // The copy is built from Display on the whole set, so both names must
         // appear. This is the property the refusal message depends on.
@@ -246,22 +363,74 @@ mod tests {
     #[test]
     fn a_missing_embed_links_degrades_text_but_leaves_voice_joinable() {
         let granted = TEXT_REQUIRED - Permissions::EMBED_LINKS;
-        let p = compute(text_ch(), granted, Some((voice_ch(), VOICE_REQUIRED)));
+        let p = compute(
+            text_ch(),
+            granted,
+            VoiceCheck::resolved(voice_ch(), VOICE_REQUIRED),
+        );
         assert!(!p.text.is_whole());
         assert_eq!(p.text.missing(), Permissions::EMBED_LINKS);
         assert!(p.text.view() && p.text.send() && !p.text.embed());
-        assert!(p.voice.expect("voice was supplied").can_join());
+        assert!(p.voice.perms().expect("voice was supplied").can_join());
     }
 
     #[test]
-    fn no_voice_channel_is_none_not_a_denial() {
-        let p = compute(text_ch(), TEXT_REQUIRED, None);
-        // 🪤 `None` means "the author is in no voice channel", which is a
-        // different thing from "in a channel we cannot join". Rendering it as
-        // a denial would tell someone to grant a permission that is already
-        // granted.
-        assert!(p.voice.is_none());
+    fn no_voice_channel_is_its_own_state_not_a_denial() {
+        let p = compute(text_ch(), TEXT_REQUIRED, VoiceCheck::NotInVoice);
+        // 🪤 `NotInVoice` means "the author is in no voice channel", which is
+        // a different thing from "in a channel we cannot join". Rendering it
+        // as a denial would tell someone to grant a permission that is
+        // already granted.
+        assert_eq!(p.voice, VoiceCheck::NotInVoice);
+        assert!(p.voice.perms().is_none());
         assert!(p.text.is_whole());
+    }
+
+    #[test]
+    fn an_unseeable_voice_channel_is_not_the_same_state_as_no_voice_channel() {
+        let unreadable = compute(text_ch(), TEXT_REQUIRED, VoiceCheck::Unreadable(voice_ch()));
+        let absent = compute(text_ch(), TEXT_REQUIRED, VoiceCheck::NotInVoice);
+        // 🪤 Both have no `VoicePerms`, which is exactly how the two-state
+        // version collapsed them into one and told a user sitting in a voice
+        // channel that they were not in one. `perms()` returning `None` must
+        // never be read as "no voice channel".
+        assert!(unreadable.voice.perms().is_none());
+        assert!(absent.voice.perms().is_none());
+        assert_ne!(unreadable.voice, absent.voice);
+        assert_eq!(unreadable.voice, VoiceCheck::Unreadable(voice_ch()));
+    }
+
+    #[test]
+    fn a_channel_we_cannot_see_earns_a_view_channel_refusal_and_names_nothing_else() {
+        let err = unreadable_refusal(voice_ch());
+        match &err {
+            CrackedError::MissingBotPermissions {
+                scope,
+                channel,
+                missing,
+            } => {
+                assert_eq!(*scope, PermScope::Voice);
+                assert_eq!(*channel, voice_ch().widen());
+                assert_eq!(*missing, Permissions::VIEW_CHANNEL);
+            },
+            other => panic!("expected MissingBotPermissions, got {other:?}"),
+        }
+        let rendered = format!("{err}");
+        assert!(rendered.contains("View Channel"), "got {rendered}");
+        assert!(
+            rendered.contains(&format!("<#{}>", voice_ch())),
+            "must name the channel: {rendered}"
+        );
+        // 🪤 CONNECT and SPEAK are *unknown* here, not known-missing. Naming
+        // them would send an admin to grant permissions they already granted.
+        assert!(
+            !rendered.contains("Connect"),
+            "Connect is unknown, not missing: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Speak"),
+            "Speak is unknown, not missing: {rendered}"
+        );
     }
 
     #[test]
@@ -334,6 +503,45 @@ mod tests {
     // `voice_refusal` above and their *placement* by the source-scan guard in
     // Task 4. What is tested here is the one decision that is neither:
     // what they do when the cache cannot answer.
+
+    #[test]
+    fn an_unknown_lookup_refuses_nothing() {
+        // 🪤 Fail OPEN. Refusing a join we merely could not verify would
+        // break working guilds during the cache warm-up after every restart.
+        assert!(join_refusal(voice_ch(), JoinLookup::Unknown).is_none());
+    }
+
+    #[test]
+    fn a_withheld_channel_refuses_the_join_instead_of_waving_it_through() {
+        // 🪤 This is the C1 regression. The two-state version answered
+        // `Ok(())` here, so the join went ahead and songbird spent ~10s
+        // arriving at `JoinError::TimedOut`, which names nothing -- the exact
+        // symptom this module exists to delete.
+        let err = join_refusal(voice_ch(), JoinLookup::Withheld)
+            .expect("a channel Discord withheld must not be waved through");
+        match err {
+            CrackedError::MissingBotPermissions { missing, .. } => {
+                assert_eq!(missing, Permissions::VIEW_CHANNEL);
+            },
+            other => panic!("expected MissingBotPermissions, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_granted_lookup_defers_to_the_voice_bitset() {
+        assert!(join_refusal(voice_ch(), JoinLookup::Granted(VOICE_REQUIRED)).is_none());
+        let err = join_refusal(
+            voice_ch(),
+            JoinLookup::Granted(VOICE_REQUIRED - Permissions::CONNECT),
+        )
+        .expect("CONNECT is missing");
+        match err {
+            CrackedError::MissingBotPermissions { missing, .. } => {
+                assert_eq!(missing, Permissions::CONNECT);
+            },
+            other => panic!("expected MissingBotPermissions, got {other:?}"),
+        }
+    }
 
     #[test]
     fn the_gate_fails_open_when_the_cache_is_empty() {

--- a/crack-core/src/music/perms.rs
+++ b/crack-core/src/music/perms.rs
@@ -12,7 +12,7 @@
 //!   would be strictly worse for the user than playing silently.
 
 use poise::serenity_prelude as serenity;
-use serenity::all::{Cache, ChannelId, GenericChannelId, GuildId, Permissions, UserId};
+use serenity::all::{Cache, ChannelId, GenericChannelId, GuildId, Permissions, RoleId, UserId};
 
 use crate::errors::{CrackedError, PermScope};
 
@@ -142,10 +142,34 @@ pub fn compute(
     }
 }
 
+/// Whether every role the permission math depends on is actually in the cache.
+///
+/// 🪤 `Guild::user_permissions_in` has no way to say "unknown role". When a
+/// role id on the member is absent from `guild.roles`, or the `@everyone` role
+/// (whose id is the guild id) is, serenity substitutes `Permissions::empty()`
+/// for it and only logs — see `user_permissions_in_` in serenity's
+/// `model/guild/mod.rs`, the `@everyone role missing` error and the
+/// `has non-existent role` warning. The bitset that comes back is then
+/// **under**-reported, which would make the gate refuse a join that would have
+/// worked and send an admin to grant a permission they had already granted.
+/// That is the fail-open constraint violated in the worst direction, so both
+/// cache readers below check this first and give up rather than guess.
+///
+/// Takes a lookup closure rather than a `Guild` so the rule is pure and
+/// testable without a populated [`Cache`].
+pub fn roles_resolvable(
+    guild_id: GuildId,
+    member_roles: &[RoleId],
+    is_known: impl Fn(RoleId) -> bool,
+) -> bool {
+    is_known(RoleId::new(guild_id.get())) && member_roles.iter().all(|r| is_known(*r))
+}
+
 /// Read the bot's permissions out of the cache.
 ///
 /// Returns `None` when the guild, the bot's own member, or the text channel is
-/// not cached — callers treat that as "assume fine" rather than refusing.
+/// not cached, or when the bot's roles cannot all be resolved — callers treat
+/// that as "assume fine" rather than refusing.
 ///
 /// No HTTP on this path. `GatewayIntents::GUILD_MEMBERS` is enabled
 /// (`config.rs:321`), so the bot's own `Member` is cached and permissions
@@ -161,6 +185,12 @@ pub fn resolve(
     let bot_id = cache.current_user().id;
     let guild = cache.guild(guild_id)?;
     let bot = guild.members.get(&bot_id)?;
+
+    // An under-reported bitset is worse than no answer at all: see
+    // [`roles_resolvable`].
+    if !roles_resolvable(guild_id, &bot.roles, |r| guild.roles.get(&r).is_some()) {
+        return None;
+    }
 
     let text_chan = guild.channels.get(&text_channel.expect_channel())?;
     let text_granted = guild.user_permissions_in(text_chan, bot);
@@ -246,8 +276,8 @@ pub fn ensure_can_join(
 /// exists to prevent, one layer down.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JoinLookup {
-    /// Genuine ignorance — the guild is not cached, or the bot's own member
-    /// is not cached.
+    /// Genuine ignorance — the guild is not cached, the bot's own member is
+    /// not cached, or one of the bot's roles cannot be resolved.
     Unknown,
     /// The guild **is** cached and the channel is absent from it, which
     /// Discord does exactly when the bot lacks `VIEW_CHANNEL` there.
@@ -294,6 +324,11 @@ fn join_lookup(cache: &Cache, guild_id: GuildId, channel_id: ChannelId) -> JoinL
     let Some(bot) = guild.members.get(&bot_id) else {
         return JoinLookup::Unknown;
     };
+    // An under-reported bitset would refuse a join that works: see
+    // [`roles_resolvable`].
+    if !roles_resolvable(guild_id, &bot.roles, |r| guild.roles.get(&r).is_some()) {
+        return JoinLookup::Unknown;
+    }
     match guild.channels.get(&channel_id) {
         Some(chan) => JoinLookup::Granted(guild.user_permissions_in(chan, bot)),
         None => JoinLookup::Withheld,
@@ -303,7 +338,7 @@ fn join_lookup(cache: &Cache, guild_id: GuildId, channel_id: ChannelId) -> JoinL
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ::serenity::all::{ChannelId, GenericChannelId};
+    use ::serenity::all::{ChannelId, GenericChannelId, RoleId};
 
     fn text_ch() -> GenericChannelId {
         GenericChannelId::new(1)
@@ -431,6 +466,35 @@ mod tests {
             !rendered.contains("Speak"),
             "Speak is unknown, not missing: {rendered}"
         );
+    }
+
+    #[test]
+    fn a_role_the_cache_does_not_have_makes_the_bitset_untrustworthy() {
+        let gid = serenity::all::GuildId::new(10);
+        let everyone = RoleId::new(10);
+        let extra = RoleId::new(11);
+        let known = [everyone, extra];
+
+        assert!(
+            roles_resolvable(gid, &[extra], |r| known.contains(&r)),
+            "every role resolves, so the bitset can be trusted"
+        );
+        // 🪤 serenity substitutes Permissions::empty() for a role it cannot
+        // find and only logs, so the bitset comes back *under*-reported and
+        // the gate would refuse a join that works.
+        assert!(
+            !roles_resolvable(gid, &[RoleId::new(99)], |r| known.contains(&r)),
+            "an unknown bot role must not be silently treated as no permissions"
+        );
+    }
+
+    #[test]
+    fn a_missing_everyone_role_makes_the_bitset_untrustworthy() {
+        let gid = serenity::all::GuildId::new(10);
+        // @everyone carries the guild's baseline grants and its id is the
+        // guild id; without it every permission looks denied.
+        assert!(!roles_resolvable(gid, &[], |_| false));
+        assert!(roles_resolvable(gid, &[], |r| r == RoleId::new(10)));
     }
 
     #[test]

--- a/crack-core/src/music/perms.rs
+++ b/crack-core/src/music/perms.rs
@@ -652,7 +652,16 @@ mod tests {
 /// history count was. A join added in a fourth *file* would never be
 /// scanned, and the test would pass silently. So this walks `src/` at test
 /// time instead — the file set is discovered, not listed. Adding a fourth
-/// join site, in any file, fails this test until it is gated too.
+/// join site anywhere in `crack-core` fails this test until it is gated too.
+///
+/// 🪤 Anywhere in `crack-core`, and nowhere else. `crack-types` also depends
+/// on songbird, so a join added there is NOT guarded by this. The walk is
+/// not simply widened to the workspace root because the matcher below is not
+/// songbird-aware: `crack-sleevenote/src/client.rs` calls
+/// `self.join(&["health"])` on a URL builder, whose first argument is not a
+/// string literal either, and every such call would fail this test. Widening
+/// the walk means teaching the matcher what a songbird join looks like
+/// first.
 #[cfg(test)]
 mod join_site_guard_tests {
     use std::path::{Path, PathBuf};
@@ -661,8 +670,12 @@ mod join_site_guard_tests {
     const GATE: &str = "ensure_can_join(";
 
     /// How far back from a join to look for its gate. Generous enough to span
-    /// a `let Some(..) = ... else` or a log line in between, tight enough that
-    /// a gate on an unrelated earlier join cannot satisfy a later one.
+    /// a `let Some(..) = ... else` or a log line in between.
+    ///
+    /// 🪤 It does NOT pair a gate with its own join. Any two joins within
+    /// 1200 bytes of each other share a window, so an earlier join's gate
+    /// satisfies a later one. What this catches is an *ungated* join, not a
+    /// mis-paired one -- and no window size fixes that, only parsing would.
     const WINDOW: usize = 1200;
 
     /// This file, relative to `src/`. Excluded from the walk below: it
@@ -700,6 +713,20 @@ mod join_site_guard_tests {
         }
     }
 
+    /// Round a raw byte offset down to a char boundary.
+    ///
+    /// 🪤 `at - WINDOW` is arithmetic on bytes and can land inside a
+    /// multi-byte character. This repo puts 🪤, ⚠️ and ❌ in comments
+    /// routinely, so that is a question of when, not whether. Slicing there
+    /// panics with `str`'s byte-index error, which replaces the report this
+    /// test exists to produce with noise about UTF-8.
+    fn floor_boundary(src: &str, mut i: usize) -> usize {
+        while i > 0 && !src.is_char_boundary(i) {
+            i -= 1;
+        }
+        i
+    }
+
     /// Finds `.join(` calls that are songbird joins. String `.join(" ")` and
     /// friends are excluded by requiring the first argument to not be a
     /// literal.
@@ -716,6 +743,26 @@ mod join_site_guard_tests {
             from = at + ".join(".len();
         }
         out
+    }
+
+    #[test]
+    fn a_window_edge_inside_a_multibyte_character_reports_instead_of_panicking() {
+        // 🪤 The window edge is byte arithmetic, and this repo puts 🪤, ⚠️
+        // and ❌ in comments routinely, so it lands mid-character sooner or
+        // later. A raw slice there panics with `str`'s byte-index error,
+        // replacing the report this guard exists to print with noise about
+        // UTF-8 -- the test fails, but for the wrong reason and with the
+        // wrong message.
+        let src = "🪤 ensure_can_join( .join(x)";
+        for i in 1..4 {
+            assert!(!src.is_char_boundary(i), "byte {i} is inside the trap");
+            assert_eq!(floor_boundary(src, i), 0);
+            // The point: this does not panic.
+            let _ = &src[floor_boundary(src, i)..];
+        }
+        // A boundary is left exactly where it is.
+        assert_eq!(floor_boundary(src, 4), 4);
+        assert_eq!(floor_boundary(src, 0), 0);
     }
 
     #[test]
@@ -737,7 +784,7 @@ mod join_site_guard_tests {
                 .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
             for at in songbird_join_offsets(&src) {
                 checked += 1;
-                let start = at.saturating_sub(WINDOW);
+                let start = floor_boundary(&src, at.saturating_sub(WINDOW));
                 let before = &src[start..at];
                 assert!(
                     before.contains(GATE),
@@ -749,7 +796,7 @@ mod join_site_guard_tests {
                      test.\n\n\
                      Context:\n{}",
                     rel.display(),
-                    &src[start.max(at.saturating_sub(300))..at]
+                    &src[floor_boundary(&src, start.max(at.saturating_sub(300)))..at]
                 );
             }
         }

--- a/crack-core/src/utils.rs
+++ b/crack-core/src/utils.rs
@@ -296,19 +296,34 @@ pub async fn edit_reponse_interaction(
 }
 
 /// Edit the embed response of the given message.
+///
+/// `content` is for text that must survive when the embed does not. 🪤 A
+/// channel without `EMBED_LINKS` has its embeds stripped by Discord, so a
+/// notice about that very permission is invisible if it rides inside one.
 #[cfg(not(tarpaulin_include))]
 pub async fn edit_embed_response2(
     ctx: CrackContext<'_>,
     embed: CreateEmbed<'_>,
     msg: ReplyHandle<'_>,
+    content: Option<String>,
 ) -> Result<Message, Error> {
     match get_interaction(ctx) {
-        Some(interaction) => interaction
-            .edit_response(ctx.http(), EditInteractionResponse::new().add_embed(embed))
-            .await
-            .map_err(Into::into),
+        Some(interaction) => {
+            let mut edit = EditInteractionResponse::new().add_embed(embed);
+            if let Some(content) = content {
+                edit = edit.content(content);
+            }
+            interaction
+                .edit_response(ctx.http(), edit)
+                .await
+                .map_err(Into::into)
+        },
         None => {
-            msg.edit(ctx, CreateReply::default().embed(embed)).await?;
+            let mut reply = CreateReply::default().embed(embed);
+            if let Some(content) = content {
+                reply = reply.content(content);
+            }
+            msg.edit(ctx, reply).await?;
             Ok(msg.into_message().await?)
             // let msg = msg.into_message().await?;
             // msg.edit(&ctx, EditMessage::new().embed(embed))


### PR DESCRIPTION
Closes #496. Follow-up to ct#495, landing **before** v0.9.7 is tagged — the
release does not exist yet, so none of this reached anyone.

ct#495's whole-branch review arrived after that PR merged (its results were
generated but never delivered). It found a Critical and three Importants.

## Critical — #496

**A voice channel the bot cannot see read as "you're not in a voice channel",
and the gate waved the join through.**

Discord omits channels the bot lacks `VIEW_CHANNEL` on from `GUILD_CREATE`, so
`guild.channels` has no entry. In `resolve`, the `?` on the channel lookup sat
**inside** the `and_then` closure, collapsing "present but unreadable" into the
same `None` as "in no voice channel". `/diagnose` said *"you're not in a voice
channel, join one and run this again"* — false and unfollowable — and `/play`
sailed past the gate into songbird's ~10s `TimedOut`.

**That is the exact symptom the feature exists to delete.** Two reviewers found
it independently.

Fixed with a third state:

```rust
pub enum VoiceCheck {
    NotInVoice,              // not a denial
    Unreadable(ChannelId),   // missing VIEW_CHANNEL — which is why we never got it
    Resolved(VoicePerms),
}
```

🔑 **Why refusing here does not violate fail-open.** The branch's binding rule
is that a check which cannot read the cache returns "fine", never "refused".
That still holds. The distinction: a **guild** missing from cache is genuine
ignorance, so we fail open. A **channel** absent from an *already-cached* guild
is **information** — Discord would have sent it if we could see it. So the
refusal is not a guess, and it names the real missing permission instead of
timing out silently.

## Important

**The gate could fail CLOSED when a bot role was uncached.** `user_permissions_in`
does not signal "unknown role" — serenity substitutes `Permissions::empty()`
and only logs. A cached guild with one of the bot's roles absent from
`guild.roles` yielded an under-reported bitset, hence a refusal of a join that
would have worked, telling an admin to grant a permission they already granted.
Now guarded by a pure `roles_resolvable`, applied in both `resolve` and
`ensure_can_join`.

**The degraded-permissions notice rode inside the embed it warned about.** On a
prefix `r!play` without `EMBED_LINKS`, Discord strips the embed — so "Missing
**Embed Links** here" reached nobody, precisely when it applied. The note now
travels as reply **content** when `EMBED_LINKS` is among the missing set, and
stays an embed field otherwise.

**The notice could have shipped entirely dead.** Its four tests exercised the
private helper in isolation; deleting the wiring left them all green. A
`degraded_notice_wiring_tests` module now pins what the built reply actually
carries.

## 🪤 The C1 fix was itself unpinned, and only sabotage caught it

The first version of the C1 fix looked complete: four clean commits, full gate
green, 249 tests passing, reviewers satisfied.

Then reverting the one line that carries the bug —
`None => VoiceCheck::Unreadable(cid)` back to `NotInVoice` — **left all 249
tests passing.** The new tests handed `Unreadable` to `compute` directly and
checked `compute` kept the states apart, which it does; but the *classification*
lives in `resolve`'s cache-reading glue, which no test reached.

That is the same structural gap that produced the original bug, and the same one
`voice_refusal` was extracted to close for `ensure_can_join`. So `classify_voice`
is now a pure function taking closures, and the same sabotage fails two tests
that name exactly what broke.

This was the **fifth** test on this feature that passed against broken code, and
the first found by deliberately reintroducing the bug rather than by reading it.
Every behavioural fix here was accepted only after that demonstration.

## Also

- The join-site guard's comment claimed a fourth join "IN ANY FILE" fails the
  test. False — the walk covers `crack-core` only, and `crack-types` also
  depends on songbird. Comment corrected to say what is actually guarded. (Not
  widened: `crack-sleevenote` has `.join(&["health"])` calls that a naive walk
  false-positives on.)
- The guard's error-context slicing used raw byte offsets that could land
  mid-UTF-8 and panic rather than report — in a repo that routinely puts
  🪤/⚠️/❌ in comments. Now char-boundary-safe.
- The `WINDOW` comment claimed a gate on an earlier join could not satisfy a
  later one. Also false; reworded.
- `/diagnose` in a thread said "try again in a moment", a retry that can never
  succeed (threads live in `guild.threads`). Copy no longer implies transience.
- Stale comment in `gp_persist.rs` referring to a "below" that the
  `abandon_resume` extraction removed.
- Oxford-comma correction in an `errors.rs` comment.

## Gate

`cargo fmt --all -- --check` clean · `cargo clippy --all -- -D clippy::all -D
warnings` zero warnings · `SQLX_OFFLINE=true cargo check` clean ·
`cargo test --workspace` — crack-core **256 passed**.

Measured baselines, since ct#495's body originally quoted a figure taken from
the wrong branch: `git grep -h '#\[test\]' <rev> -- crack-core/src` gives
**173** at `3b1c486` (pre-ct#495), **195** after ct#495, **and 214 here.**

`crack-testing::tests::test_enqueue_query` still fails; it hits live YouTube and
panics only when `CI` is unset (`crack-testing/src/lib.rs:840`), unrelated to
this branch. ct#471.

