### PR TITLE
fix(summon): the join path never answered, and reported failure as success

### DIFF
--- a/crack-core/src/commands/music/summon.rs
+++ b/crack-core/src/commands/music/summon.rs
@@ -54,6 +54,12 @@ pub async fn summon_internal(
     channel: Option<Channel>,
     channel_id_str: Option<String>,
 ) -> Result<(), Error> {
+    // A voice handshake can outlive Discord's three-second interaction
+    // deadline -- songbird waits a full 10s before giving up -- so defer
+    // before touching it. Without this a slow or refused join answers an
+    // already-dead token: the user sees "The application did not respond"
+    // and the eventual reply 404s.
+    ctx.defer().await?;
     let guild_id = ctx.guild_id().ok_or(CrackedError::GuildOnly)?;
     let manager = ctx.data().songbird.clone();
     let guild = ctx.guild().ok_or(CrackedError::NoGuildCached)?.clone();

--- a/crack-core/src/commands/music/summon.rs
+++ b/crack-core/src/commands/music/summon.rs
@@ -1,4 +1,4 @@
-use crate::commands::{cmd_check_music, do_join, help, sub_help as help};
+use crate::commands::{cmd_check_music, connected_call, do_join, help, sub_help as help};
 use crate::{
     connection::get_voice_channel_for_user_summon, errors::CrackedError, poise_ext::ContextExt,
     Context, Error,
@@ -54,12 +54,6 @@ pub async fn summon_internal(
     channel: Option<Channel>,
     channel_id_str: Option<String>,
 ) -> Result<(), Error> {
-    // A voice handshake can outlive Discord's three-second interaction
-    // deadline -- songbird waits a full 10s before giving up -- so defer
-    // before touching it. Without this a slow or refused join answers an
-    // already-dead token: the user sees "The application did not respond"
-    // and the eventual reply 404s.
-    ctx.defer().await?;
     let guild_id = ctx.guild_id().ok_or(CrackedError::GuildOnly)?;
     let manager = ctx.data().songbird.clone();
     let guild = ctx.guild().ok_or(CrackedError::NoGuildCached)?.clone();
@@ -70,20 +64,26 @@ pub async fn summon_internal(
         None => get_voice_channel_for_user_summon(&guild, &user_id)?,
     };
 
-    let call: Arc<Mutex<Call>> = match manager.get(guild_id) {
+    // 🪤 This must ask for a *connected* call, not merely a registered one.
+    // songbird keeps the Call after a failed join or a forced disconnect, and
+    // the old `manager.get` accepted it: the `_ => call.clone()` arm below
+    // returned that dead handle, so `do_join` never ran, `ensure_can_join`
+    // never ran, no join was attempted and the command returned Ok having
+    // sent nothing at all.
+    let call: Arc<Mutex<Call>> = match connected_call(&manager, guild_id, None).await {
         Some(call) => {
-            let handler = call.lock().await;
-            let has_current_connection = handler.current_connection().is_some();
-            let chan_id = handler
+            let chan_id = call
+                .lock()
+                .await
                 .current_channel()
                 .map(|c| GenericChannelId::new(c.get()));
 
-            match (has_current_connection, chan_id) {
-                (true, Some(chan_id)) => {
+            match chan_id {
+                Some(chan_id) => {
                     // bot is in another channel
                     return Err(CrackedError::AlreadyConnected(chan_id.mention()).into());
                 },
-                _ => call.clone(),
+                None => call.clone(),
             }
         },
         None => do_join(ctx, &manager, guild_id, channel_id).await?,

--- a/crack-core/src/commands/music_utils.rs
+++ b/crack-core/src/commands/music_utils.rs
@@ -116,6 +116,23 @@ pub async fn get_call_or_join_author(ctx: Context<'_>) -> Result<Arc<Mutex<Call>
     // Ok(call)
 }
 
+/// The guild's Call, but only if it actually carries a voice connection.
+///
+/// 🪤 `Songbird::get` is not a connection test. songbird registers the Call
+/// when a join is *attempted*, before the gateway handshake, so a join that
+/// timed out still hands one back. `do_join` used to treat that as success:
+/// it registered handlers, sent a "Summoned" embed and logged "joined
+/// channel" while the bot sat in no voice channel at all -- which is why a
+/// total failure left no error anywhere in the log.
+async fn connected_call(
+    manager: &songbird::Songbird,
+    guild_id: GuildId,
+) -> Option<Arc<Mutex<Call>>> {
+    let call = manager.get(guild_id)?;
+    let connected = call.lock().await.current_connection().is_some();
+    connected.then_some(call)
+}
+
 /// Join a voice channel.
 #[cfg(not(tarpaulin_include))]
 #[tracing::instrument]
@@ -131,6 +148,18 @@ pub async fn do_join(
         .ok_or(CrackedError::NoGuildCached)?
         .clone();
     let guild_name = guild.name;
+    // Refuse a join Discord would silently drop. Without this the voice state
+    // update is accepted, nothing happens, and songbird reports TimedOut ~10s
+    // later with no mention of a permission.
+    //
+    // 🪤 This MUST come before the channel-name lookup below. Discord omits a
+    // voice channel the bot lacks VIEW_CHANNEL on from GUILD_CREATE entirely,
+    // so `guild.channels.get` misses exactly when the gate has the most to
+    // say — and `NoChannelId` would win the race and report nothing useful.
+    // That ordering made `JoinLookup::Withheld` unreachable from this, the
+    // busiest of the three join sites.
+    crate::music::perms::ensure_can_join(ctx.cache(), guild_id, channel_id)
+        .map_err(|e| -> Error { Box::new(e) })?;
     let channel_name = guild
         .channels
         .get(&channel_id)
@@ -141,17 +170,15 @@ pub async fn do_join(
     tracing::warn!(
         "Joining channel: {channel_name} ({channel_id:?}) in {guild_name} ({guild_id:?})"
     );
-    // Refuse a join Discord would silently drop. Without this the voice state
-    // update is accepted, nothing happens, and songbird reports TimedOut ~10s
-    // later with no mention of a permission.
-    crate::music::perms::ensure_can_join(ctx.cache(), guild_id, channel_id)
-        .map_err(|e| -> Error { Box::new(e) })?;
     let call = match manager.join(guild_id, channel_id).await {
         Ok(call) => call,
-        Err(err) => match manager.get(guild_id) {
+        Err(err) => match connected_call(manager, guild_id).await {
             Some(call) => call,
             None => {
                 tracing::warn!("Error joining channel: {:?}", err);
+                // Drop the connectionless Call, or the next summon finds it
+                // via `manager.get` and reports success without ever trying.
+                let _ = manager.remove(guild_id).await;
                 // let str = err.to_string().clone();
                 let my_err = CrackedError::JoinChannelError(err);
                 // let crack_msg = CrackedMessage::CrackedRed(str.clone());
@@ -176,4 +203,119 @@ pub async fn do_join(
         },
     };
     Ok(call)
+}
+
+/// Source-order guards for `do_join`'s three ordering bugs, all of which cost
+/// a production `/summon` its answer (see the 2026-09-12 RuneCast trace).
+///
+/// 🪤 These assert on source text, not behaviour. `do_join` takes a poise
+/// `Context` and a live `songbird::Songbird`, neither of which is
+/// constructible offline, so the decisions they pin have no reachable seam --
+/// unlike `perms::join_refusal`, which was extracted precisely so it would.
+/// A guard that reads the file is weaker than a test that runs the code; it
+/// is far stronger than the nothing that was here while all three shipped.
+#[cfg(test)]
+mod join_order_guard_tests {
+    /// 🪤 Builds the path by formatting rather than `Path::join`, on purpose,
+    /// and this comment avoids spelling that method call out.
+    /// `perms::join_site_guard_tests` scans source text for a join whose first
+    /// argument is not a string literal and calls it a songbird join, so
+    /// joining a path with a variable -- or merely naming the method in prose,
+    /// which cost a second red run to notice -- reads as an ungated join. The
+    /// heuristic is deliberately conservative: a false positive is loud and
+    /// cheap, a false negative is silent and cost ct#496. The fix belongs on
+    /// this side, not in that guard.
+    fn read(rel: &str) -> String {
+        let path = format!("{}/src/{rel}", env!("CARGO_MANIFEST_DIR"));
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
+    }
+
+    /// The body of one function, bounded at the next `}` in column 0, with
+    /// `//` comments stripped.
+    ///
+    /// Bounding matters: this very module lives in `music_utils.rs` and
+    /// contains every literal searched for below. An unbounded slice would
+    /// let the test satisfy itself -- the trap `perms.rs` names `SELF_PATH`.
+    ///
+    /// 🪤 Stripping comments matters just as much, and cost a red test to
+    /// learn: the comment *explaining* why the gate precedes the channel
+    /// lookup names `NoChannelId`, and sits above the gate. Searching raw
+    /// text found the prose first and failed correct code. A guard that reads
+    /// commentary is not reading the program.
+    fn body_of(src: &str, signature: &str) -> String {
+        let start = src.find(signature).unwrap_or_else(|| {
+            panic!("{signature} not found -- guard is looking at the wrong file")
+        });
+        let rest = &src[start..];
+        let end = rest.find("\n}\n").expect("unterminated function body");
+        rest[..end]
+            .lines()
+            .map(|line| match line.find("//") {
+                Some(i) => &line[..i],
+                None => line,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn gate_runs_before_the_channel_name_lookup() {
+        let body = body_of(&read("commands/music_utils.rs"), "pub async fn do_join(");
+        let gate = body
+            .find("ensure_can_join(")
+            .expect("do_join lost its gate");
+        let lookup = body
+            .find("NoChannelId")
+            .expect("do_join lost its channel-name lookup -- rewrite this guard");
+        assert!(
+            gate < lookup,
+            "`ensure_can_join` must precede the `NoChannelId` lookup. Discord omits a \
+             voice channel the bot cannot see from GUILD_CREATE, so the lookup misses \
+             exactly when the gate has the most to say, and `JoinLookup::Withheld` \
+             becomes unreachable from this join site."
+        );
+    }
+
+    #[test]
+    fn a_failed_join_is_not_reported_as_success() {
+        let body = body_of(&read("commands/music_utils.rs"), "pub async fn do_join(");
+        assert!(
+            body.contains("connected_call(manager, guild_id)"),
+            "the join-failure fallback must go through `connected_call`"
+        );
+        assert!(
+            !body.contains("manager.get(guild_id)"),
+            "`do_join` must not consult `Songbird::get` directly: it returns a Call for a \
+             join that only *started*, so a timed-out join is reported as success. Route \
+             it through `connected_call`, which checks for an actual connection."
+        );
+        let helper = body_of(&read("commands/music_utils.rs"), "async fn connected_call(");
+        assert!(
+            helper.contains("current_connection().is_some()"),
+            "`connected_call` must test the connection, not merely fetch the Call"
+        );
+        assert!(
+            body.contains("manager.remove(guild_id)"),
+            "a connectionless Call must be dropped, or the next summon finds it via \
+             `manager.get` and reports success without ever attempting a join"
+        );
+    }
+
+    #[test]
+    fn summon_defers_before_joining() {
+        let body = body_of(
+            &read("commands/music/summon.rs"),
+            "pub async fn summon_internal(",
+        );
+        let defer = body
+            .find("ctx.defer()")
+            .expect("summon_internal must defer: a join can take 10s, the token dies at 3s");
+        let join = body
+            .find("do_join(")
+            .expect("summon_internal no longer calls do_join -- rewrite this guard");
+        assert!(
+            defer < join,
+            "the defer must precede the join, not follow it"
+        );
+    }
 }

--- a/crack-core/src/commands/music_utils.rs
+++ b/crack-core/src/commands/music_utils.rs
@@ -87,9 +87,14 @@ pub async fn set_global_handlers_with(
 pub async fn get_call_or_join_author(ctx: Context<'_>) -> Result<Arc<Mutex<Call>>, CrackedError> {
     let guild_id = ctx.guild_id().ok_or(CrackedError::NoGuildId)?;
     let manager = ctx.data().songbird.clone();
-    // Return the call if it already exists.
+    // Return the call if it already exists AND actually carries a connection.
     // Otherwise, try to join the channel of the user who sent the message.
-    if let Some(call) = manager.get(guild_id) {
+    //
+    // 🪤 `Songbird::get` alone was the bug: a connectionless Call short-
+    // circuited the join here, so `/play` and `/downvote` bypassed
+    // `ensure_can_join` and enqueued into a driver connected to nothing --
+    // a "Queued" embed and silence, with no error anywhere.
+    if let Some(call) = connected_call(&manager, guild_id, None).await {
         Ok(call)
     } else {
         let channel_id = {
@@ -116,21 +121,41 @@ pub async fn get_call_or_join_author(ctx: Context<'_>) -> Result<Arc<Mutex<Call>
     // Ok(call)
 }
 
-/// The guild's Call, but only if it actually carries a voice connection.
+/// The guild's Call, but only if it actually carries a voice connection --
+/// and, when `expect` is given, only if that connection is to that channel.
 ///
-/// 🪤 `Songbird::get` is not a connection test. songbird registers the Call
-/// when a join is *attempted*, before the gateway handshake, so a join that
-/// timed out still hands one back. `do_join` used to treat that as success:
-/// it registered handlers, sent a "Summoned" embed and logged "joined
-/// channel" while the bot sat in no voice channel at all -- which is why a
-/// total failure left no error anywhere in the log.
-async fn connected_call(
+/// 🪤 `Songbird::get` is not a connection test, and this is the only place in
+/// the crate allowed to call it (`join_order_guard_tests` enforces that).
+/// songbird registers the Call when a join is *attempted*, before the gateway
+/// handshake, so a join that timed out still hands one back. Three call sites
+/// used to treat that as success: `do_join` registered handlers and sent a
+/// "Summoned" embed for a bot in no voice channel, and `summon_internal` and
+/// `get_call_or_join_author` skipped the join -- and therefore the permission
+/// gate -- entirely.
+///
+/// 🪤 `expect` matters because "connected" is not "connected to the channel
+/// you asked for". A concurrent `/gp` resume can land a join on another
+/// channel between a failed `manager.join` and this check, and without the
+/// comparison `do_join` would announce "Summoned <#B>" for a bot in A.
+pub(crate) async fn connected_call(
     manager: &songbird::Songbird,
     guild_id: GuildId,
+    expect: Option<ChannelId>,
 ) -> Option<Arc<Mutex<Call>>> {
     let call = manager.get(guild_id)?;
-    let connected = call.lock().await.current_connection().is_some();
-    connected.then_some(call)
+    let (connected, here) = {
+        let handler = call.lock().await;
+        (
+            handler.current_connection().is_some(),
+            handler.current_channel(),
+        )
+    };
+    match (connected, here, expect) {
+        (false, _, _) => None,
+        (true, _, None) => Some(call),
+        (true, Some(here), Some(want)) => (here.get() == want.get()).then_some(call),
+        (true, None, Some(_)) => None,
+    }
 }
 
 /// Join a voice channel.
@@ -170,15 +195,32 @@ pub async fn do_join(
     tracing::warn!(
         "Joining channel: {channel_name} ({channel_id:?}) in {guild_name} ({guild_id:?})"
     );
+    // Every join that gets this far can outlive Discord's three-second
+    // interaction deadline -- songbird's gateway_timeout is 10s -- so defer
+    // here, the one point every command's join funnels through, rather than
+    // in each of them. poise's defer is idempotent and a no-op on prefix
+    // commands, so callers that already deferred pay nothing.
+    //
+    // Deliberately AFTER the gate: a refusal is cache-only and answers in
+    // microseconds, so it should not spend a round-trip on "thinking...".
+    ctx.defer().await?;
     let call = match manager.join(guild_id, channel_id).await {
         Ok(call) => call,
-        Err(err) => match connected_call(manager, guild_id).await {
+        Err(err) => match connected_call(manager, guild_id, Some(channel_id)).await {
             Some(call) => call,
             None => {
                 tracing::warn!("Error joining channel: {:?}", err);
-                // Drop the connectionless Call, or the next summon finds it
-                // via `manager.get` and reports success without ever trying.
-                let _ = manager.remove(guild_id).await;
+                // Drop the connectionless Call, or the next join finds it and
+                // reports success without ever trying. songbird's `remove` is
+                // `leave(..)?` *then* `calls.remove(..)`, so a failing leave
+                // skips the removal -- log it rather than discarding the only
+                // signal that the Call is still registered.
+                if let Err(e) = manager.remove(guild_id).await {
+                    tracing::warn!(
+                        "Could not remove the connectionless Call for {guild_id:?}: {e:?}. \
+                         A later join may find it and skip the permission gate."
+                    );
+                }
                 // let str = err.to_string().clone();
                 let my_err = CrackedError::JoinChannelError(err);
                 // let crack_msg = CrackedMessage::CrackedRed(str.clone());
@@ -280,42 +322,95 @@ mod join_order_guard_tests {
     fn a_failed_join_is_not_reported_as_success() {
         let body = body_of(&read("commands/music_utils.rs"), "pub async fn do_join(");
         assert!(
-            body.contains("connected_call(manager, guild_id)"),
-            "the join-failure fallback must go through `connected_call`"
-        );
-        assert!(
-            !body.contains("manager.get(guild_id)"),
-            "`do_join` must not consult `Songbird::get` directly: it returns a Call for a \
-             join that only *started*, so a timed-out join is reported as success. Route \
-             it through `connected_call`, which checks for an actual connection."
-        );
-        let helper = body_of(&read("commands/music_utils.rs"), "async fn connected_call(");
-        assert!(
-            helper.contains("current_connection().is_some()"),
-            "`connected_call` must test the connection, not merely fetch the Call"
+            body.contains("connected_call(manager, guild_id, Some(channel_id))"),
+            "the join-failure fallback must go through `connected_call`, and must name \
+             the channel it asked for -- a Call connected to a *different* channel is \
+             not a successful join of this one"
         );
         assert!(
             body.contains("manager.remove(guild_id)"),
-            "a connectionless Call must be dropped, or the next summon finds it via \
-             `manager.get` and reports success without ever attempting a join"
+            "a connectionless Call must be dropped, or a later join finds it and skips \
+             the gate"
+        );
+        assert!(
+            !body.contains("let _ = manager.remove"),
+            "songbird's `remove` is `leave(..)?` then `calls.remove(..)`, so a failing \
+             leave skips the removal entirely. Discarding that error hides the fact \
+             that the Call is still registered."
+        );
+    }
+
+    /// The twin-hunting guard. The narrow version of this pinned `do_join`
+    /// alone and read green while two live copies of the same defect shipped
+    /// on the `/summon` and `/play` entry points.
+    #[test]
+    fn songbird_get_is_reachable_only_through_connected_call() {
+        let files = ["commands/music_utils.rs", "commands/music/summon.rs"];
+        let mut inspected = 0usize;
+        for rel in files {
+            // 🪤 Stop at the first test module. This very guard contains the
+            // literal it searches for, so scanning itself fails itself -- the
+            // fourth time in this change that a scanner tripped over text
+            // written about it. A guard reads the program, not the tests.
+            let whole = read(rel);
+            let src = match whole.find("#[cfg(test)]") {
+                Some(i) => whole[..i].to_string(),
+                None => whole,
+            };
+            let helper_body = if rel.ends_with("music_utils.rs") {
+                body_of(&src, "pub(crate) async fn connected_call(")
+            } else {
+                String::new()
+            };
+            for (n, line) in src.lines().enumerate() {
+                let code = match line.find("//") {
+                    Some(i) => &line[..i],
+                    None => line,
+                };
+                if !code.contains("manager.get(") {
+                    continue;
+                }
+                inspected += 1;
+                assert!(
+                    helper_body.lines().any(|h| h.trim() == code.trim()),
+                    "{rel}:{}: `Songbird::get` outside `connected_call`.\n\n\
+                     It returns a Call for a join that only *started*, so this reads a \
+                     connectionless handle as a live one -- skipping the join, and with \
+                     it `ensure_can_join`. Route it through `connected_call`.\n\n  {}",
+                    n + 1,
+                    code.trim()
+                );
+            }
+        }
+        assert!(
+            inspected >= 1,
+            "scanned {inspected} `manager.get(` sites across {} files -- the scan has \
+             stopped checking rather than the calls being gone. Fix the scan.",
+            files.len()
         );
     }
 
     #[test]
-    fn summon_defers_before_joining() {
-        let body = body_of(
-            &read("commands/music/summon.rs"),
-            "pub async fn summon_internal(",
+    fn do_join_defers_before_the_handshake() {
+        let body = body_of(&read("commands/music_utils.rs"), "pub async fn do_join(");
+        let defer = body.find("ctx.defer()").expect(
+            "do_join must defer: songbird waits 10s for the handshake, the interaction \
+             token dies at 3s. It is the one point every command's join funnels through.",
         );
-        let defer = body
-            .find("ctx.defer()")
-            .expect("summon_internal must defer: a join can take 10s, the token dies at 3s");
         let join = body
-            .find("do_join(")
-            .expect("summon_internal no longer calls do_join -- rewrite this guard");
+            .find("manager.join(")
+            .expect("do_join no longer joins -- rewrite this guard");
+        let gate = body
+            .find("ensure_can_join(")
+            .expect("do_join lost its gate -- see the other guard");
         assert!(
             defer < join,
-            "the defer must precede the join, not follow it"
+            "the defer must precede the handshake it exists to outlast"
+        );
+        assert!(
+            gate < defer,
+            "the gate must precede the defer: a refusal is cache-only and answers in \
+             microseconds, so it should not spend a round-trip on \"thinking...\""
         );
     }
 }

--- a/crack-core/src/commands/music_utils.rs
+++ b/crack-core/src/commands/music_utils.rs
@@ -284,18 +284,64 @@ mod join_order_guard_tests {
     /// lookup names `NoChannelId`, and sits above the gate. Searching raw
     /// text found the prose first and failed correct code. A guard that reads
     /// commentary is not reading the program.
+    /// Drop a trailing `//` comment, but not the `//` in a URL.
+    ///
+    /// 🪤 A naive cut at the first `//` truncates any line holding a
+    /// `https://` literal -- routine in a Discord bot -- and a guard that
+    /// silently scans less than it claims is the failure this whole module
+    /// exists to prevent.
+    fn strip_comment(line: &str) -> &str {
+        let b = line.as_bytes();
+        let mut i = 0;
+        while i + 1 < b.len() {
+            if b[i] == b'/' && b[i + 1] == b'/' {
+                if i > 0 && b[i - 1] == b':' {
+                    i += 2;
+                    continue;
+                }
+                return &line[..i];
+            }
+            i += 1;
+        }
+        line
+    }
+
+    #[test]
+    fn strip_comment_cuts_comments_and_keeps_urls() {
+        assert_eq!(strip_comment("let x = 1; // note"), "let x = 1; ");
+        assert_eq!(strip_comment("// whole line"), "");
+        assert_eq!(strip_comment("no comment here"), "no comment here");
+        assert_eq!(
+            strip_comment(r#"warn!("see https://x/y");"#),
+            r#"warn!("see https://x/y");"#
+        );
+        assert_eq!(
+            strip_comment(r#"let u = "https://a"; // trailing"#),
+            r#"let u = "https://a"; "#
+        );
+    }
+
     fn body_of(src: &str, signature: &str) -> String {
         let start = src.find(signature).unwrap_or_else(|| {
             panic!("{signature} not found -- guard is looking at the wrong file")
         });
+        // 🪤 `find` takes the FIRST match, and the test module below holds
+        // these same signatures as string literals. That resolves to the real
+        // definition only because the module happens to sit at the bottom of
+        // the file -- position, not design. Pin it, so moving this module up
+        // fails loudly instead of silently parsing its own literals.
+        if let Some(tests) = src.find("#[cfg(test)]") {
+            assert!(
+                start < tests,
+                "`{signature}` was first found inside a test module. `body_of` is \
+                 parsing the guard's own string literals, not the program."
+            );
+        }
         let rest = &src[start..];
         let end = rest.find("\n}\n").expect("unterminated function body");
         rest[..end]
             .lines()
-            .map(|line| match line.find("//") {
-                Some(i) => &line[..i],
-                None => line,
-            })
+            .map(strip_comment)
             .collect::<Vec<_>>()
             .join("\n")
     }
@@ -363,10 +409,7 @@ mod join_order_guard_tests {
                 String::new()
             };
             for (n, line) in src.lines().enumerate() {
-                let code = match line.find("//") {
-                    Some(i) => &line[..i],
-                    None => line,
-                };
+                let code = strip_comment(line);
                 if !code.contains("manager.get(") {
                     continue;
                 }

--- a/crack-core/src/commands/music_utils.rs
+++ b/crack-core/src/commands/music_utils.rs
@@ -124,14 +124,19 @@ pub async fn get_call_or_join_author(ctx: Context<'_>) -> Result<Arc<Mutex<Call>
 /// The guild's Call, but only if it actually carries a voice connection --
 /// and, when `expect` is given, only if that connection is to that channel.
 ///
-/// 🪤 `Songbird::get` is not a connection test, and this is the only place in
-/// the crate allowed to call it (`join_order_guard_tests` enforces that).
-/// songbird registers the Call when a join is *attempted*, before the gateway
-/// handshake, so a join that timed out still hands one back. Three call sites
-/// used to treat that as success: `do_join` registered handlers and sent a
-/// "Summoned" embed for a bot in no voice channel, and `summon_internal` and
-/// `get_call_or_join_author` skipped the join -- and therefore the permission
-/// gate -- entirely.
+/// 🪤 `Songbird::get` is not a connection test. songbird registers the Call
+/// when a join is *attempted*, before the gateway handshake, so a join that
+/// timed out still hands one back. Three call sites used to treat that as
+/// success: `do_join` registered handlers and sent a "Summoned" embed for a
+/// bot in no voice channel, and `summon_internal` and `get_call_or_join_author`
+/// skipped the join -- and therefore the permission gate -- entirely.
+///
+/// This is the only `Songbird::get` **on the join path**, which is what
+/// `join_order_guard_tests` enforces, over `music_utils.rs` and `summon.rs`.
+/// It is NOT the only one in the crate: ~20 other sites read the Call to
+/// answer "are we playing?" for `/queue`, `/volume`, `/clear` and friends.
+/// Those want a registered Call and are mostly harmless, but several would
+/// also be better off asking this question -- tracked separately.
 ///
 /// 🪤 `expect` matters because "connected" is not "connected to the channel
 /// you asked for". A concurrent `/gp` resume can land a join on another
@@ -159,6 +164,23 @@ pub(crate) async fn connected_call(
 }
 
 /// Join a voice channel.
+///
+/// Defers before the handshake, and only there. Every join that reaches
+/// `Songbird::join` can outlive Discord's three-second interaction deadline --
+/// songbird's `gateway_timeout` is 10s -- and this is the one point every
+/// command's join funnels through, so the defer belongs here rather than in
+/// each of them. poise's defer is idempotent and a no-op on prefix commands,
+/// so a caller that already deferred pays nothing.
+///
+/// It sits deliberately *after* the permission gate: a refusal is cache-only
+/// and answers in microseconds, so it should not spend a round-trip putting
+/// the user on "thinking...".
+///
+/// 🪤 Keep the body between the gate and `manager.join` short.
+/// `perms::join_site_guard_tests` asserts the gate appears within 1200 bytes
+/// before the join, so prose added between them eats that budget and makes an
+/// unrelated guard fail with a misleading "ungated join" message. That is why
+/// this rationale lives up here and not inline.
 #[cfg(not(tarpaulin_include))]
 #[tracing::instrument]
 pub async fn do_join(
@@ -183,8 +205,31 @@ pub async fn do_join(
     // say — and `NoChannelId` would win the race and report nothing useful.
     // That ordering made `JoinLookup::Withheld` unreachable from this, the
     // busiest of the three join sites.
-    crate::music::perms::ensure_can_join(ctx.cache(), guild_id, channel_id)
-        .map_err(|e| -> Error { Box::new(e) })?;
+    //
+    // 🪤 But a channel absent from the cache is ambiguous: either Discord
+    // withheld it (no VIEW_CHANNEL) or it is not a channel in this guild at
+    // all -- and `/summonchannel` takes a raw id, so a typo lands here.
+    // Voice states are NOT filtered by VIEW_CHANNEL, so a member sitting in
+    // it proves it is real and merely hidden. With nobody in it we cannot
+    // tell, and `NoChannelId` is the answer that does not invent a
+    // permission problem on a channel that may not exist.
+    if !guild.channels.contains_key(&channel_id)
+        && !guild
+            .voice_states
+            .iter()
+            .any(|vs| vs.channel_id == Some(channel_id))
+    {
+        return Err(Box::new(CrackedError::NoChannelId));
+    }
+    crate::music::perms::ensure_can_join(ctx.cache(), guild_id, channel_id).map_err(
+        |e| -> Error {
+            // The named "Joining channel" line below never runs for a refusal,
+            // so without this a gate refusal is invisible server-side -- the
+            // same blind spot as #467/#468, on the feature built to end it.
+            tracing::warn!("Refusing join into {channel_id:?} in {guild_id:?}: {e}");
+            Box::new(e)
+        },
+    )?;
     let channel_name = guild
         .channels
         .get(&channel_id)
@@ -195,19 +240,18 @@ pub async fn do_join(
     tracing::warn!(
         "Joining channel: {channel_name} ({channel_id:?}) in {guild_name} ({guild_id:?})"
     );
-    // Every join that gets this far can outlive Discord's three-second
-    // interaction deadline -- songbird's gateway_timeout is 10s -- so defer
-    // here, the one point every command's join funnels through, rather than
-    // in each of them. poise's defer is idempotent and a no-op on prefix
-    // commands, so callers that already deferred pay nothing.
-    //
-    // Deliberately AFTER the gate: a refusal is cache-only and answers in
-    // microseconds, so it should not spend a round-trip on "thinking...".
+    // See this function's doc comment for why the defer sits exactly here.
     ctx.defer().await?;
     let call = match manager.join(guild_id, channel_id).await {
         Ok(call) => call,
         Err(err) => match connected_call(manager, guild_id, Some(channel_id)).await {
-            Some(call) => call,
+            Some(call) => {
+                // The handshake reported a problem but the connection is up.
+                // Worth a line: a recovered join should be distinguishable in
+                // the log from a clean one.
+                tracing::warn!("Join into {channel_id:?} reported {err:?} but connected");
+                call
+            },
             None => {
                 tracing::warn!("Error joining channel: {:?}", err);
                 // Drop the connectionless Call, or the next join finds it and
@@ -215,11 +259,19 @@ pub async fn do_join(
                 // `leave(..)?` *then* `calls.remove(..)`, so a failing leave
                 // skips the removal -- log it rather than discarding the only
                 // signal that the Call is still registered.
-                if let Err(e) = manager.remove(guild_id).await {
-                    tracing::warn!(
-                        "Could not remove the connectionless Call for {guild_id:?}: {e:?}. \
-                         A later join may find it and skip the permission gate."
-                    );
+                //
+                // 🪤 Guarded on there being NO connection at all. The arm
+                // above is also taken when we are connected to a *different*
+                // channel -- the concurrent-`/gp`-resume race `expect` exists
+                // for -- and `remove` is `leave` then drop, so removing here
+                // would disconnect that live session and bin its queue.
+                if connected_call(manager, guild_id, None).await.is_none() {
+                    if let Err(e) = manager.remove(guild_id).await {
+                        tracing::warn!(
+                            "Could not remove the connectionless Call for {guild_id:?}: {e:?}. \
+                             A later join may find it and skip the permission gate."
+                        );
+                    }
                 }
                 // let str = err.to_string().clone();
                 let my_err = CrackedError::JoinChannelError(err);
@@ -272,6 +324,47 @@ mod join_order_guard_tests {
         std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
     }
 
+    /// Drop a trailing `//` comment.
+    ///
+    /// 🪤 Deliberately conservative: it refuses to cut when a quote appears
+    /// before the `//`, so a line carrying a string literal -- a URL, or any
+    /// text with a slash pair in it -- is scanned whole rather than truncated
+    /// mid-literal. Over-inclusion makes a guard fail loudly; truncation makes
+    /// it pass while checking less than it claims, which is the failure this
+    /// module exists to prevent. It does not parse Rust and does not need to:
+    /// every assertion here is "this exact code line is, or is not, present".
+    fn strip_comment(line: &str) -> &str {
+        match line.find("//") {
+            Some(i) if !line[..i].contains('"') => &line[..i],
+            _ => line,
+        }
+    }
+
+    #[test]
+    fn strip_comment_cuts_comments_but_never_truncates_a_literal() {
+        assert_eq!(strip_comment("let x = 1; // note"), "let x = 1; ");
+        assert_eq!(strip_comment("// whole line"), "");
+        assert_eq!(strip_comment("no comment here"), "no comment here");
+        // A URL inside a literal must not cost us the rest of the line.
+        assert_eq!(
+            strip_comment(r#"warn!("see https://x/y");"#),
+            r#"warn!("see https://x/y");"#
+        );
+        // The case that matters most: code AFTER a literal containing `//`
+        // stays visible. Truncating here would hide a banned call from the
+        // scan, which is a guard passing while checking less than it claims.
+        assert_eq!(
+            strip_comment(r#"warn!("a // b"); manager.get(guild_id)"#),
+            r#"warn!("a // b"); manager.get(guild_id)"#
+        );
+        // Over-inclusive by design: a genuine trailing comment after a literal
+        // survives. That can only make a guard louder, never blinder.
+        assert_eq!(
+            strip_comment(r#"let u = "x"; // trailing"#),
+            r#"let u = "x"; // trailing"#
+        );
+    }
+
     /// The body of one function, bounded at the next `}` in column 0, with
     /// `//` comments stripped.
     ///
@@ -284,43 +377,6 @@ mod join_order_guard_tests {
     /// lookup names `NoChannelId`, and sits above the gate. Searching raw
     /// text found the prose first and failed correct code. A guard that reads
     /// commentary is not reading the program.
-    /// Drop a trailing `//` comment, but not the `//` in a URL.
-    ///
-    /// 🪤 A naive cut at the first `//` truncates any line holding a
-    /// `https://` literal -- routine in a Discord bot -- and a guard that
-    /// silently scans less than it claims is the failure this whole module
-    /// exists to prevent.
-    fn strip_comment(line: &str) -> &str {
-        let b = line.as_bytes();
-        let mut i = 0;
-        while i + 1 < b.len() {
-            if b[i] == b'/' && b[i + 1] == b'/' {
-                if i > 0 && b[i - 1] == b':' {
-                    i += 2;
-                    continue;
-                }
-                return &line[..i];
-            }
-            i += 1;
-        }
-        line
-    }
-
-    #[test]
-    fn strip_comment_cuts_comments_and_keeps_urls() {
-        assert_eq!(strip_comment("let x = 1; // note"), "let x = 1; ");
-        assert_eq!(strip_comment("// whole line"), "");
-        assert_eq!(strip_comment("no comment here"), "no comment here");
-        assert_eq!(
-            strip_comment(r#"warn!("see https://x/y");"#),
-            r#"warn!("see https://x/y");"#
-        );
-        assert_eq!(
-            strip_comment(r#"let u = "https://a"; // trailing"#),
-            r#"let u = "https://a"; "#
-        );
-    }
-
     fn body_of(src: &str, signature: &str) -> String {
         let start = src.find(signature).unwrap_or_else(|| {
             panic!("{signature} not found -- guard is looking at the wrong file")
@@ -352,8 +408,11 @@ mod join_order_guard_tests {
         let gate = body
             .find("ensure_can_join(")
             .expect("do_join lost its gate");
+        // Anchored on the lookup itself, not on any mention of the error --
+        // there is a second, deliberate `NoChannelId` above the gate now, and
+        // matching that one made this guard fail correct code.
         let lookup = body
-            .find("NoChannelId")
+            .find(".ok_or(CrackedError::NoChannelId)")
             .expect("do_join lost its channel-name lookup -- rewrite this guard");
         assert!(
             gate < lookup,
@@ -361,6 +420,34 @@ mod join_order_guard_tests {
              voice channel the bot cannot see from GUILD_CREATE, so the lookup misses \
              exactly when the gate has the most to say, and `JoinLookup::Withheld` \
              becomes unreachable from this join site."
+        );
+    }
+
+    /// The gate may only claim VIEW_CHANNEL for a channel we have evidence is
+    /// real. `/summonchannel` takes a raw id, and a cache miss cannot tell a
+    /// hidden channel from a typo.
+    #[test]
+    fn an_unknown_unoccupied_channel_is_not_called_a_permission_problem() {
+        let body = body_of(&read("commands/music_utils.rs"), "pub async fn do_join(");
+        let bail = body
+            .find("return Err(Box::new(CrackedError::NoChannelId))")
+            .expect(
+                "do_join must bail on a channel that is neither cached nor occupied, or a \
+                 typo'd id is reported as a missing View Channel on a channel that does \
+                 not exist -- the exact false diagnosis perms.rs exists to prevent",
+            );
+        assert!(
+            body.contains("voice_states"),
+            "the existence check must consult voice states: they are NOT filtered by \
+             VIEW_CHANNEL, so a member sitting in the channel is the only offline proof \
+             that a channel missing from the cache is real rather than imaginary"
+        );
+        let gate = body
+            .find("ensure_can_join(")
+            .expect("do_join lost its gate");
+        assert!(
+            bail < gate,
+            "the existence check must precede the gate, or the gate answers first"
         );
     }
 
@@ -377,6 +464,14 @@ mod join_order_guard_tests {
             body.contains("manager.remove(guild_id)"),
             "a connectionless Call must be dropped, or a later join finds it and skips \
              the gate"
+        );
+        assert!(
+            body.contains("connected_call(manager, guild_id, None).await.is_none()"),
+            "the teardown must be guarded on there being NO connection at all. The arm \
+             above is also taken when we are connected to a DIFFERENT channel -- the \
+             concurrent-/gp-resume race `expect` exists for -- and `remove` is `leave` \
+             then drop, so removing there would disconnect a live session and bin its \
+             queue."
         );
         assert!(
             !body.contains("let _ = manager.remove"),

--- a/crack-core/src/commands/music_utils.rs
+++ b/crack-core/src/commands/music_utils.rs
@@ -176,11 +176,8 @@ pub(crate) async fn connected_call(
 /// and answers in microseconds, so it should not spend a round-trip putting
 /// the user on "thinking...".
 ///
-/// 🪤 Keep the body between the gate and `manager.join` short.
-/// `perms::join_site_guard_tests` asserts the gate appears within 1200 bytes
-/// before the join, so prose added between them eats that budget and makes an
-/// unrelated guard fail with a misleading "ungated join" message. That is why
-/// this rationale lives up here and not inline.
+/// 🪤 `perms::join_site_guard_tests` asserts the gate appears within 1200
+/// bytes before `manager.join`, so keep prose out of the span between them.
 #[cfg(not(tarpaulin_include))]
 #[tracing::instrument]
 pub async fn do_join(
@@ -189,57 +186,48 @@ pub async fn do_join(
     guild_id: GuildId,
     channel_id: ChannelId,
 ) -> Result<Arc<Mutex<Call>>, Error> {
-    // let ctx_owned = ctx.clone();
-    let guild = guild_id
-        .to_guild_cached(ctx.cache())
-        .ok_or(CrackedError::NoGuildCached)?
-        .clone();
-    let guild_name = guild.name;
+    // One cache read, no clone. This used to deep-copy the whole Guild --
+    // every member, role, channel and presence -- for a name and one lookup.
+    // The ref is confined to this block because it cannot be held across the
+    // await below.
+    let (guild_name, channel_name) = {
+        let guild = guild_id
+            .to_guild_cached(ctx.cache())
+            .ok_or(CrackedError::NoGuildCached)?;
+        let channel = guild.channels.get(&channel_id);
+        // A channel missing from the cache is ambiguous: either Discord
+        // withheld it (the bot lacks VIEW_CHANNEL, and it omits those from
+        // GUILD_CREATE) or it is not a channel in this guild at all --
+        // `/summonchannel` takes a raw id, so a typo lands here. Voice states
+        // are NOT filtered by VIEW_CHANNEL, so a member sitting in it proves
+        // it is real and merely hidden. With nobody in it we cannot tell, and
+        // `NoChannelId` is the answer that does not invent a permission
+        // problem on a channel that may not exist.
+        if channel.is_none()
+            && !guild
+                .voice_states
+                .iter()
+                .any(|vs| vs.channel_id == Some(channel_id))
+        {
+            return Err(Box::new(CrackedError::NoChannelId));
+        }
+        (
+            guild.name.to_string(),
+            channel.map(|c| c.base.name.to_string()),
+        )
+    };
+    // Logged before the gate so a refusal is visible server-side too. The
+    // name is an Option because the channel we most need to report on is
+    // exactly the one Discord did not send us.
+    tracing::warn!(
+        "Joining {} ({channel_id:?}) in {guild_name} ({guild_id:?})",
+        channel_name.as_deref().unwrap_or("<not visible to us>")
+    );
     // Refuse a join Discord would silently drop. Without this the voice state
     // update is accepted, nothing happens, and songbird reports TimedOut ~10s
-    // later with no mention of a permission.
-    //
-    // 🪤 This MUST come before the channel-name lookup below. Discord omits a
-    // voice channel the bot lacks VIEW_CHANNEL on from GUILD_CREATE entirely,
-    // so `guild.channels.get` misses exactly when the gate has the most to
-    // say — and `NoChannelId` would win the race and report nothing useful.
-    // That ordering made `JoinLookup::Withheld` unreachable from this, the
-    // busiest of the three join sites.
-    //
-    // 🪤 But a channel absent from the cache is ambiguous: either Discord
-    // withheld it (no VIEW_CHANNEL) or it is not a channel in this guild at
-    // all -- and `/summonchannel` takes a raw id, so a typo lands here.
-    // Voice states are NOT filtered by VIEW_CHANNEL, so a member sitting in
-    // it proves it is real and merely hidden. With nobody in it we cannot
-    // tell, and `NoChannelId` is the answer that does not invent a
-    // permission problem on a channel that may not exist.
-    if !guild.channels.contains_key(&channel_id)
-        && !guild
-            .voice_states
-            .iter()
-            .any(|vs| vs.channel_id == Some(channel_id))
-    {
-        return Err(Box::new(CrackedError::NoChannelId));
-    }
-    crate::music::perms::ensure_can_join(ctx.cache(), guild_id, channel_id).map_err(
-        |e| -> Error {
-            // The named "Joining channel" line below never runs for a refusal,
-            // so without this a gate refusal is invisible server-side -- the
-            // same blind spot as #467/#468, on the feature built to end it.
-            tracing::warn!("Refusing join into {channel_id:?} in {guild_id:?}: {e}");
-            Box::new(e)
-        },
-    )?;
-    let channel_name = guild
-        .channels
-        .get(&channel_id)
-        .ok_or(CrackedError::NoChannelId)?
-        .base
-        .name
-        .clone();
-    tracing::warn!(
-        "Joining channel: {channel_name} ({channel_id:?}) in {guild_name} ({guild_id:?})"
-    );
+    // later naming no permission at all.
+    crate::music::perms::ensure_can_join(ctx.cache(), guild_id, channel_id)
+        .map_err(|e| -> Error { Box::new(e) })?;
     // See this function's doc comment for why the defer sits exactly here.
     ctx.defer().await?;
     let call = match manager.join(guild_id, channel_id).await {
@@ -297,258 +285,4 @@ pub async fn do_join(
         },
     };
     Ok(call)
-}
-
-/// Source-order guards for `do_join`'s three ordering bugs, all of which cost
-/// a production `/summon` its answer (see the 2026-09-12 RuneCast trace).
-///
-/// 🪤 These assert on source text, not behaviour. `do_join` takes a poise
-/// `Context` and a live `songbird::Songbird`, neither of which is
-/// constructible offline, so the decisions they pin have no reachable seam --
-/// unlike `perms::join_refusal`, which was extracted precisely so it would.
-/// A guard that reads the file is weaker than a test that runs the code; it
-/// is far stronger than the nothing that was here while all three shipped.
-#[cfg(test)]
-mod join_order_guard_tests {
-    /// 🪤 Builds the path by formatting rather than `Path::join`, on purpose,
-    /// and this comment avoids spelling that method call out.
-    /// `perms::join_site_guard_tests` scans source text for a join whose first
-    /// argument is not a string literal and calls it a songbird join, so
-    /// joining a path with a variable -- or merely naming the method in prose,
-    /// which cost a second red run to notice -- reads as an ungated join. The
-    /// heuristic is deliberately conservative: a false positive is loud and
-    /// cheap, a false negative is silent and cost ct#496. The fix belongs on
-    /// this side, not in that guard.
-    fn read(rel: &str) -> String {
-        let path = format!("{}/src/{rel}", env!("CARGO_MANIFEST_DIR"));
-        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
-    }
-
-    /// Drop a trailing `//` comment.
-    ///
-    /// 🪤 Deliberately conservative: it refuses to cut when a quote appears
-    /// before the `//`, so a line carrying a string literal -- a URL, or any
-    /// text with a slash pair in it -- is scanned whole rather than truncated
-    /// mid-literal. Over-inclusion makes a guard fail loudly; truncation makes
-    /// it pass while checking less than it claims, which is the failure this
-    /// module exists to prevent. It does not parse Rust and does not need to:
-    /// every assertion here is "this exact code line is, or is not, present".
-    fn strip_comment(line: &str) -> &str {
-        match line.find("//") {
-            Some(i) if !line[..i].contains('"') => &line[..i],
-            _ => line,
-        }
-    }
-
-    #[test]
-    fn strip_comment_cuts_comments_but_never_truncates_a_literal() {
-        assert_eq!(strip_comment("let x = 1; // note"), "let x = 1; ");
-        assert_eq!(strip_comment("// whole line"), "");
-        assert_eq!(strip_comment("no comment here"), "no comment here");
-        // A URL inside a literal must not cost us the rest of the line.
-        assert_eq!(
-            strip_comment(r#"warn!("see https://x/y");"#),
-            r#"warn!("see https://x/y");"#
-        );
-        // The case that matters most: code AFTER a literal containing `//`
-        // stays visible. Truncating here would hide a banned call from the
-        // scan, which is a guard passing while checking less than it claims.
-        assert_eq!(
-            strip_comment(r#"warn!("a // b"); manager.get(guild_id)"#),
-            r#"warn!("a // b"); manager.get(guild_id)"#
-        );
-        // Over-inclusive by design: a genuine trailing comment after a literal
-        // survives. That can only make a guard louder, never blinder.
-        assert_eq!(
-            strip_comment(r#"let u = "x"; // trailing"#),
-            r#"let u = "x"; // trailing"#
-        );
-    }
-
-    /// The body of one function, bounded at the next `}` in column 0, with
-    /// `//` comments stripped.
-    ///
-    /// Bounding matters: this very module lives in `music_utils.rs` and
-    /// contains every literal searched for below. An unbounded slice would
-    /// let the test satisfy itself -- the trap `perms.rs` names `SELF_PATH`.
-    ///
-    /// 🪤 Stripping comments matters just as much, and cost a red test to
-    /// learn: the comment *explaining* why the gate precedes the channel
-    /// lookup names `NoChannelId`, and sits above the gate. Searching raw
-    /// text found the prose first and failed correct code. A guard that reads
-    /// commentary is not reading the program.
-    fn body_of(src: &str, signature: &str) -> String {
-        let start = src.find(signature).unwrap_or_else(|| {
-            panic!("{signature} not found -- guard is looking at the wrong file")
-        });
-        // 🪤 `find` takes the FIRST match, and the test module below holds
-        // these same signatures as string literals. That resolves to the real
-        // definition only because the module happens to sit at the bottom of
-        // the file -- position, not design. Pin it, so moving this module up
-        // fails loudly instead of silently parsing its own literals.
-        if let Some(tests) = src.find("#[cfg(test)]") {
-            assert!(
-                start < tests,
-                "`{signature}` was first found inside a test module. `body_of` is \
-                 parsing the guard's own string literals, not the program."
-            );
-        }
-        let rest = &src[start..];
-        let end = rest.find("\n}\n").expect("unterminated function body");
-        rest[..end]
-            .lines()
-            .map(strip_comment)
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-
-    #[test]
-    fn gate_runs_before_the_channel_name_lookup() {
-        let body = body_of(&read("commands/music_utils.rs"), "pub async fn do_join(");
-        let gate = body
-            .find("ensure_can_join(")
-            .expect("do_join lost its gate");
-        // Anchored on the lookup itself, not on any mention of the error --
-        // there is a second, deliberate `NoChannelId` above the gate now, and
-        // matching that one made this guard fail correct code.
-        let lookup = body
-            .find(".ok_or(CrackedError::NoChannelId)")
-            .expect("do_join lost its channel-name lookup -- rewrite this guard");
-        assert!(
-            gate < lookup,
-            "`ensure_can_join` must precede the `NoChannelId` lookup. Discord omits a \
-             voice channel the bot cannot see from GUILD_CREATE, so the lookup misses \
-             exactly when the gate has the most to say, and `JoinLookup::Withheld` \
-             becomes unreachable from this join site."
-        );
-    }
-
-    /// The gate may only claim VIEW_CHANNEL for a channel we have evidence is
-    /// real. `/summonchannel` takes a raw id, and a cache miss cannot tell a
-    /// hidden channel from a typo.
-    #[test]
-    fn an_unknown_unoccupied_channel_is_not_called_a_permission_problem() {
-        let body = body_of(&read("commands/music_utils.rs"), "pub async fn do_join(");
-        let bail = body
-            .find("return Err(Box::new(CrackedError::NoChannelId))")
-            .expect(
-                "do_join must bail on a channel that is neither cached nor occupied, or a \
-                 typo'd id is reported as a missing View Channel on a channel that does \
-                 not exist -- the exact false diagnosis perms.rs exists to prevent",
-            );
-        assert!(
-            body.contains("voice_states"),
-            "the existence check must consult voice states: they are NOT filtered by \
-             VIEW_CHANNEL, so a member sitting in the channel is the only offline proof \
-             that a channel missing from the cache is real rather than imaginary"
-        );
-        let gate = body
-            .find("ensure_can_join(")
-            .expect("do_join lost its gate");
-        assert!(
-            bail < gate,
-            "the existence check must precede the gate, or the gate answers first"
-        );
-    }
-
-    #[test]
-    fn a_failed_join_is_not_reported_as_success() {
-        let body = body_of(&read("commands/music_utils.rs"), "pub async fn do_join(");
-        assert!(
-            body.contains("connected_call(manager, guild_id, Some(channel_id))"),
-            "the join-failure fallback must go through `connected_call`, and must name \
-             the channel it asked for -- a Call connected to a *different* channel is \
-             not a successful join of this one"
-        );
-        assert!(
-            body.contains("manager.remove(guild_id)"),
-            "a connectionless Call must be dropped, or a later join finds it and skips \
-             the gate"
-        );
-        assert!(
-            body.contains("connected_call(manager, guild_id, None).await.is_none()"),
-            "the teardown must be guarded on there being NO connection at all. The arm \
-             above is also taken when we are connected to a DIFFERENT channel -- the \
-             concurrent-/gp-resume race `expect` exists for -- and `remove` is `leave` \
-             then drop, so removing there would disconnect a live session and bin its \
-             queue."
-        );
-        assert!(
-            !body.contains("let _ = manager.remove"),
-            "songbird's `remove` is `leave(..)?` then `calls.remove(..)`, so a failing \
-             leave skips the removal entirely. Discarding that error hides the fact \
-             that the Call is still registered."
-        );
-    }
-
-    /// The twin-hunting guard. The narrow version of this pinned `do_join`
-    /// alone and read green while two live copies of the same defect shipped
-    /// on the `/summon` and `/play` entry points.
-    #[test]
-    fn songbird_get_is_reachable_only_through_connected_call() {
-        let files = ["commands/music_utils.rs", "commands/music/summon.rs"];
-        let mut inspected = 0usize;
-        for rel in files {
-            // 🪤 Stop at the first test module. This very guard contains the
-            // literal it searches for, so scanning itself fails itself -- the
-            // fourth time in this change that a scanner tripped over text
-            // written about it. A guard reads the program, not the tests.
-            let whole = read(rel);
-            let src = match whole.find("#[cfg(test)]") {
-                Some(i) => whole[..i].to_string(),
-                None => whole,
-            };
-            let helper_body = if rel.ends_with("music_utils.rs") {
-                body_of(&src, "pub(crate) async fn connected_call(")
-            } else {
-                String::new()
-            };
-            for (n, line) in src.lines().enumerate() {
-                let code = strip_comment(line);
-                if !code.contains("manager.get(") {
-                    continue;
-                }
-                inspected += 1;
-                assert!(
-                    helper_body.lines().any(|h| h.trim() == code.trim()),
-                    "{rel}:{}: `Songbird::get` outside `connected_call`.\n\n\
-                     It returns a Call for a join that only *started*, so this reads a \
-                     connectionless handle as a live one -- skipping the join, and with \
-                     it `ensure_can_join`. Route it through `connected_call`.\n\n  {}",
-                    n + 1,
-                    code.trim()
-                );
-            }
-        }
-        assert!(
-            inspected >= 1,
-            "scanned {inspected} `manager.get(` sites across {} files -- the scan has \
-             stopped checking rather than the calls being gone. Fix the scan.",
-            files.len()
-        );
-    }
-
-    #[test]
-    fn do_join_defers_before_the_handshake() {
-        let body = body_of(&read("commands/music_utils.rs"), "pub async fn do_join(");
-        let defer = body.find("ctx.defer()").expect(
-            "do_join must defer: songbird waits 10s for the handshake, the interaction \
-             token dies at 3s. It is the one point every command's join funnels through.",
-        );
-        let join = body
-            .find("manager.join(")
-            .expect("do_join no longer joins -- rewrite this guard");
-        let gate = body
-            .find("ensure_can_join(")
-            .expect("do_join lost its gate -- see the other guard");
-        assert!(
-            defer < join,
-            "the defer must precede the handshake it exists to outlast"
-        );
-        assert!(
-            gate < defer,
-            "the gate must precede the defer: a refusal is cache-only and answers in \
-             microseconds, so it should not spend a round-trip on \"thinking...\""
-        );
-    }
 }


### PR DESCRIPTION
## The report

> "I played a playlist and then I tried to summon it to a channel that it doesn't have permissions in and I got application did not respond."

## Production trace

`/summon` in RuneCast → voice channel `test`, 2026-09-12:

```
11:45:10.609  Joining channel: test (1548298312245977180)
11:45:20.612  songbird: Global event added        ← 10.003s later
11:45:20.731  Error sending reply: ... 404
11:45:20.731  joined channel: 1548298312245977180 ← FALSE
```

Decoding the bitfields from that same log line: the channel's `@everyone` overwrite denies **View Channel + Connect**, and the bot's `app_permissions` there confirm `CONNECT: NO`, `VIEW_CHANNEL: NO`, `SPEAK: YES` — the misleading combination.

## What was wrong

**1. Nothing deferred.** songbird's `gateway_timeout` is 10s; Discord's interaction deadline is 3s. Hence "The application did not respond", and the eventual reply 404'd on a dead token. The defer now lives in `do_join` — the one point every command's join funnels through — so `/summon`, `/play` and `/downvote` all get it. It sits *after* the gate, since a refusal is cache-only and shouldn't spend a round-trip on "thinking…".

**2. `Songbird::get` was treated as a connection test, in three places.** songbird registers the `Call` when a join is *attempted*, before the handshake, so a timed-out join still hands one back. `do_join` took that as success — handlers registered, "Summoned" embed sent, `joined channel` logged, bot in no voice channel. **That is why a total failure left no error in the log.** `summon_internal` and `get_call_or_join_author` were worse: they short-circuited the join entirely, so `/summon` and `/play` bypassed the permission gate. All three now go through `connected_call`, which checks for a connection *and* that it's to the channel asked for.

**3. The gate was unreachable for the case it was built for.** `do_join` resolved the channel *name* (`NoChannelId`) before calling `ensure_can_join`, and Discord omits a voice channel the bot lacks `VIEW_CHANNEL` on from `GUILD_CREATE` — so that lookup missed precisely when the gate had the most to say. **A deploy restarts the bot**, dropping the denied channel from cache, so shipping v0.9.7 as it stood would have answered the reporter's exact test with "no channel id" and looked like the feature didn't work.

## Found by review, not by me

Two review passes on this branch found things the tests and my own reading did not. Recorded because the PR is more useful with them than without:

- The first three fixes each **stopped one call frame short**, and the defer turned a 3s timeout into a permanent "thinking…" on `/summon` against a stale Call — a regression the diff introduced.
- The `expect` parameter added to fix that then created a worse bug: `manager.remove` ran whenever `connected_call(.., Some(channel))` was None, which is *also* true when connected to a different channel. A failed join into B would have disconnected a concurrently-resumed `/gp` game in A and binned its queue.
- Hoisting the gate made a typo'd `/summonchannel` id report a missing View Channel on a channel that does not exist — a false permission claim in the feature built to prevent exactly that. Voice states are not filtered by `VIEW_CHANNEL`, so a member sitting in the channel is offline proof it's real; with nobody in it, `NoChannelId` is the answer that doesn't fabricate.
- Gate refusals **logged nothing**, since the named "Joining channel" line sits after the gate and `FrameworkError::Command` replies without logging. Same blind spot as #467/#468.

## Version

**No bump.** v0.9.7 is merged (`739ecbd`) but never tagged, and without these the gate it added does not reach the case it was written for. musicreco stays on 0.9.8 as planned.

## Tests

crack-core **214 → 220**, measured with `git grep -h '#\[test\]' <rev> -- crack-core/src` at both revisions.

Five are source-order guards. They assert on source text, which is weaker than running the code — `do_join` takes a poise `Context` and a live `songbird::Songbird`, neither constructible offline. `strip_comment` is a pure function and gets a real behavioural test.

**Eight sabotages, each failing exactly its own guard and no other:**

| Sabotage | Guard that caught it |
|---|---|
| Gate moved back below the `NoChannelId` lookup | `gate_runs_before_the_channel_name_lookup` |
| `connected_call` → bare `manager.get` in `do_join` | `a_failed_join_is_not_reported_as_success` |
| Same, in `summon_internal` | `songbird_get_is_reachable_only_through_connected_call` |
| Same, in `get_call_or_join_author` | `songbird_get_is_reachable_only_through_connected_call` |
| Defer removed from `do_join` | `do_join_defers_before_the_handshake` |
| `remove()` error discarded again | `a_failed_join_is_not_reported_as_success` |
| Teardown made unconditional again | `a_failed_join_is_not_reported_as_success` |
| Channel existence check removed | `an_unknown_unoccupied_channel_is_not_called_a_permission_problem` |

The third and fourth rows matter most: the original guard pinned `do_join`'s body alone and read **green** while two live copies of the defect shipped on the `/summon` and `/play` entry points.

Four times in this change a scanner tripped over prose written *about* it — a comment naming `NoChannelId`, a path join, the word for that method, and the guard's own search string. `body_of` now strips comments, stops at the first `#[cfg(test)]`, and asserts the signature it matched sits above that.

## Gate

`cargo fmt --check`, `cargo clippy --workspace --all-targets` (0 warnings), `SQLX_OFFLINE=true cargo check`, `cargo test --workspace` — clean except the known pre-existing `crack-testing::tests::test_enqueue_query` (deleted YouTube video id, fails on master too, #471).

## Not fixed here

#501 · #502 · #503 · #504 · #505 · #506. Closed as fixed here: #500.

Related: #494, #495, #496, #497.
