### PR TITLE
ci: set up Buildx in docker.yml, which the cache I added requires

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,16 @@ jobs:
     steps:
       - name: Repository Checkout
         uses: actions/checkout@v4
+      -
+        # 🪤 Required before any `cache-to:` below. Without it build-push-action
+        # uses the default `docker` driver, which cannot export a cache and
+        # fails the whole build with "Cache export is not supported for the
+        # docker driver". dockerhub.yml has always had this; docker.yml did
+        # not, and a cache was added here without it -- which nothing could
+        # catch, because CI skips the Docker job on pull requests (#424), so
+        # this file is only ever exercised on master.
+        name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
       - 
         name: Extract Git Metadata
         id: meta


### PR DESCRIPTION
## Breakage

#508 added `cache-from`/`cache-to: type=gha` to `docker.yml` without the Buildx setup step that makes cache export possible. `build-push-action` falls back to the default `docker` driver and the build dies:

```
ERROR: failed to build: Cache export is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
```

This blocked the v0.9.8 image on master.

## Fix

Add `docker/setup-buildx-action@v3` before the build steps. `dockerhub.yml` has had it all along — `docker.yml` never did, because until #508 it never needed one.

## 🪤 Why nothing caught it

CI **skips the Docker job on pull requests** (#424), so `docker.yml` is only ever exercised by a push to master or a tag. A change to this file is untested by construction, and #508 shipped one on the strength of reasoning rather than a run.

Same gap that made the master Docker build the last unverified gate before tagging v0.9.7. Worth considering a `pull_request` path that builds without pushing (`push: false`), so changes to this file are exercised before they reach master — filed as a follow-up rather than bundled here, since this needs to land now.

## Verification

This one can only be verified on master, which is the whole point above. Watching the run directly after merge.
