### PR TITLE
v0.9.8: VIEW_CHANNEL blocks a voice join, it does not merely degrade it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,14 +1012,14 @@ dependencies = [
 
 [[package]]
 name = "crack-bf"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "crack-core"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "crack-gpt"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "async-openai",
  "const_format",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "crack-osint"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "crack-types",
  "ipinfo",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "crack-sleevenote"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "crack-testing"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "crack-types"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "humantime",
  "poise",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "crack-voting"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "chrono",
  "dbl-rs",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "cracktunes"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "config-file",
  "crack-core",

--- a/crack-bf/Cargo.toml
+++ b/crack-bf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-bf"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-cli/Cargo.toml
+++ b/crack-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "cracktunes"
-version = "0.9.7"
+version = "0.9.8"
 description = "Cracktunes is a hassle-free, highly performant, host-it-yourself, cracking smoking, discord-music-bot."
 publish = true
 edition = "2021"

--- a/crack-core/Cargo.toml
+++ b/crack-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-core"
-version = "0.9.7"
+version = "0.9.8"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 edition = "2021"
 description = "Core module for the cracking smoking, discord-music-bot Cracktunes."

--- a/crack-core/src/music/perms.rs
+++ b/crack-core/src/music/perms.rs
@@ -22,8 +22,29 @@ pub const TEXT_REQUIRED: Permissions = Permissions::VIEW_CHANNEL
     .union(Permissions::SEND_MESSAGES)
     .union(Permissions::EMBED_LINKS);
 
-/// Voice permissions a join needs. Missing either blocks playback outright.
-pub const VOICE_REQUIRED: Permissions = Permissions::CONNECT.union(Permissions::SPEAK);
+/// Permissions a voice join needs. Missing any of them blocks it outright.
+///
+/// 🪤 `VIEW_CHANNEL` is in here, not only in [`TEXT_REQUIRED`]. It is required
+/// to *initiate* a connection, which is the only way a bot ever gets into a
+/// voice channel: it sends a voice state update over the gateway, and Discord
+/// validates that against VIEW_CHANNEL as well as CONNECT, then silently
+/// drops it.
+///
+/// Note this is NOT the same as "cannot be present in". Hiding a voice
+/// channel while granting CONNECT is a deliberate pattern -- members who
+/// cannot see it can still be dragged in by someone with MOVE_MEMBERS and
+/// then talk normally. That escape hatch does not exist for a bot: there is
+/// nothing to drag until it is already in voice, and it cannot get there by
+/// itself. So for our purposes the channel is unreachable, and the refusal
+/// names the permission that would actually fix it.
+///
+/// Classified as text-only degradation ("I can play, I just cannot announce")
+/// until production proved otherwise: SHAMELESS 21+, 2026-09-12, where
+/// Discord reported CONNECT: YES, SPEAK: YES, VIEW_CHANNEL: NO and the join
+/// died in songbird's ~10s timeout while this gate said everything was fine.
+pub const VOICE_REQUIRED: Permissions = Permissions::VIEW_CHANNEL
+    .union(Permissions::CONNECT)
+    .union(Permissions::SPEAK);
 
 /// The bot's permissions as they bear on playing music in one guild.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -659,6 +680,39 @@ mod tests {
     #[test]
     fn everything_granted_earns_no_refusal() {
         assert!(voice_refusal(voice_ch(), VOICE_REQUIRED).is_none());
+    }
+
+    /// 🪤 Written with literal permissions rather than `VOICE_REQUIRED - X`.
+    /// Every other refusal test derives its input from the constant, so they
+    /// move with it and cannot notice it being wrong -- all 36 passed both
+    /// before and after `VIEW_CHANNEL` was added to it. A test defined in
+    /// terms of the value under test checks an identity, not a fact.
+    #[test]
+    fn connect_and_speak_without_view_channel_still_blocks_the_join() {
+        let granted = Permissions::CONNECT.union(Permissions::SPEAK);
+        let err = voice_refusal(voice_ch(), granted).expect("VIEW_CHANNEL is missing");
+        match err {
+            CrackedError::MissingBotPermissions {
+                scope,
+                channel,
+                missing,
+            } => {
+                assert_eq!(scope, PermScope::Voice);
+                assert_eq!(channel, voice_ch().widen());
+                assert_eq!(missing, Permissions::VIEW_CHANNEL);
+            },
+            other => panic!("expected MissingBotPermissions, got {other:?}"),
+        }
+    }
+
+    /// The other direction, also spelled out, so the pair pins the exact
+    /// boundary Discord enforces rather than the one we happen to declare.
+    #[test]
+    fn view_channel_connect_and_speak_together_earn_no_refusal() {
+        let granted = Permissions::VIEW_CHANNEL
+            .union(Permissions::CONNECT)
+            .union(Permissions::SPEAK);
+        assert!(voice_refusal(voice_ch(), granted).is_none());
     }
 
     #[test]

--- a/crack-gpt/Cargo.toml
+++ b/crack-gpt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-gpt"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-osint/Cargo.toml
+++ b/crack-osint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-osint"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-sleevenote/Cargo.toml
+++ b/crack-sleevenote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-sleevenote"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-testing/Cargo.toml
+++ b/crack-testing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Cycle Five <cycle.five@proton.me>"]
 name = "crack-testing"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2021"
 publish = true
 license = "MIT"

--- a/crack-types/Cargo.toml
+++ b/crack-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-types"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true

--- a/crack-voting/Cargo.toml
+++ b/crack-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crack-voting"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2021"
 authors = ["Cycle Five <cycle.five@proton.me>"]
 publish = true


### PR DESCRIPTION
## v0.9.7 shipped and did not fix the guild it was written for

Production, SHAMELESS 21+, minutes after the deploy — both `/play` and `/summon`:

```
15:39:59.172  Joining 𝐒𝐀𝐘 𝐀𝐍𝐘𝐓𝐇𝐈𝐍𝐆 ˡᵛˡ ⁴ (ChannelId(1504207529868263686))
15:40:09.518  Error joining channel: TimedOut
```

The command was invoked from that voice channel's own text chat, so Discord's `app_permissions` in the interaction *is* the bot's permission set there. It decodes to:

| | |
|---|---|
| `CONNECT` | **YES** |
| `SPEAK` | **YES** |
| `VIEW_CHANNEL` | **NO** |

The gate checked `CONNECT` and `SPEAK`, found both, said nothing, and waved through a join that cannot work. The text tier separately reported `VIEW_CHANNEL` as a mere "I can play, I just cannot announce" degradation.

## The fix

`VOICE_REQUIRED` gains `VIEW_CHANNEL`. It is required to **initiate** a voice connection — the only way a bot ever gets into a channel is by sending a voice state update itself, and Discord validates that against `VIEW_CHANNEL` as well as `CONNECT`, then drops it silently.

**This is not the same as "cannot be present in".** Hiding a voice channel while granting `CONNECT` is a deliberate pattern: a member who cannot see it can still be dragged in by someone with `MOVE_MEMBERS` and talk normally. A bot has no such escape hatch — there is nothing to drag until it is already in voice, and it cannot get there by itself. So the channel is unreachable for us, and the refusal names the permission that would actually fix it.

## The tests all passed, before and after

🪤 **All 36 perms tests passed identically with the constant right and wrong.** Every refusal test derives its input from the constant under test:

```rust
let granted = VOICE_REQUIRED - Permissions::SPEAK;
```

A test defined in terms of the value it is testing checks an identity, not a fact — so they moved in lockstep with the bug and could never see it. Same shape as v0.9.7's vacuous scope test.

The two added here spell the permissions out literally. Sabotage-tested — reverting the constant fails `connect_and_speak_without_view_channel_still_blocks_the_join` and nothing else:

```
connect_and_speak_without_view_channel_still_blocks_the_join ... FAILED
view_channel_connect_and_speak_together_earn_no_refusal ... ok
(36 others) ... ok
```

## Confidence

Strong but not fully isolated. `VIEW_CHANNEL: NO` is the one denied permission and the symptom matches exactly, but I have not ruled out a coincident cause — notably the voice channel's **user limit**, which the original spec put out of scope and which produces an identical silent drop.

**The decisive check is cheap:** grant the bot View Channel in that channel and retry. If it joins, this is confirmed.

## Version

**0.9.7 → 0.9.8** across all nine members (patch, bug fix). ⚠️ This takes the number crack-musicreco was targeting on `feat/musicatlas-autoplay`; that branch needs moving to 0.9.9.

## Gate

`cargo fmt --check`, clippy 0 warnings (with `-u DATABASE_URL SQLX_OFFLINE=true`), `cargo test --workspace` clean bar the known `test_enqueue_query` (#471). crack-core 256 → 258.

Related: #495, #496, #499.
