### PR TITLE
ci: stop re-running work that already succeeded on the same tree

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -1,7 +1,13 @@
 name: CI Workflow
 
 on:
+  # Branches only. A bare `push:` also matches tag pushes, so cutting a
+  # release re-ran this whole workflow -- build and lint on both toolchains --
+  # against a commit master had already built and tested minutes earlier.
+  # Nothing here is tag-conditional: the Docker job below requires
+  # refs/heads/master, and cargo-dist's release lives in release.yml.
   push:
+    branches: ['**']
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,6 +53,13 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # This image is built from scratch twice for every release: once on
+          # the push to master, then again on the tag, which is what produces
+          # the vX.Y.Z tag the compose files pin to. The layers are identical;
+          # only the tag differs. A shared GHA layer cache makes the second
+          # build a retag rather than a rebuild.
+          cache-from: type=gha,scope=runner
+          cache-to: type=gha,mode=max,scope=runner
       -
         name: Extract Git Metadata (migrate image)
         id: meta-migrate
@@ -68,3 +75,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-migrate.outputs.tags }}
           labels: ${{ steps.meta-migrate.outputs.labels }}
+          cache-from: type=gha,scope=migrate
+          cache-to: type=gha,mode=max,scope=migrate

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,62 +16,44 @@ jobs:
         cache-key: [""]
     runs-on: ubuntu-latest
 
+    # fmt and clippy never touch the database. `sqlx::query!` expands against
+    # the committed `.sqlx/` metadata, so this job needs no postgres, no
+    # sqlx-cli and no migrations -- they cost ~50s a leg and checked nothing.
+    # build.yml still runs the real thing against a real database.
+    env:
+      SQLX_OFFLINE: "true"
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      
-      - name: "Update"
-        run: |
-          sudo apt-get update
-          sudo apt-get dist-upgrade -y 
-          sudo apt-get autoremove -y
+
+      # There was an `apt-get update && dist-upgrade && autoremove` here. It
+      # took 2m10s a leg -- 4m20s per CI run, ~19% of the whole thing -- to
+      # upgrade the entire runner OS before running fmt and clippy, which
+      # need nothing from it. GitHub rebuilds these images weekly anyway.
 
       - name: "Install Rust"
         run: |
           rustup toolchain install ${{ matrix.rust-version }} --profile minimal --no-self-update
           rustup component add rustfmt clippy --toolchain ${{ matrix.rust-version }}
           rustup default ${{ matrix.rust-version }}
-          rustup update
         shell: bash
-      - 
-        uses: ikalnytskyi/action-setup-postgres@v4
-        with:
-          username: postgres
-          password: mysecretpassword
-          database: postgres
-          port: 5432
-        id: postgres
 
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ${{ matrix.cache-key }}
-      - name: Install sqlx-cli
-        run: cargo install sqlx-cli --no-default-features --features postgres
-      - name: Migrate database
-        env:
-          DATABASE_URL: ${{ steps.postgres.outputs.connection-uri }}
-          PG_USER: postgres
-          PG_PASSWORD: mysecretpassword
-          VIRUSTOTAL_API_KEY: ${{secrets.VIRUSTOTAL_API_KEY}}
-        run: |
-          sqlx database create
-          sqlx migrate run --source migrations/
-          cargo sqlx prepare --workspace -- --tests
 
+      # 🪤 This was `if: ${{ matrix.rust-version }} == 'nightly'`, which does
+      # not do what it reads as: the expression is substituted, the trailing
+      # `== 'nightly'` is left as dead text, and a non-empty leading value is
+      # truthy -- so fmt ran on BOTH legs. The stable leg then silently
+      # ignored rustfmt.toml's nightly-only `imports_layout` and
+      # `match_arm_blocks` (it warns and carries on), so it was enforcing
+      # something weaker than the nightly leg while appearing to agree.
       - name: Run cargo fmt
-        if: ${{ matrix.rust-version }} == 'nightly'
-        env:
-          DATABASE_URL: ${{ steps.postgres.outputs.connection-uri }}
-          PG_USER: postgres
-          PG_PASSWORD: mysecretpassword
-          VIRUSTOTAL_API_KEY: ${{secrets.VIRUSTOTAL_API_KEY}}
+        if: matrix.rust-version == 'nightly'
         run: cargo fmt --all -- --check
 
       - name: Run clippy
-        env:
-          DATABASE_URL: ${{ steps.postgres.outputs.connection-uri }}
-          PG_USER: postgres
-          PG_PASSWORD: mysecretpassword
-          VIRUSTOTAL_API_KEY: ${{secrets.VIRUSTOTAL_API_KEY}}
         if: success() || failure()
         run: cargo clippy --all -- -D clippy::all -D warnings --allow clippy::needless_return

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -12,9 +12,12 @@ name: rust-clippy analyze
 on:
   push:
     branches: [ "master" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+  # No `pull_request:` trigger. This workflow exists to feed SARIF into code
+  # scanning, not to gate a PR -- lint.yml already runs clippy with
+  # `-D warnings` on two toolchains, so a PR is gated twice over before this
+  # would have said anything. Running it here as well cost a third full
+  # clippy (~3.2m) on every push to a PR branch. master and the nightly cron
+  # still keep the Security tab current.
   schedule:
     - cron: '0 0 * * *'
   # Lets this be re-run by hand. GitHub disables workflows with a `schedule:`


### PR DESCRIPTION
## Measured, not guessed

From #499, where five pushes produced **30 workflow runs**. One commit costs **~22 minutes** of runner time:

| Job | Time | Where it actually goes |
|---|---|---|
| Build (nightly) | 5.3m | 4m is `Run Unit Tests` |
| Build (stable) | 5.2m | the same suite again |
| Lint (nightly) | 4.4m | **2m10s `apt-get dist-upgrade`**, 41s DB migrate, 31s clippy |
| Lint (stable) | 3.8m | same |
| rust-clippy analyze | 3.2m | clippy a **third** time |

On one shipped change, the identical tree gets **fully tested twice** (PR head, then the squash-merge commit), **clippy'd 6×**, and the **Docker image built twice** with no layer cache.

## Changes

**No gate is weakened.** Every check that ran before still runs; they stop running more than once on the same thing.

1. **lint.yml stops upgrading the runner OS.** `apt-get update && dist-upgrade && autoremove` — 2m10s per leg, **4m20s per run (~19% of CI)** — to run fmt and clippy, which need nothing from it. GitHub rebuilds these images weekly.
2. **lint.yml stops provisioning postgres.** It installed sqlx-cli, created a database and ran migrations (~50s a leg) so fmt and clippy could run against it. Neither touches a database — `sqlx::query!` expands against the committed `.sqlx/` (81 query files), which is what `SQLX_OFFLINE=true` selects. `build.yml` still runs the real tests against a real postgres.
3. **ci_workflow.yml runs on branches, not tags.** A bare `push:` matches tag pushes, so cutting v0.9.7 re-ran build and lint on both toolchains against a commit master had built and tested minutes earlier. Nothing there is tag-conditional: the Docker job requires `refs/heads/master`, and the release lives in `release.yml`.
4. **rust-clippy.yml drops `pull_request`.** It feeds SARIF to code scanning; it gates nothing. lint.yml already runs clippy with `-D warnings` on two toolchains, so a PR is gated twice before this third full clippy speaks. master pushes and the nightly cron keep the Security tab current.
5. **docker.yml gets a GHA layer cache.** The image is built from scratch twice per release — master push, then the tag that produces the `vX.Y.Z` pin the compose files use — identical layers, no cache at all.

## A correctness bug, not just speed

`lint.yml`'s fmt step read:

```yaml
if: ${{ matrix.rust-version }} == 'nightly'
```

That is substituted first, leaving `stable == 'nightly'` as dead text with a truthy leading value — so **fmt ran on both legs**. Both reported `Run cargo fmt=success`. The stable leg silently ignored `rustfmt.toml`'s nightly-only `imports_layout` and `match_arm_blocks` (rustfmt warns and carries on), enforcing something weaker while appearing to agree.

Verified:
- `cargo +nightly fmt --all -- --check` → clean, no warnings
- `cargo fmt --all -- --check` on stable → `Warning: can't set 'imports_layout = Mixed', unstable features are only available in nightly`

## Verification

```
env -u DATABASE_URL SQLX_OFFLINE=true cargo clippy --all -- -D clippy::all -D warnings --allow clippy::needless_return
```
→ exit 0, which is exactly what the new lint job runs.

**Check this PR's own run list against #499's** — it should show no `rust-clippy analyze`, and the Lint jobs should drop by roughly 3 minutes each.

Expected: **~9 minutes back per PR push, and one entire CI run per release.**
